### PR TITLE
Fix Avtocomplete focus

### DIFF
--- a/src/app/listings/new/page.tsx
+++ b/src/app/listings/new/page.tsx
@@ -24,7 +24,6 @@ function AddListingPage() {
   const [listingId, setListingId] = useState<string | null>(null)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
-  const [searchTerm, setSearchTerm] = useState('')
   const [isSearching, setIsSearching] = useState(false)
 
   // Use a small initial limit for performance and enable lazy loading
@@ -36,11 +35,10 @@ function AddListingPage() {
   } = api.games.list.useQuery(
     {
       limit: 100,
-      search: searchTerm || undefined,
+      search: undefined,
     },
     {
       refetchOnWindowFocus: false,
-      enabled: searchTerm.length >= 2 || searchTerm === '',
     },
   )
 
@@ -63,7 +61,6 @@ function AddListingPage() {
   }, [success, error])
 
   const handleGameSearch = async (query: string) => {
-    setSearchTerm(query)
     setIsSearching(true)
 
     try {

--- a/src/components/ui/Autocomplete.tsx
+++ b/src/components/ui/Autocomplete.tsx
@@ -50,7 +50,7 @@ function Autocomplete(props: Props) {
 
   // Keep inputValue in sync with value prop
   useEffect(() => {
-    if (!props.value) return setInputValue('')
+    if (!props.value) return
 
     const selected = props.options.find((o) => o.value === props.value)
     setInputValue(selected ? selected.label : '')
@@ -171,7 +171,7 @@ function Autocomplete(props: Props) {
         <input
           ref={inputRef}
           type="text"
-          className={`w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition-all duration-200 ${props.leftIcon ? 'pl-10' : ''} ${props.rightIcon || loading ? 'pr-10' : ''}`}
+          className={`w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition-all duration-200 pr-10 ${props.leftIcon ? 'pl-10' : ''}`}
           placeholder={placeholder}
           value={inputValue}
           onChange={handleChange}


### PR DESCRIPTION
The searchTerm state in the form component always causes the input to rerender and lose focus if the state update happens inside the handler triggered by interaction with that input.

I analyzed why this state was created and found that it basically triggers a search when the input has 2 or more characters. If this criterion is not critical, then my approach of removing this state should work for you.

Additionally: the entire form shifts in width briefly when typing in the search field.
This happens because of Tailwind — space for the loading spinner is reserved conditionally via the input’s class. Tailwind doesn’t react quickly enough to the spinner being absolutely positioned, causing the form to jump.
I fixed this by reserving the spinner’s space upfront without conditional classes.

This commit contains quite a bit of my own solution ideas for the problem. I’ll understand if the pull request is not approved :)