### PR TITLE
fix: disable service worker caching for API

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -105,6 +105,12 @@ self.addEventListener(
     // Never cache navigations (dynamic HTML).
     if (event.request.mode === 'navigate') return
 
+    // Always bypass cache for API requests to ensure fresh data
+    if (url.pathname.startsWith('/api')) {
+      event.respondWith(fetch(event.request))
+      return
+    }
+
     event.respondWith(
       caches.match(event.request).then((cached) => {
         if (cached) return cached

--- a/public/sw-register.js
+++ b/public/sw-register.js
@@ -11,9 +11,23 @@ if ('serviceWorker' in navigator) {
   if (isDevelopment) {
     console.log('Service Worker disabled in development mode')
   } else {
-    window.addEventListener('load', function () {
+    window.addEventListener('load', async function () {
+      const swUrl = '/service-worker.js'
+
+      // Unregister any previous service workers that might be controlling the page
+      if (navigator.serviceWorker.getRegistrations) {
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        const currentSwUrl = new URL(swUrl, window.location.href).href
+
+        for (const registration of registrations) {
+          if (registration.active && registration.active.scriptURL !== currentSwUrl) {
+            await registration.unregister()
+          }
+        }
+      }
+
       navigator.serviceWorker
-        .register('/service-worker.js')
+        .register(swUrl, { updateViaCache: 'none' })
         .then(function (registration) {
           console.log('Service Worker registered with scope:', registration.scope)
         })


### PR DESCRIPTION
## Summary
- bypass service worker cache for `/api` requests to avoid stale data
- unregister outdated service workers before registering a new one to ensure updates are applied

## Testing
- `npm test`
- `npm run lint`
- `npm run types`


------
https://chatgpt.com/codex/tasks/task_e_68a6f74b199c83249879dc21405f48c3