### PR TITLE
Fix pagination back behavior

### DIFF
--- a/src/app/admin/emulators/[emulatorId]/page.tsx
+++ b/src/app/admin/emulators/[emulatorId]/page.tsx
@@ -45,7 +45,7 @@ function EditEmulatorPage() {
         className="mb-6"
       >
         <ArrowLeft className="mr-2 h-4 w-4" />
-        Back to Emulators
+        Go Back
       </Button>
 
       <h1 className="text-3xl font-bold mb-8 text-gray-800 dark:text-white">

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -47,7 +47,7 @@ function GameDetailsPage() {
             className="mb-6"
           >
             <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Games
+            Go Back
           </Button>
         </div>
 

--- a/src/app/listings/hooks/useListingsState.ts
+++ b/src/app/listings/hooks/useListingsState.ts
@@ -56,7 +56,9 @@ function useListingsState() {
   // Helper to update URL and state
   const updateQuery = (
     params: Record<string, string | number | string[] | number[] | null>,
+    options: { pushHistory?: boolean } = {},
   ) => {
+    const { pushHistory = false } = options
     const newParams = new URLSearchParams(searchParams.toString())
     Object.entries(params).forEach(([key, value]) => {
       if (value === null || value === '' || value === undefined) {
@@ -71,7 +73,12 @@ function useListingsState() {
         newParams.set(key, String(value))
       }
     })
-    router.replace(`?${newParams.toString()}`)
+    const url = `?${newParams.toString()}`
+    if (pushHistory) {
+      router.push(url)
+    } else {
+      router.replace(url)
+    }
   }
 
   const handleSort = (field: string) => {

--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -698,7 +698,10 @@ function ListingsPage() {
                 itemsPerPage={listingsQuery.data.pagination.limit}
                 onPageChange={(newPage) => {
                   listingsState.setPage(newPage)
-                  listingsState.updateQuery({ page: newPage })
+                  listingsState.updateQuery(
+                    { page: newPage },
+                    { pushHistory: true },
+                  )
                 }}
               />
             )}


### PR DESCRIPTION
## Summary
- keep page history when changing page
- add pushHistory option to updateQuery
- use "Go Back" label for back buttons

## Testing
- `npm run test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68574e2ce71483248171dda763298b0b