### PR TITLE
Show pending counts on admin cards

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,8 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,27 +33,27 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
+
           # Optional: Allow Claude to run specific commands
           # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests
           #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/src/app/admin/components/ApprovalCountBadge.tsx
+++ b/src/app/admin/components/ApprovalCountBadge.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { Badge } from '@/components/ui'
+import { api } from '@/lib/api'
+import { cn } from '@/lib/utils'
+import { hasPermission, PERMISSIONS } from '@/utils/permission-system'
+
+interface Props {
+  href: string
+  className?: string
+}
+
+export default function ApprovalCountBadge(props: Props) {
+  const userQuery = api.users.me.useQuery()
+
+  const canViewStats = hasPermission(
+    userQuery.data?.permissions,
+    PERMISSIONS.VIEW_STATISTICS,
+  )
+
+  const gameStatsQuery = api.games.getStats.useQuery(undefined, {
+    enabled: canViewStats && props.href === '/admin/games/approvals',
+    refetchInterval: 30000,
+    staleTime: 10000,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+  })
+
+  const listingStatsQuery = api.listings.getStats.useQuery(undefined, {
+    enabled: canViewStats && props.href === '/admin/approvals',
+    refetchInterval: 30000,
+    staleTime: 10000,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+  })
+
+  const pcListingStatsQuery = api.pcListings.stats.useQuery(undefined, {
+    enabled: canViewStats && props.href === '/admin/pc-listing-approvals',
+    refetchInterval: 30000,
+    staleTime: 10000,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+  })
+
+  const statsMap = {
+    '/admin/games/approvals': gameStatsQuery,
+    '/admin/approvals': listingStatsQuery,
+    '/admin/pc-listing-approvals': pcListingStatsQuery,
+  } as const
+
+  const count = statsMap[props.href]?.data?.pending
+
+  if (typeof count !== 'number' || count <= 0) return null
+
+  return (
+    <Badge
+      variant="danger"
+      size="sm"
+      pill
+      className={cn(
+        'absolute top-2 right-2 transition-all duration-300 ease-in-out',
+        props.className,
+      )}
+    >
+      {count}
+    </Badge>
+  )
+}

--- a/src/app/admin/components/ApprovalCountBadge.tsx
+++ b/src/app/admin/components/ApprovalCountBadge.tsx
@@ -48,7 +48,7 @@ export default function ApprovalCountBadge(props: Props) {
     '/admin/pc-listing-approvals': pcListingStatsQuery,
   } as const
 
-  const count = statsMap[props.href]?.data?.pending
+  const count = statsMap[props.href as keyof typeof statsMap]?.data?.pending
 
   if (typeof count !== 'number' || count <= 0) return null
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import { getCurrentUser } from '@/server/utils/auth'
 import { hasPermission } from '@/utils/permissions'
 import { Role } from '@orm'
+import ApprovalCountBadge from './components/ApprovalCountBadge'
 import {
   moderatorNavItems,
   adminNavItems,
@@ -91,6 +92,7 @@ async function AdminDashboardPage() {
               key={item.href}
               href={item.href}
               className={cn(
+                'relative',
                 'bg-green-50 dark:bg-green-900/20',
                 'p-6 rounded-lg',
                 'border border-green-200 dark:border-green-700 hover:border-green-300 dark:hover:border-green-500 transition-colors',
@@ -103,6 +105,7 @@ async function AdminDashboardPage() {
               <p className="text-sm text-green-700 dark:text-green-400">
                 {item.description}
               </p>
+              <ApprovalCountBadge href={item.href} />
             </Link>
           ))}
         {isModerator &&
@@ -111,6 +114,7 @@ async function AdminDashboardPage() {
               key={item.href}
               href={item.href}
               className={cn(
+                'relative',
                 'bg-white dark:bg-gray-800',
                 'p-6 rounded-lg',
                 'border border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-500 transition-colors',
@@ -121,6 +125,7 @@ async function AdminDashboardPage() {
               <p className="text-sm text-gray-600 dark:text-gray-400">
                 {item.description}
               </p>
+              <ApprovalCountBadge href={item.href} />
             </Link>
           ))}
         {isAdmin &&
@@ -129,6 +134,7 @@ async function AdminDashboardPage() {
               key={item.href}
               href={item.href}
               className={cn(
+                'relative',
                 'bg-white dark:bg-gray-800',
                 'p-6 rounded-lg',
                 'border border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-500 transition-colors',
@@ -139,6 +145,7 @@ async function AdminDashboardPage() {
               <p className="text-sm text-gray-600 dark:text-gray-400">
                 {item.description}
               </p>
+              <ApprovalCountBadge href={item.href} />
             </Link>
           ))}
 
@@ -148,6 +155,7 @@ async function AdminDashboardPage() {
               key={item.href}
               href={item.href}
               className={cn(
+                'relative',
                 'bg-purple-50 dark:bg-purple-900/20',
                 'p-6 rounded-lg',
                 'border border-purple-200 dark:border-purple-700 hover:border-purple-300 dark:hover:border-purple-500 transition-colors',
@@ -160,6 +168,7 @@ async function AdminDashboardPage() {
               <p className="text-sm text-purple-700 dark:text-purple-400">
                 {item.description}
               </p>
+              <ApprovalCountBadge href={item.href} />
             </Link>
           ))}
       </div>


### PR DESCRIPTION
## Summary
- add `ApprovalCountBadge` component to fetch approval stats via TRPC
- display approval counts on admin dashboard cards
- refine badge styling and avoid prop destructuring

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879271392308324ac5d887de1f307f5