### PR TITLE
refactor: centralize prisma selects across routers

### DIFF
--- a/src/server/api/routers/cache.ts
+++ b/src/server/api/routers/cache.ts
@@ -9,6 +9,7 @@ import {
   suggestIndexes,
   analyzeQueryComplexity,
 } from '@/server/utils/query-performance'
+import { gameTitleSelect } from '@/server/utils/selects'
 import { ApprovalStatus } from '@orm'
 
 export const cacheRouter = createTRPCRouter({
@@ -60,7 +61,7 @@ export const cacheRouter = createTRPCRouter({
       const popularGames = await ctx.prisma.game.findMany({
         take: 10,
         orderBy: { listings: { _count: 'desc' } },
-        select: { id: true, title: true },
+        select: gameTitleSelect,
       })
 
       // Warm game metadata
@@ -85,7 +86,7 @@ export const cacheRouter = createTRPCRouter({
         where: { status: ApprovalStatus.APPROVED },
         orderBy: { votes: { _count: 'desc' } },
         include: {
-          game: { select: { title: true } },
+          game: { select: gameTitleSelect },
           device: { include: { brand: true } },
           emulator: true,
         },

--- a/src/server/api/routers/emulators.ts
+++ b/src/server/api/routers/emulators.ts
@@ -19,7 +19,12 @@ import {
 import { calculateOffset, createPaginationResult } from '@/server/utils/pagination'
 import { buildSearchFilter } from '@/server/utils/query-builders'
 import { batchQueries } from '@/server/utils/query-performance'
-import { userSelect, emulatorBasicSelect, systemBasicSelect } from '@/server/utils/selects'
+import {
+  userSelect,
+  emulatorBasicSelect,
+  systemBasicSelect,
+  systemIdSelect,
+} from '@/server/utils/selects'
 import { hasPermission } from '@/utils/permissions'
 import { type Prisma, Role } from '@orm'
 
@@ -278,7 +283,7 @@ export const emulatorsRouter = createTRPCRouter({
 
       const systems = await ctx.prisma.system.findMany({
         where: { id: { in: input.systemIds } },
-        select: userSelect(['id']),
+        select: systemIdSelect,
       })
 
       if (systems.length !== input.systemIds.length) {

--- a/src/server/api/routers/emulators.ts
+++ b/src/server/api/routers/emulators.ts
@@ -19,6 +19,7 @@ import {
 import { calculateOffset, createPaginationResult } from '@/server/utils/pagination'
 import { buildSearchFilter } from '@/server/utils/query-builders'
 import { batchQueries } from '@/server/utils/query-performance'
+import { userSelect, emulatorBasicSelect, systemBasicSelect } from '@/server/utils/selects'
 import { hasPermission } from '@/utils/permissions'
 import { type Prisma, Role } from '@orm'
 
@@ -73,10 +74,10 @@ export const emulatorsRouter = createTRPCRouter({
     const emulators = await ctx.prisma.emulator.findMany({
       where,
       include: {
-        systems: { select: { id: true, name: true, key: true } },
+        systems: { select: systemBasicSelect },
         verifiedDevelopers: {
           include: {
-            user: { select: { id: true, name: true, profileImage: true } },
+            user: { select: userSelect(['id', 'name', 'profileImage']) },
           },
         },
         _count: { select: { listings: true, systems: true } },
@@ -96,10 +97,10 @@ export const emulatorsRouter = createTRPCRouter({
     const emulator = await ctx.prisma.emulator.findUnique({
       where: { id: input.id },
       include: {
-        systems: { select: { id: true, name: true, key: true } },
+        systems: { select: systemBasicSelect },
         verifiedDevelopers: {
           include: {
-            user: { select: { id: true, name: true, profileImage: true } },
+            user: { select: userSelect(['id', 'name', 'profileImage']) },
           },
         },
         customFieldDefinitions: { orderBy: { displayOrder: 'asc' } },
@@ -162,10 +163,10 @@ export const emulatorsRouter = createTRPCRouter({
     const emulators = await ctx.prisma.emulator.findMany({
       where,
       include: {
-        systems: { select: { id: true, name: true, key: true } },
+        systems: { select: systemBasicSelect },
         verifiedDevelopers: {
           include: {
-            user: { select: { id: true, name: true, profileImage: true } },
+            user: { select: userSelect(['id', 'name', 'profileImage']) },
           },
         },
         _count: { select: { listings: true, systems: true } },
@@ -191,8 +192,8 @@ export const emulatorsRouter = createTRPCRouter({
           },
         },
         include: {
-          user: { select: { id: true, name: true, profileImage: true } },
-          emulator: { select: { id: true, name: true } },
+          user: { select: userSelect(['id', 'name', 'profileImage']) },
+          emulator: { select: emulatorBasicSelect },
         },
       }),
   ),
@@ -277,7 +278,7 @@ export const emulatorsRouter = createTRPCRouter({
 
       const systems = await ctx.prisma.system.findMany({
         where: { id: { in: input.systemIds } },
-        select: { id: true },
+        select: userSelect(['id']),
       })
 
       if (systems.length !== input.systemIds.length) {

--- a/src/server/api/routers/games.ts
+++ b/src/server/api/routers/games.ts
@@ -39,6 +39,12 @@ import { isPrismaError, PRISMA_ERROR_CODES } from '@/server/utils/prisma-errors'
 import { buildSearchFilter } from '@/server/utils/query-builders'
 import { createCountQuery, analyzeQueryComplexity } from '@/server/utils/query-performance'
 import {
+  userSelect,
+  userIdNameSelect,
+  systemBasicSelect,
+  brandBasicSelect,
+} from '@/server/utils/selects'
+import {
   findTitleIdForGameName,
   getBestTitleIdMatch,
   getSwitchGamesStats,
@@ -106,7 +112,7 @@ async function performGameUpdate(
       data,
       include: {
         system: true,
-        submitter: { select: { id: true, name: true, email: true } },
+        submitter: { select: userSelect(['id', 'name', 'email']) },
       },
     })
   } catch (error) {
@@ -223,9 +229,9 @@ export const gamesRouter = createTRPCRouter({
           approvedBy: true,
           approvedAt: true,
           createdAt: true,
-          system: { select: { id: true, name: true } },
+          system: { select: systemBasicSelect },
           submitter: hasPermission(ctx.session?.user?.role, Role.ADMIN)
-            ? { select: { id: true, name: true, email: true } }
+            ? { select: userSelect(['id', 'name', 'email']) }
             : false,
           _count: { select: { listings: true, pcListings: true } },
         },
@@ -311,7 +317,7 @@ export const gamesRouter = createTRPCRouter({
 
     // Define include configuration for reusability and complexity analysis
     const includeConfig = {
-      submitter: { select: { id: true, name: true } },
+      submitter: { select: userIdNameSelect },
       system: { include: { emulators: true } },
       listings: {
         where: listingsWhere,
@@ -332,7 +338,7 @@ export const gamesRouter = createTRPCRouter({
             select: {
               id: true,
               modelName: true,
-              brand: { select: { id: true, name: true } },
+              brand: { select: brandBasicSelect },
             },
           },
           emulator: {
@@ -364,7 +370,7 @@ export const gamesRouter = createTRPCRouter({
                     isActive: true,
                     OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
                   },
-                  select: { id: true },
+                  select: userSelect(['id']),
                 },
               }),
             },
@@ -404,7 +410,7 @@ export const gamesRouter = createTRPCRouter({
                     isActive: true,
                     OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
                   },
-                  select: { id: true },
+                  select: userSelect(['id']),
                 },
               }),
             },
@@ -450,7 +456,7 @@ export const gamesRouter = createTRPCRouter({
           id: true,
           tgdbGameId: true,
           title: true,
-          system: { select: { name: true } },
+          system: { select: userSelect(['name']) },
         },
       })
 
@@ -514,7 +520,7 @@ export const gamesRouter = createTRPCRouter({
         },
         include: {
           system: true,
-          submitter: { select: { id: true, name: true } },
+          submitter: { select: userIdNameSelect },
         },
       })
 
@@ -696,10 +702,10 @@ export const gamesRouter = createTRPCRouter({
               select: { id: true, name: true, key: true, tgdbPlatformId: true },
             },
             submitter: {
-              select: { id: true, name: true, email: true, profileImage: true },
+              select: userSelect(['id', 'name', 'email', 'profileImage']),
             },
             approver: {
-              select: { id: true, name: true, email: true, profileImage: true },
+              select: userSelect(['id', 'name', 'email', 'profileImage']),
             },
           },
           orderBy: orderBy as Prisma.GameOrderByWithRelationInput,
@@ -735,8 +741,8 @@ export const gamesRouter = createTRPCRouter({
           },
           include: {
             system: true,
-            submitter: { select: { id: true, name: true, email: true } },
-            approver: { select: { id: true, name: true, email: true } },
+            submitter: { select: userSelect(['id', 'name', 'email']) },
+            approver: { select: userSelect(['id', 'name', 'email']) },
           },
         }),
     )
@@ -923,8 +929,8 @@ export const gamesRouter = createTRPCRouter({
         },
         include: {
           system: true,
-          submitter: { select: { id: true, name: true, email: true } },
-          approver: { select: { id: true, name: true, email: true } },
+          submitter: { select: userSelect(['id', 'name', 'email']) },
+          approver: { select: userSelect(['id', 'name', 'email']) },
         },
       })
 
@@ -985,8 +991,8 @@ export const gamesRouter = createTRPCRouter({
         },
         include: {
           system: true,
-          submitter: { select: { id: true, name: true, email: true } },
-          approver: { select: { id: true, name: true, email: true } },
+          submitter: { select: userSelect(['id', 'name', 'email']) },
+          approver: { select: userSelect(['id', 'name', 'email']) },
         },
       })
 

--- a/src/server/api/routers/games.ts
+++ b/src/server/api/routers/games.ts
@@ -370,7 +370,7 @@ export const gamesRouter = createTRPCRouter({
                     isActive: true,
                     OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
                   },
-                  select: userSelect(['id']),
+                  select: { id: true },
                 },
               }),
             },
@@ -410,7 +410,7 @@ export const gamesRouter = createTRPCRouter({
                     isActive: true,
                     OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
                   },
-                  select: userSelect(['id']),
+                  select: { id: true },
                 },
               }),
             },
@@ -456,7 +456,7 @@ export const gamesRouter = createTRPCRouter({
           id: true,
           tgdbGameId: true,
           title: true,
-          system: { select: userSelect(['name']) },
+          system: { select: systemBasicSelect },
         },
       })
 

--- a/src/server/api/routers/listingReports.ts
+++ b/src/server/api/routers/listingReports.ts
@@ -17,6 +17,7 @@ import { calculateOffset, createPaginationResult } from '@/server/utils/paginati
 import { batchQueries } from '@/server/utils/query-performance'
 import {
   userSelect,
+  userNameSelect,
   userIdNameSelect,
   gameTitleSelect,
   emulatorBasicSelect,
@@ -182,7 +183,7 @@ export const listingReportsRouter = createTRPCRouter({
         listing: {
           include: {
             game: { select: gameTitleSelect },
-            author: { select: userSelect(['name']) },
+            author: { select: userNameSelect },
           },
         },
       },
@@ -232,11 +233,11 @@ export const listingReportsRouter = createTRPCRouter({
           listing: {
             include: {
               game: { select: gameTitleSelect },
-              author: { select: userSelect(['name']) },
+              author: { select: userNameSelect },
             },
           },
-          reportedBy: { select: userSelect(['name']) },
-          reviewedBy: { select: userSelect(['name']) },
+          reportedBy: { select: userNameSelect },
+          reviewedBy: { select: userNameSelect },
         },
       })
     }),

--- a/src/server/api/routers/listingReports.ts
+++ b/src/server/api/routers/listingReports.ts
@@ -15,6 +15,12 @@ import {
 } from '@/server/api/trpc'
 import { calculateOffset, createPaginationResult } from '@/server/utils/pagination'
 import { batchQueries } from '@/server/utils/query-performance'
+import {
+  userSelect,
+  userIdNameSelect,
+  gameTitleSelect,
+  emulatorBasicSelect,
+} from '@/server/utils/selects'
 import { PERMISSIONS } from '@/utils/permission-system'
 import { ApprovalStatus, type Prisma, ReportStatus } from '@orm'
 
@@ -92,14 +98,14 @@ export const listingReportsRouter = createTRPCRouter({
           include: {
             listing: {
               include: {
-                game: { select: { id: true, title: true } },
-                author: { select: { id: true, name: true } },
+                game: { select: gameTitleSelect },
+                author: { select: userIdNameSelect },
                 device: true,
-                emulator: { select: { id: true, name: true } },
+                emulator: { select: emulatorBasicSelect },
               },
             },
-            reportedBy: { select: { id: true, name: true, email: true } },
-            reviewedBy: { select: { id: true, name: true } },
+            reportedBy: { select: userSelect(['id', 'name', 'email']) },
+            reviewedBy: { select: userIdNameSelect },
           },
         }),
         ctx.prisma.listingReport.count({ where }),
@@ -120,14 +126,14 @@ export const listingReportsRouter = createTRPCRouter({
           listing: {
             include: {
               game: true,
-              author: { select: { id: true, name: true, email: true } },
+              author: { select: userSelect(['id', 'name', 'email']) },
               device: true,
               emulator: true,
               performance: true,
             },
           },
-          reportedBy: { select: { id: true, name: true, email: true } },
-          reviewedBy: { select: { id: true, name: true } },
+          reportedBy: { select: userSelect(['id', 'name', 'email']) },
+          reviewedBy: { select: userIdNameSelect },
         },
       })
 
@@ -175,8 +181,8 @@ export const listingReportsRouter = createTRPCRouter({
       include: {
         listing: {
           include: {
-            game: { select: { title: true } },
-            author: { select: { name: true } },
+            game: { select: gameTitleSelect },
+            author: { select: userSelect(['name']) },
           },
         },
       },
@@ -225,12 +231,12 @@ export const listingReportsRouter = createTRPCRouter({
         include: {
           listing: {
             include: {
-              game: { select: { title: true } },
-              author: { select: { name: true } },
+              game: { select: gameTitleSelect },
+              author: { select: userSelect(['name']) },
             },
           },
-          reportedBy: { select: { name: true } },
-          reviewedBy: { select: { name: true } },
+          reportedBy: { select: userSelect(['name']) },
+          reviewedBy: { select: userSelect(['name']) },
         },
       })
     }),

--- a/src/server/api/routers/listingVerifications.ts
+++ b/src/server/api/routers/listingVerifications.ts
@@ -10,6 +10,7 @@ import {
   userIdNameSelect,
   emulatorBasicSelect,
   gameTitleSelect,
+  brandBasicSelect,
 } from '@/server/utils/selects'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
 
@@ -133,10 +134,10 @@ export const listingVerificationsRouter = createTRPCRouter({
             listing: {
               include: {
                 game: { select: { title: true } },
-                emulator: { select: userSelect(['name']) },
+                emulator: { select: emulatorBasicSelect },
                 device: {
                   include: {
-                    brand: { select: userSelect(['name']) },
+                    brand: { select: brandBasicSelect },
                   },
                 },
               },

--- a/src/server/api/routers/listingVerifications.ts
+++ b/src/server/api/routers/listingVerifications.ts
@@ -5,6 +5,12 @@ import {
   GetListingVerificationsSchema,
   GetMyVerificationsSchema,
 } from '@/schemas/listingVerification'
+import {
+  userSelect,
+  userIdNameSelect,
+  emulatorBasicSelect,
+  gameTitleSelect,
+} from '@/server/utils/selects'
 import { createTRPCRouter, protectedProcedure } from '../trpc'
 
 export const listingVerificationsRouter = createTRPCRouter({
@@ -16,9 +22,9 @@ export const listingVerificationsRouter = createTRPCRouter({
     const listing = await ctx.prisma.listing.findUnique({
       where: { id: listingId },
       include: {
-        emulator: { select: { id: true, name: true } },
-        game: { select: { title: true } },
-        author: { select: { name: true } },
+        emulator: { select: emulatorBasicSelect },
+        game: { select: gameTitleSelect },
+        author: { select: userIdNameSelect },
       },
     })
 
@@ -62,11 +68,7 @@ export const listingVerificationsRouter = createTRPCRouter({
       },
       include: {
         developer: {
-          select: {
-            id: true,
-            name: true,
-            profileImage: true,
-          },
+          select: userSelect(['id', 'name', 'profileImage']),
         },
       },
     })
@@ -106,11 +108,7 @@ export const listingVerificationsRouter = createTRPCRouter({
         where: { listingId: input.listingId },
         include: {
           developer: {
-            select: {
-              id: true,
-              name: true,
-              profileImage: true,
-            },
+            select: userSelect(['id', 'name', 'profileImage']),
           },
         },
         orderBy: { verifiedAt: 'desc' },
@@ -135,10 +133,10 @@ export const listingVerificationsRouter = createTRPCRouter({
             listing: {
               include: {
                 game: { select: { title: true } },
-                emulator: { select: { name: true } },
+                emulator: { select: userSelect(['name']) },
                 device: {
                   include: {
-                    brand: { select: { name: true } },
+                    brand: { select: userSelect(['name']) },
                   },
                 },
               },

--- a/src/server/api/routers/listings/core.ts
+++ b/src/server/api/routers/listings/core.ts
@@ -35,6 +35,13 @@ import {
   buildNsfwFilter,
   buildArrayFilter,
 } from '@/server/utils/query-builders'
+import {
+  userSelect,
+  userIdNameSelect,
+  systemBasicSelect,
+  performanceBasicSelect,
+  brandBasicSelect,
+} from '@/server/utils/selects'
 import { withSavepoint } from '@/server/utils/transactions'
 import { roleIncludesRole } from '@/utils/permission-system'
 import { hasPermission } from '@/utils/permissions'
@@ -254,7 +261,7 @@ export const coreRouter = createTRPCRouter({
                 },
               },
               developerVerifications: {
-                include: { developer: { select: { id: true, name: true } } },
+                include: { developer: { select: userIdNameSelect } },
               },
               _count: { select: { votes: true, comments: true } },
               votes: ctx.session
@@ -393,7 +400,7 @@ export const coreRouter = createTRPCRouter({
         developerVerifications: {
           include: {
             developer: {
-              select: { id: true, name: true },
+              select: userIdNameSelect,
             },
           },
         },
@@ -487,7 +494,7 @@ export const coreRouter = createTRPCRouter({
         developerVerifications: {
           include: {
             developer: {
-              select: { id: true, name: true },
+              select: userIdNameSelect,
             },
           },
         },
@@ -498,9 +505,9 @@ export const coreRouter = createTRPCRouter({
         comments: {
           where: { parentId: null },
           include: {
-            user: { select: { id: true, name: true } },
+            user: { select: userIdNameSelect },
             replies: {
-              include: { user: { select: { id: true, name: true } } },
+              include: { user: { select: userIdNameSelect } },
               orderBy: { createdAt: 'asc' },
             },
           },
@@ -521,7 +528,7 @@ export const coreRouter = createTRPCRouter({
           isActive: true,
           OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
         },
-        select: { id: true },
+        select: userSelect(['id']),
       })
 
       if (authorBanStatus) {
@@ -594,7 +601,7 @@ export const coreRouter = createTRPCRouter({
 
     const userExists = await ctx.prisma.user.findUnique({
       where: { id: authorId },
-      select: { id: true },
+      select: userSelect(['id']),
     })
 
     if (!userExists) {
@@ -625,7 +632,7 @@ export const coreRouter = createTRPCRouter({
 
       const emulator = await tx.emulator.findUnique({
         where: { id: emulatorId },
-        include: { systems: { select: { id: true } } },
+        include: { systems: { select: userSelect(['id']) } },
       })
 
       if (!emulator) return ResourceError.emulator.notFound()
@@ -759,7 +766,7 @@ export const coreRouter = createTRPCRouter({
 
     const userExists = await ctx.prisma.user.findUnique({
       where: { id: userId },
-      select: { id: true },
+      select: userSelect(['id']),
     })
 
     if (!userExists) return ResourceError.user.notInDatabase(userId)
@@ -991,9 +998,9 @@ export const coreRouter = createTRPCRouter({
         device: { include: { brand: true } },
         emulator: true,
         performance: true,
-        author: { select: { id: true, name: true } },
+        author: { select: userIdNameSelect },
         developerVerifications: {
-          include: { developer: { select: { id: true, name: true } } },
+          include: { developer: { select: userIdNameSelect } },
         },
         _count: { select: { votes: true, comments: true } },
       },
@@ -1213,14 +1220,14 @@ export const coreRouter = createTRPCRouter({
             select: {
               id: true,
               title: true,
-              system: { select: { id: true, name: true } },
+              system: { select: systemBasicSelect },
             },
           },
           device: {
             select: {
               id: true,
               modelName: true,
-              brand: { select: { id: true, name: true } },
+              brand: { select: brandBasicSelect },
             },
           },
           emulator: {
@@ -1230,7 +1237,7 @@ export const coreRouter = createTRPCRouter({
               customFieldDefinitions: { orderBy: { displayOrder: 'asc' } },
             },
           },
-          performance: { select: { id: true, label: true, rank: true } },
+          performance: { select: performanceBasicSelect },
           customFieldValues: { include: { customFieldDefinition: true } },
         },
       })
@@ -1252,7 +1259,7 @@ export const coreRouter = createTRPCRouter({
       where: { id: input.listingId },
       include: {
         emulator: true,
-        author: { select: { id: true, name: true } },
+        author: { select: userIdNameSelect },
       },
     })
 
@@ -1297,7 +1304,7 @@ export const coreRouter = createTRPCRouter({
         verifiedBy: userId,
         notes: input.notes,
       },
-      include: { developer: { select: { id: true, name: true } } },
+      include: { developer: { select: userIdNameSelect } },
     })
 
     // Emit notification event for listing verification

--- a/src/server/api/routers/listings/core.ts
+++ b/src/server/api/routers/listings/core.ts
@@ -39,6 +39,7 @@ import {
   userSelect,
   userIdNameSelect,
   systemBasicSelect,
+  systemIdSelect,
   performanceBasicSelect,
   brandBasicSelect,
 } from '@/server/utils/selects'
@@ -528,7 +529,7 @@ export const coreRouter = createTRPCRouter({
           isActive: true,
           OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
         },
-        select: userSelect(['id']),
+        select: { id: true },
       })
 
       if (authorBanStatus) {
@@ -632,7 +633,7 @@ export const coreRouter = createTRPCRouter({
 
       const emulator = await tx.emulator.findUnique({
         where: { id: emulatorId },
-        include: { systems: { select: userSelect(['id']) } },
+        include: { systems: { select: systemIdSelect } },
       })
 
       if (!emulator) return ResourceError.emulator.notFound()

--- a/src/server/api/routers/mobile/admin.ts
+++ b/src/server/api/routers/mobile/admin.ts
@@ -32,6 +32,7 @@ import {
   systemBasicSelect,
   gameTitleSelect,
   emulatorBasicSelect,
+  brandBasicSelect,
 } from '@/server/utils/selects'
 import { ApprovalStatus, Prisma, ReportStatus, TrustAction } from '@orm'
 
@@ -402,7 +403,7 @@ export const mobileAdminRouter = createMobileTRPCRouter({
             listing: {
               include: {
                 game: { select: gameTitleSelect },
-                device: { include: { brand: { select: userSelect(['name']) } } },
+                device: { include: { brand: { select: brandBasicSelect } } },
                 emulator: { select: emulatorBasicSelect },
                 author: { select: userIdNameSelect },
               },
@@ -446,7 +447,7 @@ export const mobileAdminRouter = createMobileTRPCRouter({
           reviewedAt: new Date(),
         },
         include: {
-          listing: { select: userSelect(['id']) },
+          listing: { select: { id: true } },
           reportedBy: { select: userIdNameSelect },
           reviewedBy: { select: userIdNameSelect },
         },

--- a/src/server/api/routers/mobile/admin.ts
+++ b/src/server/api/routers/mobile/admin.ts
@@ -26,6 +26,13 @@ import { listingStatsCache } from '@/server/utils/cache/instances'
 import { calculateOffset, createPaginationResult } from '@/server/utils/pagination'
 import { buildSearchFilter } from '@/server/utils/query-builders'
 import { createCountQuery } from '@/server/utils/query-performance'
+import {
+  userSelect,
+  userIdNameSelect,
+  systemBasicSelect,
+  gameTitleSelect,
+  emulatorBasicSelect,
+} from '@/server/utils/selects'
 import { ApprovalStatus, Prisma, ReportStatus, TrustAction } from '@orm'
 
 const LISTING_STATS_CACHE_KEY = 'listing-stats'
@@ -128,7 +135,7 @@ export const mobileAdminRouter = createMobileTRPCRouter({
           game: { include: { system: true } },
           device: { include: { brand: true } },
           emulator: true,
-          author: { select: { id: true, name: true, email: true } },
+          author: { select: userSelect(['id', 'name', 'email']) },
           performance: true,
         },
         orderBy: { createdAt: 'desc' },
@@ -231,7 +238,7 @@ export const mobileAdminRouter = createMobileTRPCRouter({
 
       const listingToReject = await ctx.prisma.listing.findUnique({
         where: { id: listingId },
-        include: { author: { select: { id: true } } },
+        include: { author: { select: userSelect(['id']) } },
       })
 
       if (!listingToReject || listingToReject.status !== ApprovalStatus.PENDING) {
@@ -296,8 +303,8 @@ export const mobileAdminRouter = createMobileTRPCRouter({
             isErotic: true,
             status: true,
             submittedAt: true,
-            system: { select: { id: true, name: true } },
-            submitter: { select: { id: true, name: true, email: true } },
+            system: { select: systemBasicSelect },
+            submitter: { select: userSelect(['id', 'name', 'email']) },
           },
           orderBy: { submittedAt: 'desc' },
           skip,
@@ -337,7 +344,7 @@ export const mobileAdminRouter = createMobileTRPCRouter({
         },
         include: {
           system: true,
-          submitter: { select: { id: true, name: true, email: true } },
+          submitter: { select: userSelect(['id', 'name', 'email']) },
         },
       })
     }),
@@ -369,7 +376,7 @@ export const mobileAdminRouter = createMobileTRPCRouter({
         },
         include: {
           system: true,
-          submitter: { select: { id: true, name: true, email: true } },
+          submitter: { select: userSelect(['id', 'name', 'email']) },
         },
       })
     }),
@@ -394,14 +401,14 @@ export const mobileAdminRouter = createMobileTRPCRouter({
           include: {
             listing: {
               include: {
-                game: { select: { title: true } },
-                device: { include: { brand: { select: { name: true } } } },
-                emulator: { select: { name: true } },
-                author: { select: { id: true, name: true } },
+                game: { select: gameTitleSelect },
+                device: { include: { brand: { select: userSelect(['name']) } } },
+                emulator: { select: emulatorBasicSelect },
+                author: { select: userIdNameSelect },
               },
             },
-            reportedBy: { select: { id: true, name: true } },
-            reviewedBy: { select: { id: true, name: true } },
+            reportedBy: { select: userIdNameSelect },
+            reviewedBy: { select: userIdNameSelect },
           },
           orderBy: { createdAt: 'desc' },
           skip,
@@ -439,9 +446,9 @@ export const mobileAdminRouter = createMobileTRPCRouter({
           reviewedAt: new Date(),
         },
         include: {
-          listing: { select: { id: true } },
-          reportedBy: { select: { id: true, name: true } },
-          reviewedBy: { select: { id: true, name: true } },
+          listing: { select: userSelect(['id']) },
+          reportedBy: { select: userIdNameSelect },
+          reviewedBy: { select: userIdNameSelect },
         },
       })
     }),
@@ -464,8 +471,8 @@ export const mobileAdminRouter = createMobileTRPCRouter({
         ctx.prisma.userBan.findMany({
           where,
           include: {
-            user: { select: { id: true, name: true, email: true } },
-            bannedBy: { select: { id: true, name: true } },
+            user: { select: userSelect(['id', 'name', 'email']) },
+            bannedBy: { select: userIdNameSelect },
           },
           orderBy: { createdAt: 'desc' },
           skip,
@@ -491,7 +498,7 @@ export const mobileAdminRouter = createMobileTRPCRouter({
       // Check if user exists
       const user = await ctx.prisma.user.findUnique({
         where: { id: userId },
-        select: { id: true },
+        select: userSelect(['id']),
       })
 
       if (!user) return ResourceError.user.notFound()
@@ -516,8 +523,8 @@ export const mobileAdminRouter = createMobileTRPCRouter({
           isActive: true,
         },
         include: {
-          user: { select: { id: true, name: true, email: true } },
-          bannedBy: { select: { id: true, name: true } },
+          user: { select: userSelect(['id', 'name', 'email']) },
+          bannedBy: { select: userIdNameSelect },
         },
       })
     }),
@@ -543,8 +550,8 @@ export const mobileAdminRouter = createMobileTRPCRouter({
           expiresAt: expiresAt ? new Date(expiresAt) : undefined,
         },
         include: {
-          user: { select: { id: true, name: true, email: true } },
-          bannedBy: { select: { id: true, name: true } },
+          user: { select: userSelect(['id', 'name', 'email']) },
+          bannedBy: { select: userIdNameSelect },
         },
       })
     }),

--- a/src/server/api/routers/mobile/auth.ts
+++ b/src/server/api/routers/mobile/auth.ts
@@ -11,6 +11,7 @@ import {
   mobileProtectedProcedure,
   mobilePublicProcedure,
 } from '@/server/api/mobileContext'
+import { userSelect } from '@/server/utils/selects'
 
 const clerkClient = createClerkClient({
   secretKey: process.env.CLERK_SECRET_KEY!,
@@ -88,7 +89,7 @@ export const mobileAuthRouter = createMobileTRPCRouter({
 
       return await ctx.prisma.user.findUnique({
         where: { id: userId },
-        select: { id: true, email: true, name: true, role: true },
+        select: userSelect(['id', 'email', 'name', 'role']),
       })
     }),
 

--- a/src/server/api/routers/mobile/cpus.ts
+++ b/src/server/api/routers/mobile/cpus.ts
@@ -1,6 +1,7 @@
 import { ResourceError } from '@/lib/errors'
 import { GetCpusSchema, GetCpuByIdSchema } from '@/schemas/cpu'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
+import { brandBasicSelect } from '@/server/utils/selects'
 import { Prisma } from '@orm'
 
 export const mobileCpusRouter = createMobileTRPCRouter({
@@ -77,7 +78,7 @@ export const mobileCpusRouter = createMobileTRPCRouter({
     const [cpus, total] = await Promise.all([
       ctx.prisma.cpu.findMany({
         where,
-        include: { brand: { select: { id: true, name: true } } },
+        include: { brand: { select: brandBasicSelect } },
         orderBy,
         skip: actualOffset,
         take: limit,
@@ -104,7 +105,7 @@ export const mobileCpusRouter = createMobileTRPCRouter({
   getById: mobilePublicProcedure.input(GetCpuByIdSchema).query(async ({ ctx, input }) => {
     const cpu = await ctx.prisma.cpu.findUnique({
       where: { id: input.id },
-      include: { brand: { select: { id: true, name: true } } },
+      include: { brand: { select: brandBasicSelect } },
     })
 
     return cpu || ResourceError.cpu.notFound()

--- a/src/server/api/routers/mobile/customFieldDefinitions.ts
+++ b/src/server/api/routers/mobile/customFieldDefinitions.ts
@@ -1,5 +1,6 @@
 import { GetCustomFieldDefinitionsByEmulatorSchema } from '@/schemas/customFieldDefinition'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
+import { emulatorBasicSelect } from '@/server/utils/selects'
 
 export const mobileCustomFieldDefinitionsRouter = createMobileTRPCRouter({
   /**
@@ -13,7 +14,7 @@ export const mobileCustomFieldDefinitionsRouter = createMobileTRPCRouter({
         orderBy: { displayOrder: 'asc' },
         include: {
           emulator: {
-            select: { id: true, name: true },
+            select: emulatorBasicSelect,
           },
         },
       })

--- a/src/server/api/routers/mobile/developers.ts
+++ b/src/server/api/routers/mobile/developers.ts
@@ -15,6 +15,7 @@ import {
   userSelect,
   userIdNameSelect,
   emulatorBasicSelect,
+  brandBasicSelect,
   gameTitleSelect,
 } from '@/server/utils/selects'
 
@@ -159,8 +160,8 @@ export const mobileDevelopersRouter = createMobileTRPCRouter({
             listing: {
               include: {
                 game: { select: { title: true } },
-                emulator: { select: userSelect(['name']) },
-                device: { include: { brand: { select: userSelect(['name']) } } },
+                emulator: { select: emulatorBasicSelect },
+                device: { include: { brand: { select: brandBasicSelect } } },
               },
             },
           },

--- a/src/server/api/routers/mobile/developers.ts
+++ b/src/server/api/routers/mobile/developers.ts
@@ -11,6 +11,12 @@ import {
   mobileDeveloperProcedure,
   mobileProtectedProcedure,
 } from '@/server/api/mobileContext'
+import {
+  userSelect,
+  userIdNameSelect,
+  emulatorBasicSelect,
+  gameTitleSelect,
+} from '@/server/utils/selects'
 
 export const mobileDevelopersRouter = createMobileTRPCRouter({
   /**
@@ -19,7 +25,7 @@ export const mobileDevelopersRouter = createMobileTRPCRouter({
   getMyVerifiedEmulators: mobileDeveloperProcedure.query(async ({ ctx }) => {
     const verifiedDevelopers = await ctx.prisma.verifiedDeveloper.findMany({
       where: { userId: ctx.session.user.id },
-      include: { emulator: { select: { id: true, name: true, logo: true } } },
+      include: { emulator: { select: emulatorBasicSelect } },
       orderBy: { verifiedAt: 'desc' },
     })
 
@@ -57,9 +63,9 @@ export const mobileDevelopersRouter = createMobileTRPCRouter({
       const listing = await ctx.prisma.listing.findUnique({
         where: { id: listingId },
         include: {
-          emulator: { select: { id: true, name: true } },
-          game: { select: { title: true } },
-          author: { select: { name: true } },
+          emulator: { select: emulatorBasicSelect },
+          game: { select: gameTitleSelect },
+          author: { select: userIdNameSelect },
         },
       })
 
@@ -88,7 +94,7 @@ export const mobileDevelopersRouter = createMobileTRPCRouter({
       return await ctx.prisma.listingDeveloperVerification.create({
         data: { listingId, verifiedBy: userId, notes },
         include: {
-          developer: { select: { id: true, name: true, profileImage: true } },
+          developer: { select: userSelect(['id', 'name', 'profileImage']) },
         },
       })
     }),
@@ -128,7 +134,7 @@ export const mobileDevelopersRouter = createMobileTRPCRouter({
       return await ctx.prisma.listingDeveloperVerification.findMany({
         where: { listingId: input.listingId },
         include: {
-          developer: { select: { id: true, name: true, profileImage: true } },
+          developer: { select: userSelect(['id', 'name', 'profileImage']) },
         },
         orderBy: { verifiedAt: 'desc' },
       })
@@ -153,8 +159,8 @@ export const mobileDevelopersRouter = createMobileTRPCRouter({
             listing: {
               include: {
                 game: { select: { title: true } },
-                emulator: { select: { name: true } },
-                device: { include: { brand: { select: { name: true } } } },
+                emulator: { select: userSelect(['name']) },
+                device: { include: { brand: { select: userSelect(['name']) } } },
               },
             },
           },

--- a/src/server/api/routers/mobile/devices.ts
+++ b/src/server/api/routers/mobile/devices.ts
@@ -2,6 +2,7 @@ import { ResourceError } from '@/lib/errors'
 import { GetDeviceByIdSchema } from '@/schemas/device'
 import { GetDevicesSchema } from '@/schemas/mobile'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
+import { brandBasicSelect } from '@/server/utils/selects'
 import { ApprovalStatus } from '@orm'
 
 export const mobileDevicesRouter = createMobileTRPCRouter({
@@ -24,7 +25,7 @@ export const mobileDevicesRouter = createMobileTRPCRouter({
     return await ctx.prisma.device.findMany({
       where: baseWhere,
       include: {
-        brand: { select: { id: true, name: true } },
+        brand: { select: brandBasicSelect },
         soc: { select: { id: true, name: true, manufacturer: true } },
         _count: {
           select: {
@@ -43,7 +44,7 @@ export const mobileDevicesRouter = createMobileTRPCRouter({
   brands: mobilePublicProcedure.query(
     async ({ ctx }) =>
       await ctx.prisma.deviceBrand.findMany({
-        select: { id: true, name: true },
+        select: brandBasicSelect,
         orderBy: { name: 'asc' },
       }),
   ),
@@ -66,7 +67,7 @@ export const mobileDevicesRouter = createMobileTRPCRouter({
     const device = await ctx.prisma.device.findUnique({
       where: { id: input.id },
       include: {
-        brand: { select: { id: true, name: true } },
+        brand: { select: brandBasicSelect },
         soc: { select: { id: true, name: true, manufacturer: true } },
         _count: {
           select: {

--- a/src/server/api/routers/mobile/emulators.ts
+++ b/src/server/api/routers/mobile/emulators.ts
@@ -1,6 +1,7 @@
 import { GetEmulatorByIdSchema, GetEmulatorsSchema } from '@/schemas/mobile'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
 import { buildSearchFilter } from '@/server/utils/query-builders'
+import { systemBasicSelect } from '@/server/utils/selects'
 import { ApprovalStatus } from '@orm'
 
 export const mobileEmulatorsRouter = createMobileTRPCRouter({
@@ -22,7 +23,7 @@ export const mobileEmulatorsRouter = createMobileTRPCRouter({
     return await ctx.prisma.emulator.findMany({
       where: whereClause,
       include: {
-        systems: { select: { id: true, name: true, key: true } },
+        systems: { select: systemBasicSelect },
         _count: {
           select: {
             listings: { where: { status: ApprovalStatus.APPROVED } },
@@ -41,7 +42,7 @@ export const mobileEmulatorsRouter = createMobileTRPCRouter({
     return await ctx.prisma.emulator.findUnique({
       where: { id: input.id },
       include: {
-        systems: { select: { id: true, name: true, key: true } },
+        systems: { select: systemBasicSelect },
         _count: { select: { listings: true } },
       },
     })

--- a/src/server/api/routers/mobile/games.ts
+++ b/src/server/api/routers/mobile/games.ts
@@ -9,6 +9,7 @@ import {
   GetSwitchGamesStatsMobileSchema,
 } from '@/schemas/mobile'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
+import { systemBasicSelect } from '@/server/utils/selects'
 import {
   findTitleIdForGameName,
   getBestTitleIdMatch,
@@ -64,7 +65,7 @@ async function getGamesQuery(
         isErotic: true,
         status: true,
         createdAt: true,
-        system: { select: { id: true, name: true, key: true } },
+        system: { select: systemBasicSelect },
         _count: {
           select: {
             listings: { where: { status: ApprovalStatus.APPROVED } },
@@ -118,7 +119,7 @@ export const mobileGamesRouter = createMobileTRPCRouter({
         isErotic: true,
         status: true,
         createdAt: true,
-        system: { select: { id: true, name: true, key: true } },
+        system: { select: systemBasicSelect },
         _count: {
           select: { listings: { where: { status: ApprovalStatus.APPROVED } } },
         },
@@ -148,7 +149,7 @@ export const mobileGamesRouter = createMobileTRPCRouter({
         isErotic: true,
         status: true,
         createdAt: true,
-        system: { select: { id: true, name: true, key: true } },
+        system: { select: systemBasicSelect },
         _count: {
           select: {
             listings: { where: { status: ApprovalStatus.APPROVED } },
@@ -177,7 +178,7 @@ export const mobileGamesRouter = createMobileTRPCRouter({
         isErotic: true,
         status: true,
         createdAt: true,
-        system: { select: { id: true, name: true, key: true } },
+        system: { select: systemBasicSelect },
         _count: {
           select: {
             listings: { where: { status: ApprovalStatus.APPROVED } },

--- a/src/server/api/routers/mobile/general.ts
+++ b/src/server/api/routers/mobile/general.ts
@@ -1,6 +1,11 @@
 import { SearchSuggestionsSchema } from '@/schemas/mobile'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
-import { userSelect, emulatorBasicSelect, performanceBasicSelect } from '@/server/utils/selects'
+import {
+  emulatorBasicSelect,
+  performanceBasicSelect,
+  systemBasicSelect,
+  brandBasicSelect,
+} from '@/server/utils/selects'
 import { ApprovalStatus } from '@orm'
 
 export const mobileGeneralRouter = createMobileTRPCRouter({
@@ -71,7 +76,7 @@ export const mobileGeneralRouter = createMobileTRPCRouter({
               mode: 'insensitive',
             },
           },
-          select: { id: true, title: true, system: { select: userSelect(['name']) } },
+          select: { id: true, title: true, system: { select: systemBasicSelect } },
           take: perCategory,
         }),
         ctx.prisma.device.findMany({
@@ -96,7 +101,7 @@ export const mobileGeneralRouter = createMobileTRPCRouter({
           select: {
             id: true,
             modelName: true,
-            brand: { select: userSelect(['name']) },
+            brand: { select: brandBasicSelect },
           },
           take: perCategory,
         }),

--- a/src/server/api/routers/mobile/general.ts
+++ b/src/server/api/routers/mobile/general.ts
@@ -1,5 +1,6 @@
 import { SearchSuggestionsSchema } from '@/schemas/mobile'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
+import { userSelect, emulatorBasicSelect, performanceBasicSelect } from '@/server/utils/selects'
 import { ApprovalStatus } from '@orm'
 
 export const mobileGeneralRouter = createMobileTRPCRouter({
@@ -45,7 +46,7 @@ export const mobileGeneralRouter = createMobileTRPCRouter({
    */
   performanceScales: mobilePublicProcedure.query(async ({ ctx }) => {
     return await ctx.prisma.performanceScale.findMany({
-      select: { id: true, label: true, rank: true },
+      select: performanceBasicSelect,
       orderBy: { rank: 'asc' },
     })
   }),
@@ -70,7 +71,7 @@ export const mobileGeneralRouter = createMobileTRPCRouter({
               mode: 'insensitive',
             },
           },
-          select: { id: true, title: true, system: { select: { name: true } } },
+          select: { id: true, title: true, system: { select: userSelect(['name']) } },
           take: perCategory,
         }),
         ctx.prisma.device.findMany({
@@ -95,7 +96,7 @@ export const mobileGeneralRouter = createMobileTRPCRouter({
           select: {
             id: true,
             modelName: true,
-            brand: { select: { name: true } },
+            brand: { select: userSelect(['name']) },
           },
           take: perCategory,
         }),
@@ -106,7 +107,7 @@ export const mobileGeneralRouter = createMobileTRPCRouter({
               mode: 'insensitive',
             },
           },
-          select: { id: true, name: true },
+          select: emulatorBasicSelect,
           take: perCategory,
         }),
       ])

--- a/src/server/api/routers/mobile/gpus.ts
+++ b/src/server/api/routers/mobile/gpus.ts
@@ -1,6 +1,7 @@
 import { ResourceError } from '@/lib/errors'
 import { GetGpusSchema, GetGpuByIdSchema } from '@/schemas/gpu'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
+import { brandBasicSelect } from '@/server/utils/selects'
 import type { Prisma } from '@orm'
 
 export const mobileGpusRouter = createMobileTRPCRouter({
@@ -76,7 +77,7 @@ export const mobileGpusRouter = createMobileTRPCRouter({
     const [gpus, total] = await Promise.all([
       ctx.prisma.gpu.findMany({
         where,
-        include: { brand: { select: { id: true, name: true } } },
+        include: { brand: { select: brandBasicSelect } },
         orderBy,
         skip: actualOffset,
         take: limit,
@@ -103,7 +104,7 @@ export const mobileGpusRouter = createMobileTRPCRouter({
   getById: mobilePublicProcedure.input(GetGpuByIdSchema).query(async ({ ctx, input }) => {
     const gpu = await ctx.prisma.gpu.findUnique({
       where: { id: input.id },
-      include: { brand: { select: { id: true, name: true } } },
+      include: { brand: { select: brandBasicSelect } },
     })
 
     return gpu || ResourceError.gpu.notFound()

--- a/src/server/api/routers/mobile/listingReports.ts
+++ b/src/server/api/routers/mobile/listingReports.ts
@@ -5,6 +5,7 @@ import {
   mobileProtectedProcedure,
   mobilePublicProcedure,
 } from '@/server/api/mobileContext'
+import { userIdNameSelect, gameTitleSelect } from '@/server/utils/selects'
 import { ReportStatus } from '@orm'
 
 export const mobileListingReportsRouter = createMobileTRPCRouter({
@@ -44,8 +45,8 @@ export const mobileListingReportsRouter = createMobileTRPCRouter({
         include: {
           listing: {
             include: {
-              game: { select: { title: true } },
-              author: { select: { name: true } },
+              game: { select: gameTitleSelect },
+              author: { select: userIdNameSelect },
             },
           },
         },

--- a/src/server/api/routers/mobile/listings.ts
+++ b/src/server/api/routers/mobile/listings.ts
@@ -30,6 +30,13 @@ import {
   serializeGameNativeConfig,
 } from '@/server/utils/emulator-config/gamenative-converter'
 import { buildSearchFilter, buildNsfwFilter, buildArrayFilter } from '@/server/utils/query-builders'
+import {
+  userIdNameSelect,
+  systemBasicSelect,
+  emulatorBasicSelect,
+  performanceBasicSelect,
+  brandBasicSelect,
+} from '@/server/utils/selects'
 import { ApprovalStatus, type PrismaClient } from '@orm'
 
 // Helper function to calculate listing stats
@@ -111,13 +118,13 @@ async function getListingsHelper(
       include: {
         game: {
           include: {
-            system: { select: { id: true, name: true, key: true } },
+            system: { select: systemBasicSelect },
           },
         },
         device: { include: { brand: true, soc: true } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { votes: true, comments: true } },
       },
     }),
@@ -174,12 +181,12 @@ export const mobileListingsRouter = createMobileTRPCRouter({
       take: 10,
       include: {
         game: {
-          include: { system: { select: { id: true, name: true, key: true } } },
+          include: { system: { select: systemBasicSelect } },
         },
         device: { include: { brand: true, soc: true } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { votes: true, comments: true } },
       },
     })
@@ -204,9 +211,9 @@ export const mobileListingsRouter = createMobileTRPCRouter({
       },
       include: {
         device: { include: { brand: true, soc: true } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { votes: true, comments: true } },
       },
       orderBy: { createdAt: 'desc' },
@@ -226,13 +233,13 @@ export const mobileListingsRouter = createMobileTRPCRouter({
       include: {
         game: {
           include: {
-            system: { select: { id: true, name: true, key: true } },
+            system: { select: systemBasicSelect },
           },
         },
         device: { include: { brand: true, soc: true } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { votes: true, comments: true } },
         customFieldValues: {
           include: {
@@ -264,14 +271,14 @@ export const mobileListingsRouter = createMobileTRPCRouter({
       include: {
         game: {
           include: {
-            system: { select: { id: true, name: true, key: true } },
+            system: { select: systemBasicSelect },
           },
         },
         device: {
-          include: { brand: { select: { id: true, name: true } } },
+          include: { brand: { select: brandBasicSelect } },
         },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
         _count: { select: { votes: true, comments: true } },
       },
       orderBy: { createdAt: 'desc' },
@@ -303,13 +310,13 @@ export const mobileListingsRouter = createMobileTRPCRouter({
       include: {
         game: {
           include: {
-            system: { select: { id: true, name: true, key: true } },
+            system: { select: systemBasicSelect },
           },
         },
-        device: { include: { brand: { select: { id: true, name: true } } } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        device: { include: { brand: { select: brandBasicSelect } } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { votes: true, comments: true } },
       },
     })
@@ -350,13 +357,13 @@ export const mobileListingsRouter = createMobileTRPCRouter({
       include: {
         game: {
           include: {
-            system: { select: { id: true, name: true, key: true } },
+            system: { select: systemBasicSelect },
           },
         },
-        device: { include: { brand: { select: { id: true, name: true } } } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        device: { include: { brand: { select: brandBasicSelect } } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { votes: true, comments: true } },
       },
     })
@@ -430,7 +437,7 @@ export const mobileListingsRouter = createMobileTRPCRouter({
   comments: mobilePublicProcedure.input(GetListingCommentsSchema).query(async ({ ctx, input }) => {
     return await ctx.prisma.comment.findMany({
       where: { listingId: input.listingId },
-      include: { user: { select: { id: true, name: true } } },
+      include: { user: { select: userIdNameSelect } },
       orderBy: { createdAt: 'desc' },
     })
   }),
@@ -447,7 +454,7 @@ export const mobileListingsRouter = createMobileTRPCRouter({
           listingId: input.listingId,
           userId: ctx.session.user.id,
         },
-        include: { user: { select: { id: true, name: true } } },
+        include: { user: { select: userIdNameSelect } },
       })
     }),
 
@@ -472,7 +479,7 @@ export const mobileListingsRouter = createMobileTRPCRouter({
       return await ctx.prisma.comment.update({
         where: { id: input.commentId },
         data: { content: input.content },
-        include: { user: { select: { id: true, name: true } } },
+        include: { user: { select: userIdNameSelect } },
       })
     }),
 
@@ -512,19 +519,12 @@ export const mobileListingsRouter = createMobileTRPCRouter({
               id: true,
               title: true,
               system: {
-                select: {
-                  id: true,
-                  name: true,
-                  key: true,
-                },
+                select: systemBasicSelect,
               },
             },
           },
           emulator: {
-            select: {
-              id: true,
-              name: true,
-            },
+            select: emulatorBasicSelect,
           },
           customFieldValues: {
             include: {

--- a/src/server/api/routers/mobile/pcListings.ts
+++ b/src/server/api/routers/mobile/pcListings.ts
@@ -13,6 +13,13 @@ import {
 } from '@/server/api/mobileContext'
 import { pcListingInclude, buildPcListingWhere } from '@/server/api/utils/pcListingHelpers'
 import { createPaginationResult } from '@/server/utils/pagination'
+import {
+  userIdNameSelect,
+  brandBasicSelect,
+  emulatorBasicSelect,
+  performanceBasicSelect,
+  systemBasicSelect,
+} from '@/server/utils/selects'
 import { isModerator } from '@/utils/permissions'
 import { ApprovalStatus } from '@orm'
 
@@ -147,14 +154,14 @@ export const mobilePcListingsRouter = createMobileTRPCRouter({
       include: {
         game: {
           include: {
-            system: { select: { id: true, name: true, key: true } },
+            system: { select: systemBasicSelect },
           },
         },
-        cpu: { include: { brand: { select: { id: true, name: true } } } },
-        gpu: { include: { brand: { select: { id: true, name: true } } } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        cpu: { include: { brand: { select: brandBasicSelect } } },
+        gpu: { include: { brand: { select: brandBasicSelect } } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { reports: true, developerVerifications: true } },
       },
     })
@@ -195,14 +202,14 @@ export const mobilePcListingsRouter = createMobileTRPCRouter({
       include: {
         game: {
           include: {
-            system: { select: { id: true, name: true, key: true } },
+            system: { select: systemBasicSelect },
           },
         },
-        cpu: { include: { brand: { select: { id: true, name: true } } } },
-        gpu: { include: { brand: { select: { id: true, name: true } } } },
-        emulator: { select: { id: true, name: true, logo: true } },
-        performance: { select: { id: true, label: true, rank: true } },
-        author: { select: { id: true, name: true } },
+        cpu: { include: { brand: { select: brandBasicSelect } } },
+        gpu: { include: { brand: { select: brandBasicSelect } } },
+        emulator: { select: emulatorBasicSelect },
+        performance: { select: performanceBasicSelect },
+        author: { select: userIdNameSelect },
         _count: { select: { reports: true, developerVerifications: true } },
       },
     })
@@ -233,7 +240,7 @@ export const mobilePcListingsRouter = createMobileTRPCRouter({
       take: limit,
       orderBy: { modelName: 'asc' },
       include: {
-        brand: { select: { id: true, name: true } },
+        brand: { select: brandBasicSelect },
       },
     })
 
@@ -265,7 +272,7 @@ export const mobilePcListingsRouter = createMobileTRPCRouter({
       take: limit,
       orderBy: { modelName: 'asc' },
       include: {
-        brand: { select: { id: true, name: true } },
+        brand: { select: brandBasicSelect },
       },
     })
 

--- a/src/server/api/routers/mobile/preferences.ts
+++ b/src/server/api/routers/mobile/preferences.ts
@@ -13,6 +13,7 @@ import {
   DeletePcPresetSchema,
 } from '@/schemas/mobile'
 import { createMobileTRPCRouter, mobileProtectedProcedure } from '@/server/api/mobileContext'
+import { brandBasicSelect } from '@/server/utils/selects'
 import { sanitizeBio } from '@/utils/sanitization'
 
 export const mobilePreferencesRouter = createMobileTRPCRouter({
@@ -27,7 +28,7 @@ export const mobilePreferencesRouter = createMobileTRPCRouter({
           include: {
             device: {
               include: {
-                brand: { select: { id: true, name: true } },
+                brand: { select: brandBasicSelect },
                 soc: { select: { id: true, name: true, manufacturer: true } },
               },
             },
@@ -317,8 +318,8 @@ export const mobilePreferencesRouter = createMobileTRPCRouter({
         take: input.limit,
         orderBy: { createdAt: 'desc' },
         include: {
-          cpu: { include: { brand: { select: { id: true, name: true } } } },
-          gpu: { include: { brand: { select: { id: true, name: true } } } },
+          cpu: { include: { brand: { select: brandBasicSelect } } },
+          gpu: { include: { brand: { select: brandBasicSelect } } },
         },
       })
     }),
@@ -332,8 +333,8 @@ export const mobilePreferencesRouter = createMobileTRPCRouter({
             userId: ctx.session.user.id,
           },
           include: {
-            cpu: { include: { brand: { select: { id: true, name: true } } } },
-            gpu: { include: { brand: { select: { id: true, name: true } } } },
+            cpu: { include: { brand: { select: brandBasicSelect } } },
+            gpu: { include: { brand: { select: brandBasicSelect } } },
           },
         })
       }),
@@ -359,8 +360,8 @@ export const mobilePreferencesRouter = createMobileTRPCRouter({
           where: { id },
           data: updateData,
           include: {
-            cpu: { include: { brand: { select: { id: true, name: true } } } },
-            gpu: { include: { brand: { select: { id: true, name: true } } } },
+            cpu: { include: { brand: { select: brandBasicSelect } } },
+            gpu: { include: { brand: { select: brandBasicSelect } } },
           },
         })
       }),

--- a/src/server/api/routers/mobile/users.ts
+++ b/src/server/api/routers/mobile/users.ts
@@ -1,6 +1,13 @@
 import { AppError, ResourceError } from '@/lib/errors'
 import { GetUserByIdSchema } from '@/schemas/user'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
+import {
+  userSelect,
+  brandBasicSelect,
+  emulatorBasicSelect,
+  performanceBasicSelect,
+  gameTitleSelect,
+} from '@/server/utils/selects'
 import { roleIncludesRole } from '@/utils/permission-system'
 import { ApprovalStatus, Role, Prisma } from '@orm'
 
@@ -33,7 +40,7 @@ export const mobileUsersRouter = createMobileTRPCRouter({
             isActive: true,
             OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
           },
-          select: { id: true },
+          select: userSelect(['id']),
         },
       },
     })
@@ -123,12 +130,12 @@ export const mobileUsersRouter = createMobileTRPCRouter({
                 select: {
                   id: true,
                   modelName: true,
-                  brand: { select: { id: true, name: true } },
+                  brand: { select: brandBasicSelect },
                 },
               },
-              game: { select: { id: true, title: true } },
-              emulator: { select: { id: true, name: true } },
-              performance: { select: { id: true, label: true, rank: true } },
+              game: { select: gameTitleSelect },
+              emulator: { select: emulatorBasicSelect },
+              performance: { select: performanceBasicSelect },
               _count: { select: { votes: true, comments: true } },
             },
             orderBy: { createdAt: 'desc' },
@@ -147,14 +154,12 @@ export const mobileUsersRouter = createMobileTRPCRouter({
                     select: {
                       id: true,
                       modelName: true,
-                      brand: { select: { id: true, name: true } },
+                      brand: { select: brandBasicSelect },
                     },
                   },
-                  game: { select: { id: true, title: true } },
-                  emulator: { select: { id: true, name: true } },
-                  performance: {
-                    select: { id: true, label: true, rank: true },
-                  },
+                  game: { select: gameTitleSelect },
+                  emulator: { select: emulatorBasicSelect },
+                  performance: { select: performanceBasicSelect },
                 },
               },
             },

--- a/src/server/api/routers/notifications.ts
+++ b/src/server/api/routers/notifications.ts
@@ -10,6 +10,7 @@ import {
 } from '@/schemas/notification'
 import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc'
 import { notificationService } from '@/server/notifications/service'
+import { userSelect } from '@/server/utils/selects'
 import { hasPermission } from '@/utils/permissions'
 import { DeliveryChannel, NotificationCategory, Role } from '@orm'
 
@@ -94,7 +95,7 @@ export const notificationsRouter = createTRPCRouter({
 
       // Get all users
       const users = await ctx.prisma.user.findMany({
-        select: { id: true },
+        select: userSelect(['id']),
       })
 
       // Create notification for each user

--- a/src/server/api/routers/pcListings.ts
+++ b/src/server/api/routers/pcListings.ts
@@ -60,9 +60,11 @@ import { buildNsfwFilter } from '@/server/utils/query-builders'
 import { createCountQuery } from '@/server/utils/query-performance'
 import {
   userSelect,
+  userNameSelect,
   userIdNameSelect,
   gameTitleSelect,
   emulatorBasicSelect,
+  systemIdSelect,
 } from '@/server/utils/selects'
 import { PERMISSIONS } from '@/utils/permission-system'
 import { canDeleteComment, canEditComment, hasPermission, isModerator } from '@/utils/permissions'
@@ -345,7 +347,7 @@ export const pcListingsRouter = createTRPCRouter({
       input.gpuId ? ctx.prisma.gpu.findUnique({ where: { id: input.gpuId } }) : null,
       ctx.prisma.emulator.findUnique({
         where: { id: input.emulatorId },
-        include: { systems: { select: userSelect(['id']) } },
+        include: { systems: { select: systemIdSelect } },
       }),
       ctx.prisma.performanceScale.findUnique({
         where: { id: input.performanceId },
@@ -1420,7 +1422,7 @@ export const pcListingsRouter = createTRPCRouter({
           pcListing: {
             include: {
               game: { select: gameTitleSelect },
-              author: { select: userSelect(['name']) },
+              author: { select: userNameSelect },
             },
           },
         },
@@ -1511,11 +1513,11 @@ export const pcListingsRouter = createTRPCRouter({
           pcListing: {
             include: {
               game: { select: gameTitleSelect },
-              author: { select: userSelect(['name']) },
+              author: { select: userNameSelect },
             },
           },
-          reportedBy: { select: userSelect(['name']) },
-          reviewedBy: { select: userSelect(['name']) },
+          reportedBy: { select: userNameSelect },
+          reviewedBy: { select: userNameSelect },
         },
       })
     }),

--- a/src/server/api/routers/permissionLogs.ts
+++ b/src/server/api/routers/permissionLogs.ts
@@ -8,6 +8,7 @@ import {
 } from '@/schemas/permission'
 import { createTRPCRouter, permissionProcedure } from '@/server/api/trpc'
 import { calculateOffset, createPaginationResult } from '@/server/utils/pagination'
+import { userSelect } from '@/server/utils/selects'
 import { PERMISSIONS } from '@/utils/permission-system'
 import { ms } from '@/utils/time'
 
@@ -59,7 +60,7 @@ export const permissionLogsRouter = createTRPCRouter({
           skip: offset,
           take: limit,
           include: {
-            user: { select: { id: true, name: true, email: true, role: true } },
+            user: { select: userSelect(['id', 'name', 'email', 'role']) },
             permission: {
               select: { id: true, key: true, label: true, category: true },
             },
@@ -129,7 +130,7 @@ export const permissionLogsRouter = createTRPCRouter({
         take: 10,
         orderBy: { createdAt: 'desc' },
         include: {
-          user: { select: { id: true, name: true, email: true } },
+          user: { select: userSelect(['id', 'name', 'email']) },
           permission: { select: { key: true, label: true } },
         },
       }),
@@ -166,7 +167,7 @@ export const permissionLogsRouter = createTRPCRouter({
       const log = await ctx.prisma.permissionActionLog.findUnique({
         where: { id: input.id },
         include: {
-          user: { select: { id: true, name: true, email: true, role: true } },
+          user: { select: userSelect(['id', 'name', 'email', 'role']) },
           permission: {
             select: {
               id: true,
@@ -193,7 +194,7 @@ export const permissionLogsRouter = createTRPCRouter({
           where: { permissionId: input.permissionId },
           orderBy: { createdAt: 'desc' },
           take: input.limit,
-          include: { user: { select: { id: true, name: true, email: true } } },
+          include: { user: { select: userSelect(['id', 'name', 'email']) } },
         }),
     ),
 
@@ -241,7 +242,7 @@ export const permissionLogsRouter = createTRPCRouter({
         where,
         orderBy: { createdAt: 'desc' },
         include: {
-          user: { select: { id: true, name: true, email: true, role: true } },
+          user: { select: userSelect(['id', 'name', 'email', 'role']) },
           permission: {
             select: { id: true, key: true, label: true, category: true },
           },

--- a/src/server/api/routers/permissions.ts
+++ b/src/server/api/routers/permissions.ts
@@ -18,6 +18,7 @@ import {
   managePermissionsProcedure,
 } from '@/server/api/trpc'
 import { calculateOffset, createPaginationResult } from '@/server/utils/pagination'
+import { userSelect } from '@/server/utils/selects'
 import { PermissionActionType, Role } from '@orm'
 
 export const permissionsRouter = createTRPCRouter({
@@ -64,7 +65,7 @@ export const permissionsRouter = createTRPCRouter({
         skip: offset,
         take: limit,
         include: {
-          rolePermissions: { select: { role: true } },
+          rolePermissions: { select: userSelect(['role']) },
           _count: { select: { rolePermissions: true } },
         },
       }),
@@ -94,7 +95,7 @@ export const permissionsRouter = createTRPCRouter({
             select: {
               role: true,
               assignedAt: true,
-              assignedByUser: { select: { id: true, name: true, email: true } },
+              assignedByUser: { select: userSelect(['id', 'name', 'email']) },
             },
           },
         },
@@ -237,7 +238,7 @@ export const permissionsRouter = createTRPCRouter({
               isSystem: true,
             },
           },
-          assignedByUser: { select: { id: true, name: true, email: true } },
+          assignedByUser: { select: userSelect(['id', 'name', 'email']) },
         },
         orderBy: [
           { role: 'asc' },
@@ -416,7 +417,7 @@ export const permissionsRouter = createTRPCRouter({
       const permissions = await ctx.prisma.permission.findMany({
         where,
         orderBy: [{ category: 'asc' }, { label: 'asc' }],
-        include: { rolePermissions: { select: { role: true } } },
+        include: { rolePermissions: { select: userSelect(['role']) } },
       })
 
       // Get all roles

--- a/src/server/api/routers/userBans.ts
+++ b/src/server/api/routers/userBans.ts
@@ -15,7 +15,7 @@ import {
   viewUserBansProcedure,
   protectedProcedure,
 } from '@/server/api/trpc'
-import { userSelect, userIdNameSelect } from '@/server/utils/selects'
+import { userSelect, userNameSelect, userIdNameSelect } from '@/server/utils/selects'
 import { PERMISSIONS } from '@/utils/permission-system'
 import { hasPermission } from '@/utils/permissions'
 import { Role, type Prisma } from '@orm'
@@ -237,7 +237,7 @@ export const userBansRouter = createTRPCRouter({
           isActive: true,
           OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
         },
-        include: { bannedBy: { select: userSelect(['name']) } },
+        include: { bannedBy: { select: userNameSelect } },
       })
 
       return {

--- a/src/server/api/routers/userBans.ts
+++ b/src/server/api/routers/userBans.ts
@@ -15,6 +15,7 @@ import {
   viewUserBansProcedure,
   protectedProcedure,
 } from '@/server/api/trpc'
+import { userSelect, userIdNameSelect } from '@/server/utils/selects'
 import { PERMISSIONS } from '@/utils/permission-system'
 import { hasPermission } from '@/utils/permissions'
 import { Role, type Prisma } from '@orm'
@@ -88,8 +89,8 @@ export const userBansRouter = createTRPCRouter({
               createdAt: true,
             },
           },
-          bannedBy: { select: { id: true, name: true } },
-          unbannedBy: { select: { id: true, name: true } },
+          bannedBy: { select: userIdNameSelect },
+          unbannedBy: { select: userIdNameSelect },
         },
       }),
       ctx.prisma.userBan.count({ where }),
@@ -116,8 +117,8 @@ export const userBansRouter = createTRPCRouter({
             createdAt: true,
           },
         },
-        bannedBy: { select: { id: true, name: true } },
-        unbannedBy: { select: { id: true, name: true } },
+        bannedBy: { select: userIdNameSelect },
+        unbannedBy: { select: userIdNameSelect },
       },
     })
 
@@ -169,8 +170,8 @@ export const userBansRouter = createTRPCRouter({
     return await ctx.prisma.userBan.create({
       data: { userId, bannedById, reason, notes, expiresAt },
       include: {
-        user: { select: { id: true, name: true, email: true } },
-        bannedBy: { select: { id: true, name: true } },
+        user: { select: userSelect(['id', 'name', 'email']) },
+        bannedBy: { select: userIdNameSelect },
       },
     })
   }),
@@ -190,9 +191,9 @@ export const userBansRouter = createTRPCRouter({
       where: { id },
       data,
       include: {
-        user: { select: { id: true, name: true, email: true } },
-        bannedBy: { select: { id: true, name: true } },
-        unbannedBy: { select: { id: true, name: true } },
+        user: { select: userSelect(['id', 'name', 'email']) },
+        bannedBy: { select: userIdNameSelect },
+        unbannedBy: { select: userIdNameSelect },
       },
     })
   }),
@@ -220,9 +221,9 @@ export const userBansRouter = createTRPCRouter({
         notes: notes ? `${ban.notes || ''}\n\nUnban notes: ${notes}` : ban.notes,
       },
       include: {
-        user: { select: { id: true, name: true, email: true } },
-        bannedBy: { select: { id: true, name: true } },
-        unbannedBy: { select: { id: true, name: true } },
+        user: { select: userSelect(['id', 'name', 'email']) },
+        bannedBy: { select: userIdNameSelect },
+        unbannedBy: { select: userIdNameSelect },
       },
     })
   }),
@@ -236,7 +237,7 @@ export const userBansRouter = createTRPCRouter({
           isActive: true,
           OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
         },
-        include: { bannedBy: { select: { name: true } } },
+        include: { bannedBy: { select: userSelect(['name']) } },
       })
 
       return {

--- a/src/server/api/routers/userPreferences.ts
+++ b/src/server/api/routers/userPreferences.ts
@@ -7,6 +7,7 @@ import {
   BulkUpdateSocPreferencesSchema,
 } from '@/schemas/userPreferences'
 import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc'
+import { brandBasicSelect } from '@/server/utils/selects'
 import { sanitizeBio } from '@/utils/sanitization'
 
 export const userPreferencesRouter = createTRPCRouter({
@@ -28,7 +29,7 @@ export const userPreferencesRouter = createTRPCRouter({
               select: {
                 id: true,
                 modelName: true,
-                brand: { select: { id: true, name: true } },
+                brand: { select: brandBasicSelect },
                 soc: { select: { id: true, name: true, manufacturer: true } },
               },
             },

--- a/src/server/api/routers/users.ts
+++ b/src/server/api/routers/users.ts
@@ -23,6 +23,7 @@ import { createCountQuery } from '@/server/utils/query-performance'
 import { updateUserRole } from '@/server/utils/roleSync'
 import {
   userSelect,
+  userNameSelect,
   systemBasicSelect,
   gameTitleSelect,
   brandBasicSelect,
@@ -105,7 +106,7 @@ export const usersRouter = createTRPCRouter({
                   },
                 },
                 game: { select: gameTitleSelect },
-                emulator: { select: userSelect(['name']) },
+                emulator: { select: emulatorBasicSelect },
                 performance: { select: { label: true } },
               },
             },
@@ -257,7 +258,7 @@ export const usersRouter = createTRPCRouter({
               id: true,
               reason: true,
               expiresAt: true,
-              bannedBy: { select: userSelect(['name']) },
+              bannedBy: { select: userNameSelect },
               createdAt: true,
             },
           },
@@ -305,7 +306,7 @@ export const usersRouter = createTRPCRouter({
               system: { select: systemBasicSelect },
             },
           },
-          emulator: { select: userSelect(['name']) },
+          emulator: { select: emulatorBasicSelect },
           performance: { select: performanceBasicSelect },
         },
         orderBy: { createdAt: 'desc' },
@@ -340,7 +341,7 @@ export const usersRouter = createTRPCRouter({
                   system: { select: systemBasicSelect },
                 },
               },
-              emulator: { select: userSelect(['name']) },
+              emulator: { select: emulatorBasicSelect },
               performance: { select: performanceBasicSelect },
             },
           },
@@ -356,12 +357,12 @@ export const usersRouter = createTRPCRouter({
     const [availableSystems, availableEmulators] = await Promise.all([
       ctx.prisma.listing.findMany({
         where: { authorId: userId },
-        select: { device: { select: { brand: { select: userSelect(['name']) } } } },
+        select: { device: { select: { brand: { select: brandBasicSelect } } } },
         distinct: ['deviceId'],
       }),
       ctx.prisma.listing.findMany({
         where: { authorId: userId },
-        select: { emulator: { select: userSelect(['name']) } },
+        select: { emulator: { select: emulatorBasicSelect } },
         distinct: ['emulatorId'],
       }),
     ])

--- a/src/server/api/routers/verifiedDevelopers.ts
+++ b/src/server/api/routers/verifiedDevelopers.ts
@@ -131,7 +131,7 @@ export const verifiedDevelopersRouter = createTRPCRouter({
         where: { id: input.id },
         include: {
           user: { select: userSelect(['name', 'email']) },
-          emulator: { select: userSelect(['name']) },
+          emulator: { select: emulatorBasicSelect },
         },
       })
 

--- a/src/server/api/routers/verifiedDevelopers.ts
+++ b/src/server/api/routers/verifiedDevelopers.ts
@@ -11,6 +11,7 @@ import {
   manageEmulatorVerifiedDevelopersProcedure,
   protectedProcedure,
 } from '@/server/api/trpc'
+import { userSelect, userIdNameSelect, emulatorBasicSelect } from '@/server/utils/selects'
 import { hasPermission } from '@/utils/permissions'
 import { Role, Prisma } from '@orm'
 
@@ -52,16 +53,10 @@ export const verifiedDevelopersRouter = createTRPCRouter({
           where,
           include: {
             user: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-                profileImage: true,
-                role: true,
-              },
+              select: userSelect(['id', 'name', 'email', 'profileImage', 'role']),
             },
-            emulator: { select: { id: true, name: true, logo: true } },
-            verifier: { select: { id: true, name: true, email: true } },
+            emulator: { select: emulatorBasicSelect },
+            verifier: { select: userSelect(['id', 'name', 'email']) },
           },
           orderBy: { verifiedAt: 'desc' },
           skip,
@@ -89,7 +84,7 @@ export const verifiedDevelopersRouter = createTRPCRouter({
 
       const user = await ctx.prisma.user.findUnique({
         where: { id: userId },
-        select: { id: true, name: true, email: true, role: true },
+        select: userSelect(['id', 'name', 'email', 'role']),
       })
 
       if (!user) return ResourceError.user.notFound()
@@ -103,7 +98,7 @@ export const verifiedDevelopersRouter = createTRPCRouter({
 
       const emulator = await ctx.prisma.emulator.findUnique({
         where: { id: emulatorId },
-        select: { id: true, name: true },
+        select: userIdNameSelect,
       })
 
       if (!emulator) return ResourceError.emulator.notFound()
@@ -122,15 +117,9 @@ export const verifiedDevelopersRouter = createTRPCRouter({
         data: { userId, emulatorId, verifiedBy: verifierId, notes },
         include: {
           user: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              profileImage: true,
-              role: true,
-            },
+            select: userSelect(['id', 'name', 'email', 'profileImage', 'role']),
           },
-          emulator: { select: { id: true, name: true, logo: true } },
+          emulator: { select: emulatorBasicSelect },
         },
       })
     }),
@@ -141,8 +130,8 @@ export const verifiedDevelopersRouter = createTRPCRouter({
       const verifiedDeveloper = await ctx.prisma.verifiedDeveloper.findUnique({
         where: { id: input.id },
         include: {
-          user: { select: { name: true, email: true } },
-          emulator: { select: { name: true } },
+          user: { select: userSelect(['name', 'email']) },
+          emulator: { select: userSelect(['name']) },
         },
       })
 
@@ -173,7 +162,7 @@ export const verifiedDevelopersRouter = createTRPCRouter({
   getMyVerifiedEmulators: protectedProcedure.query(async ({ ctx }) => {
     const verifiedDevelopers = await ctx.prisma.verifiedDeveloper.findMany({
       where: { userId: ctx.session.user.id },
-      include: { emulator: { select: { id: true, name: true, logo: true } } },
+      include: { emulator: { select: emulatorBasicSelect } },
       orderBy: { verifiedAt: 'desc' },
     })
 
@@ -188,7 +177,7 @@ export const verifiedDevelopersRouter = createTRPCRouter({
       const verifiedDeveloper = await ctx.prisma.verifiedDeveloper.findUnique({
         where: { id },
         include: {
-          user: { select: { id: true, name: true, email: true, role: true } },
+          user: { select: userSelect(['id', 'name', 'email', 'role']) },
         },
       })
 
@@ -203,7 +192,7 @@ export const verifiedDevelopersRouter = createTRPCRouter({
 
       const emulator = await ctx.prisma.emulator.findUnique({
         where: { id: emulatorId },
-        select: { id: true, name: true },
+        select: userIdNameSelect,
       })
 
       if (!emulator) return ResourceError.emulator.notFound()
@@ -228,16 +217,10 @@ export const verifiedDevelopersRouter = createTRPCRouter({
         data: { emulatorId, notes },
         include: {
           user: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              profileImage: true,
-              role: true,
-            },
+            select: userSelect(['id', 'name', 'email', 'profileImage', 'role']),
           },
-          emulator: { select: { id: true, name: true, logo: true } },
-          verifier: { select: { id: true, name: true, email: true } },
+          emulator: { select: emulatorBasicSelect },
+          verifier: { select: userSelect(['id', 'name', 'email']) },
         },
       })
 

--- a/src/server/utils/selects.ts
+++ b/src/server/utils/selects.ts
@@ -1,0 +1,38 @@
+import type { Prisma } from '@orm'
+
+// Factory for building typed select objects from field names
+const buildSelect =
+  <T extends object>() =>
+  (fields: readonly (keyof T)[]) =>
+    fields.reduce(
+      (select, field) => {
+        ;(select as Record<string, true>)[field as string] = true
+        return select
+      },
+      {} as Record<keyof T, true>,
+    )
+
+// Model-specific pickers
+export const userSelect = buildSelect<Prisma.UserSelect>()
+export const gameSelect = buildSelect<Prisma.GameSelect>()
+export const systemSelect = buildSelect<Prisma.SystemSelect>()
+export const emulatorSelect = buildSelect<Prisma.EmulatorSelect>()
+export const performanceSelect = buildSelect<Prisma.PerformanceSelect>()
+export const brandSelect = buildSelect<Prisma.DeviceBrandSelect>()
+
+// Commonly reused selections
+export const userIdNameSelect = userSelect(['id', 'name'])
+export const gameTitleSelect = gameSelect(['id', 'title'])
+export const systemBasicSelect = systemSelect(['id', 'name', 'key'])
+export const emulatorBasicSelect = emulatorSelect(['id', 'name', 'logo'])
+export const performanceBasicSelect = performanceSelect(['id', 'label', 'rank'])
+export const brandBasicSelect = brandSelect(['id', 'name'])
+
+export const listingSummarySelect: Prisma.ListingSelect = {
+  id: true,
+  title: true,
+  system: { select: systemBasicSelect },
+  emulator: { select: emulatorBasicSelect },
+  performance: { select: performanceBasicSelect },
+  _count: { select: { votes: true, comments: true } },
+}

--- a/src/server/utils/selects.ts
+++ b/src/server/utils/selects.ts
@@ -22,8 +22,10 @@ export const brandSelect = buildSelect<Prisma.DeviceBrandSelect>()
 
 // Commonly reused selections
 export const userIdNameSelect = userSelect(['id', 'name'])
+export const userNameSelect = userSelect(['name'])
 export const gameTitleSelect = gameSelect(['id', 'title'])
 export const systemBasicSelect = systemSelect(['id', 'name', 'key'])
+export const systemIdSelect = systemSelect(['id'])
 export const emulatorBasicSelect = emulatorSelect(['id', 'name', 'logo'])
 export const performanceBasicSelect = performanceSelect(['id', 'label', 'rank'])
 export const brandBasicSelect = brandSelect(['id', 'name'])


### PR DESCRIPTION
## Summary
- add shared select builders and common field sets for users, systems, games, emulators, performances, and brands
- refactor routers to reuse these selections for nested includes and selects

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966bdb3ba88324ab36a58125f0c4c1