### PR TITLE
Chore: Add scripts to import Switch Games and Listing from RyanRetro list

### DIFF
--- a/prisma/seeders/csvGamesSeeder.ts
+++ b/prisma/seeders/csvGamesSeeder.ts
@@ -1,0 +1,265 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { ApprovalStatus, Role, type PrismaClient } from '@orm'
+
+type GameData = {
+  title: string
+  systemName: string
+}
+
+async function csvGamesSeeder(prisma: PrismaClient) {
+  console.info('🌱 Seeding games from CSV...')
+
+  // Read the CSV file
+  const csvPath = path.join(__dirname, 'data', 'rp5_flip2_odin2_switch_games.csv')
+
+  if (!fs.existsSync(csvPath)) {
+    console.error(`❌ CSV file not found at: ${csvPath}`)
+    return
+  }
+
+  const csvContent = fs.readFileSync(csvPath, 'utf-8')
+  const lines = csvContent.split('\n').filter((line) => line.trim())
+
+  if (lines.length < 2) {
+    console.error('❌ CSV file must contain at least a header row and one data row.')
+    return
+  }
+
+  // Helper function to properly parse CSV line with quoted fields
+  const parseCsvLine = (line: string): string[] => {
+    const result: string[] = []
+    let current = ''
+    let inQuotes = false
+    let i = 0
+
+    while (i < line.length) {
+      const char = line[i]
+
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          // Handle escaped quotes ("")
+          current += '"'
+          i += 2
+        } else {
+          // Toggle quote state
+          inQuotes = !inQuotes
+          i++
+        }
+      } else if (char === ',' && !inQuotes) {
+        // Field separator outside quotes
+        result.push(current.trim())
+        current = ''
+        i++
+      } else {
+        // Regular character
+        current += char
+        i++
+      }
+    }
+
+    // Add the last field
+    result.push(current.trim())
+    return result
+  }
+
+  // Parse CSV headers
+  const headers = parseCsvLine(lines[0]).map((h) => h.toLowerCase())
+  console.log('📋 CSV headers:', headers)
+
+  // Validate required headers
+  const requiredHeaders = ['title', 'systemname']
+  const missingHeaders = requiredHeaders.filter((h) => !headers.includes(h))
+  if (missingHeaders.length > 0) {
+    console.error(
+      `❌ Missing required headers: ${missingHeaders.join(', ')}. Required headers: title, systemName`,
+    )
+    return
+  }
+
+  // Parse CSV data and remove duplicates
+  const games: GameData[] = []
+  const seenGames = new Set<string>()
+  let csvDuplicatesCount = 0
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = parseCsvLine(lines[i])
+
+    if (values.length < headers.length) continue
+
+    const game: GameData = {
+      title: values[headers.indexOf('title')] || '',
+      systemName: values[headers.indexOf('systemname')] || '',
+    }
+
+    if (game.title && game.systemName) {
+      // Create a key to check for duplicates within the CSV
+      const gameKey = `${game.title.toLowerCase()}|||${game.systemName.toLowerCase()}`
+
+      if (seenGames.has(gameKey)) {
+        csvDuplicatesCount++
+        console.log(`🗑️ Skipping CSV duplicate: ${game.title} - ${game.systemName}`)
+        continue
+      }
+
+      seenGames.add(gameKey)
+      games.push(game)
+    }
+  }
+
+  console.log(
+    `📊 Parsed ${games.length} unique games (${csvDuplicatesCount} CSV duplicates removed)`,
+  )
+
+  if (games.length === 0) {
+    console.error('❌ No valid games found in CSV file.')
+    return
+  }
+
+  // Get all systems first
+  const systems = await prisma.system.findMany()
+  const systemMap = new Map(systems.map((system) => [system.name.toLowerCase(), system]))
+
+  console.log(`🎮 Found ${systems.length} systems in database`)
+
+  // Get the seeded users for submission tracking
+  const seededUsers = await prisma.user.findMany({
+    where: {
+      email: {
+        in: [
+          'superadmin@emuready.com',
+          'admin@emuready.com',
+          'author@emuready.com',
+          'user@emuready.com',
+        ],
+      },
+    },
+  })
+
+  if (seededUsers.length === 0) {
+    console.warn('⚠️ No seeded users found, games will not have submitters')
+  }
+
+  const adminUsers = seededUsers.filter(
+    (user) => user.role === Role.ADMIN || user.role === Role.SUPER_ADMIN,
+  )
+
+  if (adminUsers.length === 0) {
+    console.warn('⚠️ No admin users found, approved games will not have approvers')
+  }
+
+  // Helper function to get random element from array
+  const getRandomElement = <T>(array: T[]): T | undefined => {
+    return array.length > 0 ? array[Math.floor(Math.random() * array.length)] : undefined
+  }
+
+  // Helper function to get random date in the past (within last 90 days)
+  const getRandomPastDate = (maxDaysAgo = 90): Date => {
+    const daysAgo = Math.floor(Math.random() * maxDaysAgo)
+    return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000)
+  }
+
+  // Check for existing games in database
+  console.log('🔍 Checking for existing games in database...')
+  const existingGames = new Set<string>()
+
+  // Check in batches to avoid overwhelming the database
+  const batchSize = 50
+  for (let i = 0; i < games.length; i += batchSize) {
+    const batch = games.slice(i, i + batchSize)
+
+    for (const game of batch) {
+      const system = systemMap.get(game.systemName.toLowerCase())
+      if (!system) continue
+
+      const existing = await prisma.game.findFirst({
+        where: {
+          title: {
+            equals: game.title,
+            mode: 'insensitive',
+          },
+          systemId: system.id,
+        },
+      })
+
+      if (existing) {
+        const gameKey = `${game.title.toLowerCase()}|||${game.systemName.toLowerCase()}`
+        existingGames.add(gameKey)
+      }
+    }
+  }
+
+  console.log(`📋 Found ${existingGames.size} games that already exist in database`)
+
+  // Filter out existing games
+  const newGames = games.filter((game) => {
+    const gameKey = `${game.title.toLowerCase()}|||${game.systemName.toLowerCase()}`
+    return !existingGames.has(gameKey)
+  })
+
+  console.log(
+    `✨ Will import ${newGames.length} new games (${games.length - newGames.length} already exist)`,
+  )
+
+  if (newGames.length === 0) {
+    console.info('✅ All games from CSV already exist in database. No new games to import.')
+    return
+  }
+
+  // Process new games
+  let successCount = 0
+  let failCount = 0
+  let systemNotFoundCount = 0
+
+  console.info(`📝 Processing ${newGames.length} new games...`)
+
+  for (const game of newGames) {
+    const system = systemMap.get(game.systemName.toLowerCase())
+    if (!system) {
+      console.warn(`⚠️ System "${game.systemName}" not found, skipping game "${game.title}"`)
+      systemNotFoundCount++
+      continue
+    }
+
+    const submitter = getRandomElement(seededUsers)
+    const approver = getRandomElement(adminUsers)
+    const submittedAt = getRandomPastDate(30) // Recent submissions
+    const approvedAt = new Date(submittedAt.getTime() + Math.random() * 7 * 24 * 60 * 60 * 1000) // Approved within 7 days
+
+    try {
+      await prisma.game.create({
+        data: {
+          title: game.title,
+          systemId: system.id,
+          status: ApprovalStatus.APPROVED, // Auto-approve CSV imports
+          submittedBy: submitter?.id ?? null,
+          submittedAt: submittedAt,
+          approvedBy: approver?.id ?? null,
+          approvedAt: approvedAt,
+        },
+      })
+
+      successCount++
+
+      if (successCount % 100 === 0) {
+        console.log(`📈 Progress: ${successCount}/${newGames.length} games imported`)
+      }
+    } catch (error) {
+      console.error(`❌ Failed to create game "${game.title}" for ${game.systemName}:`, error)
+      failCount++
+    }
+  }
+
+  console.info('✅ CSV games seeding completed!')
+  console.info('📊 Summary:')
+  console.info(`   📥 ${games.length} total games in CSV`)
+  console.info(`   🗑️ ${csvDuplicatesCount} CSV duplicates removed`)
+  console.info(`   🔄 ${existingGames.size} games already existed in database`)
+  console.info(`   ✅ ${successCount} new games imported successfully`)
+  console.info(`   ❌ ${failCount} games failed to import`)
+  console.info(`   ⚠️ ${systemNotFoundCount} games skipped (system not found)`)
+  console.info(`   👥 Using ${seededUsers.length} seeded users as submitters`)
+  console.info(`   👨‍💼 Using ${adminUsers.length} admin users as approvers`)
+}
+
+export default csvGamesSeeder

--- a/prisma/seeders/csvListingsSeeder.ts
+++ b/prisma/seeders/csvListingsSeeder.ts
@@ -1,0 +1,298 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { ApprovalStatus, type PrismaClient } from '@orm'
+
+type ListingData = {
+  game: string
+  performance: string
+  drive: string
+  emulator: string
+  update: string
+  notes: string
+  device: string
+}
+
+async function csvListingsSeeder(prisma: PrismaClient) {
+  console.info('🌱 Seeding listings from CSV...')
+
+  // Read the CSV file
+  const csvPath = path.join(__dirname, 'data', 'rp5_flip2_odin2_switch_listing.csv')
+
+  if (!fs.existsSync(csvPath)) {
+    console.error(`❌ CSV file not found at: ${csvPath}`)
+    return
+  }
+
+  const csvContent = fs.readFileSync(csvPath, 'utf-8')
+  const lines = csvContent.split('\n').filter((line) => line.trim())
+
+  if (lines.length < 2) {
+    console.error('❌ CSV file must contain at least a header row and one data row.')
+    return
+  }
+
+  // Helper function to properly parse CSV line with quoted fields
+  const parseCsvLine = (line: string): string[] => {
+    const result: string[] = []
+    let current = ''
+    let inQuotes = false
+    let i = 0
+
+    while (i < line.length) {
+      const char = line[i]
+
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          // Handle escaped quotes ("")
+          current += '"'
+          i += 2
+        } else {
+          // Toggle quote state
+          inQuotes = !inQuotes
+          i++
+        }
+      } else if (char === ',' && !inQuotes) {
+        // Field separator outside quotes
+        result.push(current.trim())
+        current = ''
+        i++
+      } else {
+        // Regular character
+        current += char
+        i++
+      }
+    }
+
+    // Add the last field
+    result.push(current.trim())
+    return result
+  }
+
+  // Parse CSV headers
+  const headers = parseCsvLine(lines[0]).map((h) => h.toLowerCase())
+  console.log('📋 CSV headers:', headers)
+
+  // Validate required headers
+  const requiredHeaders = ['game', 'performance', 'drive', 'emulator', 'update', 'notes', 'device']
+  const missingHeaders = requiredHeaders.filter((h) => !headers.includes(h))
+  if (missingHeaders.length > 0) {
+    console.error(
+      `❌ Missing required headers: ${missingHeaders.join(', ')}. Required headers: ${requiredHeaders.join(', ')}`,
+    )
+    return
+  }
+
+  // Parse CSV data and remove duplicates
+  const listings: ListingData[] = []
+  const seenListings = new Set<string>()
+  let csvDuplicatesCount = 0
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = parseCsvLine(lines[i])
+
+    if (values.length < headers.length) continue
+
+    const listing: ListingData = {
+      game: values[headers.indexOf('game')] || '',
+      performance: values[headers.indexOf('performance')] || '',
+      drive: values[headers.indexOf('drive')] || '',
+      emulator: values[headers.indexOf('emulator')] || '',
+      update: values[headers.indexOf('update')] || '',
+      notes: values[headers.indexOf('notes')] || '',
+      device: values[headers.indexOf('device')] || '',
+    }
+
+    if (listing.game && listing.performance && listing.emulator && listing.device) {
+      // Create a key to check for duplicates within the CSV
+      const listingKey = `${listing.game.toLowerCase()}|||${listing.performance.toLowerCase()}|||${listing.emulator.toLowerCase()}|||${listing.device.toLowerCase()}`
+
+      if (seenListings.has(listingKey)) {
+        csvDuplicatesCount++
+        console.log(
+          `🗑️ Skipping CSV duplicate: ${listing.game} - ${listing.performance} - ${listing.emulator}`,
+        )
+        continue
+      }
+
+      seenListings.add(listingKey)
+      listings.push(listing)
+    }
+  }
+
+  console.log(
+    `📊 Parsed ${listings.length} unique listings (${csvDuplicatesCount} CSV duplicates removed)`,
+  )
+
+  if (listings.length === 0) {
+    console.error('❌ No valid listings found in CSV file.')
+    return
+  }
+
+  // Get all required data from database
+  const games = await prisma.game.findMany({
+    include: { system: true },
+  })
+  const gameMap = new Map(games.map((game) => [game.title.toLowerCase(), game]))
+
+  const emulators = await prisma.emulator.findMany()
+  const emulatorMap = new Map(emulators.map((emulator) => [emulator.name.toLowerCase(), emulator]))
+
+  const performanceScales = await prisma.performanceScale.findMany()
+  const performanceMap = new Map(performanceScales.map((perf) => [perf.label.toLowerCase(), perf]))
+
+  const devices = await prisma.device.findMany({
+    include: { brand: true },
+  })
+  // Create device map with both "Brand Model" and just "Model" as keys for flexible matching
+  const deviceMap = new Map()
+  devices.forEach((device) => {
+    const fullName = `${device.brand.name} ${device.modelName}`.toLowerCase()
+    const modelOnly = device.modelName.toLowerCase()
+    deviceMap.set(fullName, device)
+    deviceMap.set(modelOnly, device)
+  })
+
+  if (devices.length === 0) {
+    console.error('❌ No devices found in database. Please seed devices first.')
+    return
+  }
+
+  // Get specific user for authorship
+  const specificUser = await prisma.user.findUnique({
+    where: {
+      email: 'ryanretrocompatibility@gmail.com',
+    },
+  })
+
+  if (!specificUser) {
+    console.error(
+      '❌ User "ryanretrocompatibility@gmail.com" not found, cannot proceed with listings import',
+    )
+    return
+  }
+
+  // Get seeded admin users for approval
+  const adminUsers = await prisma.user.findMany({
+    where: {
+      email: {
+        in: ['superadmin@emuready.com', 'admin@emuready.com'],
+      },
+    },
+  })
+
+  // Helper function to get random element from array
+  const getRandomElement = <T>(array: T[]): T | undefined => {
+    return array.length > 0 ? array[Math.floor(Math.random() * array.length)] : undefined
+  }
+
+  console.log(
+    `🎮 Found ${games.length} games, ${emulators.length} emulators, ${performanceScales.length} performance scales, ${devices.length} devices`,
+  )
+  console.log(`👤 Author: ${specificUser.email} (${specificUser.name})`)
+  console.log(`👨‍💼 Admin approvers: ${adminUsers.length} available`)
+
+  // Process listings
+  let successCount = 0
+  let failCount = 0
+  let gameNotFoundCount = 0
+  let emulatorNotFoundCount = 0
+  let performanceNotFoundCount = 0
+  let deviceNotFoundCount = 0
+
+  console.info(`📝 Processing ${listings.length} listings...`)
+
+  for (const listing of listings) {
+    // Find game by title (case-insensitive)
+    const game = gameMap.get(listing.game.toLowerCase())
+    if (!game) {
+      console.warn(`⚠️ Game "${listing.game}" not found, skipping listing`)
+      gameNotFoundCount++
+      continue
+    }
+
+    // Find emulator by name (case-insensitive)
+    const emulator = emulatorMap.get(listing.emulator.toLowerCase())
+    if (!emulator) {
+      console.warn(`⚠️ Emulator "${listing.emulator}" not found, skipping listing`)
+      emulatorNotFoundCount++
+      continue
+    }
+
+    // Find performance scale by label (case-insensitive)
+    const performance = performanceMap.get(listing.performance.toLowerCase())
+    if (!performance) {
+      console.warn(`⚠️ Performance scale "${listing.performance}" not found, skipping listing`)
+      performanceNotFoundCount++
+      continue
+    }
+
+    // Find device by name (try both full name and model name)
+    const device = deviceMap.get(listing.device.toLowerCase())
+    if (!device) {
+      console.warn(`⚠️ Device "${listing.device}" not found, skipping listing`)
+      deviceNotFoundCount++
+      continue
+    }
+
+    // Create comprehensive notes combining all CSV fields
+    const combinedNotes = [
+      listing.notes,
+      listing.drive ? `Drive: ${listing.drive}` : '',
+      listing.update ? `Update: ${listing.update}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+
+    const author = specificUser
+    const approver = getRandomElement(adminUsers)
+
+    // Random timestamps
+    const submittedAt = new Date(Date.now() - Math.random() * 30 * 24 * 60 * 60 * 1000) // Random date in last 30 days
+    const approvedAt = new Date(submittedAt.getTime() + Math.random() * 7 * 24 * 60 * 60 * 1000) // Approved within 7 days
+
+    try {
+      await prisma.listing.create({
+        data: {
+          gameId: game.id,
+          deviceId: device.id,
+          emulatorId: emulator.id,
+          performanceId: performance.id,
+          notes: combinedNotes,
+          authorId: author.id,
+          status: ApprovalStatus.APPROVED, // Auto-approve CSV imports
+          processedAt: approvedAt,
+          processedNotes: 'Imported from CSV data',
+          processedByUserId: approver?.id ?? adminUsers[0]?.id,
+        },
+      })
+
+      successCount++
+
+      if (successCount % 50 === 0) {
+        console.log(`📈 Progress: ${successCount}/${listings.length} listings imported`)
+      }
+    } catch (error) {
+      console.error(
+        `❌ Failed to create listing for "${listing.game}" with ${listing.emulator}:`,
+        error,
+      )
+      failCount++
+    }
+  }
+
+  console.info('✅ CSV listings seeding completed!')
+  console.info('📊 Summary:')
+  console.info(`   📥 ${listings.length} total listings in CSV`)
+  console.info(`   🗑️ ${csvDuplicatesCount} CSV duplicates removed`)
+  console.info(`   ✅ ${successCount} listings imported successfully`)
+  console.info(`   ❌ ${failCount} listings failed to import`)
+  console.info(`   ⚠️ ${gameNotFoundCount} listings skipped (game not found)`)
+  console.info(`   ⚠️ ${emulatorNotFoundCount} listings skipped (emulator not found)`)
+  console.info(`   ⚠️ ${performanceNotFoundCount} listings skipped (performance scale not found)`)
+  console.info(`   ⚠️ ${deviceNotFoundCount} listings skipped (device not found)`)
+  console.info(`   📱 Devices assigned from CSV device column`)
+  console.info(`   👥 All listings authored by: ${specificUser.email}`)
+  console.info(`   👨‍💼 Using ${adminUsers.length} admin users as approvers`)
+}
+
+export default csvListingsSeeder

--- a/prisma/seeders/data/rp5_flip2_odin2_switch_games.csv
+++ b/prisma/seeders/data/rp5_flip2_odin2_switch_games.csv
@@ -1,0 +1,2824 @@
+﻿title,systemName
+8-Bit Adventures 2,Nintendo Switch
+12 Is Better Than 6,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+20 Minutes Till Dawn,Nintendo Switch
+30xx,Nintendo Switch
+60 Seconds Reatomized,Nintendo Switch
+80’s Overdrive,Nintendo Switch
+198x,Nintendo Switch
+3000th Duel,Nintendo Switch
+A Boy And His Blob,Nintendo Switch
+A Hat In Time,Nintendo Switch
+A Highland Song,Nintendo Switch
+A Juggler’s Tale,Nintendo Switch
+A Little To The Left,Nintendo Switch
+A Memoir Blue,Nintendo Switch
+A Short Hike,Nintendo Switch
+A Sketchbook About Her Sun,Nintendo Switch
+Abomi Nation,Nintendo Switch
+Abzu,Nintendo Switch
+Ace Attorney Investigations Collection,Nintendo Switch
+Ace Attorney Investigations Collection,Nintendo Switch
+Ace Combat 7: Skies Unknown,Nintendo Switch
+Advance Wars 1+2: Re-boot Camp,Nintendo Switch
+Advance Wars 1+2: Re-Boot Camp,Nintendo Switch
+Aeon Drive,Nintendo Switch
+Aery Early Birds Bundle,Nintendo Switch
+Aew Fight Forever,Nintendo Switch
+Afterimage,Nintendo Switch
+Agatha Christie – Murder On The Orient Express,Nintendo Switch
+Ak-Xolotl,Nintendo Switch
+Akane,Nintendo Switch
+Alan Wake Remastered,Nintendo Switch
+Alba,Nintendo Switch
+Alex Kidd In Miracle World Dx,Nintendo Switch
+Alien Hominid HD,Nintendo Switch
+Alien: Isolation,Nintendo Switch
+Alphadia Genesis 2,Nintendo Switch
+Alwa’s Awakening,Nintendo Switch
+Angry Video Game Nerd I & II Deluxe,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Well,Nintendo Switch
+Animal Well,Nintendo Switch
+Animal Well,Nintendo Switch
+Animus: Revenant,Nintendo Switch
+Anno: Mutationem,Nintendo Switch
+Anno: Mutationem,Nintendo Switch
+Anodyne 2 : Return To Dust,Nintendo Switch
+Anomaly Agent,Nintendo Switch
+Anomaly Collapse,Nintendo Switch
+Another Code: Recollection,Nintendo Switch
+Another Code: Recollection,Nintendo Switch
+Another Crab’s Treasure,Nintendo Switch
+Ape Out,Nintendo Switch
+Apico,Nintendo Switch
+Apollo Justice: Ace Attorney Trilogy,Nintendo Switch
+Aragami: Shadow Edition,Nintendo Switch
+Arcade Paradise,Nintendo Switch
+Arcade Tanks World: Tank Battle Simulator,Nintendo Switch
+Archvale,Nintendo Switch
+Arietta Of Spirits,Nintendo Switch
+Arms,Nintendo Switch
+Army Of Ruin,Nintendo Switch
+Arrog,Nintendo Switch
+Art Of Rally,Nintendo Switch
+Asdivine Hearts,Nintendo Switch
+Aspire: Ina’s Tale,Nintendo Switch
+Assassin’s Creed 2,Nintendo Switch
+Assassin’s Creed 4,Nintendo Switch
+Assassin’s Creed 4,Nintendo Switch
+Assassin’s Creed: The Ezio Collection,Nintendo Switch
+Assassin’s Creed: The Rebel Collection,Nintendo Switch
+Assassin’s Creed: The Rebel Collection,Nintendo Switch
+Astalon: Tears Of The Earth,Nintendo Switch
+Astalon: Tears Of The Earth,Nintendo Switch
+Astebreed,Nintendo Switch
+Asterix & Obelix Xxl3: The Crystal Menhir,Nintendo Switch
+Asterix & Obelix Xxxl: The Ram From Hibernia,Nintendo Switch
+Astlibra Revision,Nintendo Switch
+Astral Ascent,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Flux,Nintendo Switch
+Astral Flux,Nintendo Switch
+Astroneer,Nintendo Switch
+Atelier Ayesha: The Alchemist of Dusk DX,Nintendo Switch
+Atelier Marie Remake: The Alchemist of Salburg,Nintendo Switch
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Nintendo Switch
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Nintendo Switch
+Atelier Ryza: Ever Darkness & The Secret Hideout,Nintendo Switch
+Atelier Shallie: Alchemists of the Dusk Sea DX,Nintendo Switch
+Atone: Heart Of The Elder Tree,Nintendo Switch
+Avicci Invector,Nintendo Switch
+Azura’s Crystals,Nintendo Switch
+Azure Striker Gunvolt: Striker Pack,Nintendo Switch
+Baba Is You,Nintendo Switch
+Badland: Game Of The Year Edition,Nintendo Switch
+Bakeru,Nintendo Switch
+Balatro,Nintendo Switch
+Balatro,Nintendo Switch
+Balatro,Nintendo Switch
+Baldo The Guardian Owls,Nintendo Switch
+Baldur’s Gate And Baldur’s Gate II: Enhanced Editions,Nintendo Switch
+Barbie Dreamhouse Adventures,Nintendo Switch
+Bastion,Nintendo Switch
+Bastion,Nintendo Switch
+Bat Boy,Nintendo Switch
+Batman Arkham Asylum,Nintendo Switch
+Batman Arkham Asylum,Nintendo Switch
+Batman Arkham Asylum,Nintendo Switch
+Batman Arkham City,Nintendo Switch
+Batman Arkham City,Nintendo Switch
+Batman: The Telltale Series,Nintendo Switch
+Battle Brothers,Nintendo Switch
+Battle Chasers: Nightwar,Nintendo Switch
+Battle Kid: Fortress Of Peril,Nintendo Switch
+Bayonetta,Nintendo Switch
+Bayonetta,Nintendo Switch
+Bayonetta 2,Nintendo Switch
+Bayonetta 3,Nintendo Switch
+Bayonetta Origins: Cereza And The Lost Demon,Nintendo Switch
+Beasts Of Maravilla Island,Nintendo Switch
+Beat Cop,Nintendo Switch
+Belle Boomerang,Nintendo Switch
+Beyblade X Xone,Nintendo Switch
+Beyblade X Xone,Nintendo Switch
+Beyond A Steel Sky,Nintendo Switch
+Beyond Good And Evil – 20th Anniversary Edition,Nintendo Switch
+Big Helmet Heroes,Nintendo Switch
+"Big Kitty, Little City",Nintendo Switch
+Biomutant,Nintendo Switch
+Bioshock Remastered,Nintendo Switch
+Bite The Bullet,Nintendo Switch
+Black Skylands,Nintendo Switch
+Black Witchcraft,Nintendo Switch
+Black Witchcraft,Nintendo Switch
+Blade Assault,Nintendo Switch
+Blade Chimera,Nintendo Switch
+Blade Chimera,Nintendo Switch
+Blade Runner Enhanced Edition,Nintendo Switch
+Bladed Fury,Nintendo Switch
+Blair Witch,Nintendo Switch
+Blanc,Nintendo Switch
+Blasphemous,Nintendo Switch
+Blasphemous,Nintendo Switch
+Blasphemous 2,Nintendo Switch
+Blasphemous 2,Nintendo Switch
+Blast Brigade vs. The Evil Legion Of Dr. Cread,Nintendo Switch
+Blazing Strike,Nintendo Switch
+Bloodstained – Curse Of The Moon,Nintendo Switch
+Bloodstained: Ritual Of The Night,Nintendo Switch
+Bloomtown: A Different Story,Nintendo Switch
+Bluey: The Videogame,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bonds Of The Skies,Nintendo Switch
+Boomerang Fu,Nintendo Switch
+Boot Hill Heroes,Nintendo Switch
+Borderlands,Nintendo Switch
+Borderlands 2,Nintendo Switch
+Borderlands: The Pre-Sequel Ultimate Edition,Nintendo Switch
+Boreal Tenebrae,Nintendo Switch
+Born Of Bread,Nintendo Switch
+Born Of Bread,Nintendo Switch
+Boti: Byteland Overclocked,Nintendo Switch
+Braid Anniversary Edition,Nintendo Switch
+Bramble The Mountain King,Nintendo Switch
+Bravely Default II,Nintendo Switch
+Breathedge,Nintendo Switch
+Brewmaster Beer Brewing Simulator,Nintendo Switch
+Broforce,Nintendo Switch
+Brotato,Nintendo Switch
+Brothers,Nintendo Switch
+Bud Spencer & Terence Hill – Slaps And Beans 2,Nintendo Switch
+Bug Fables,Nintendo Switch
+Bugsnax,Nintendo Switch
+Bulletstorm Duke Of Switch Edition,Nintendo Switch
+Bulletstorm Duke Of Switch Edition,Nintendo Switch
+Burnout Legends,Nintendo Switch
+Burnout Paradise Remastered,Nintendo Switch
+Burnout Paradise Remastered,Nintendo Switch
+Butcher,Nintendo Switch
+Bzzzt,Nintendo Switch
+Bzzzt,Nintendo Switch
+Cadence Of Hyrule: Crypt Of The Necrodancer,Nintendo Switch
+Call Of Juarez: Gunslinger,Nintendo Switch
+Capcom Fighting Collection 2,Nintendo Switch
+Captai,Nintendo Switch
+Captain Toad: Treasure Tracker,Nintendo Switch
+Captain Toad: Treasure Tracker,Nintendo Switch
+Caravan Sandwich,Nintendo Switch
+Carrion,Nintendo Switch
+Carto,Nintendo Switch
+Cassette Beasts,Nintendo Switch
+Castlestorm,Nintendo Switch
+Castlestorm 2,Nintendo Switch
+Castlevania Anniversary Collection,Nintendo Switch
+Castlevania Dominus Collection,Nintendo Switch
+Cat Quest,Nintendo Switch
+Cat Quest III,Nintendo Switch
+Cat Quest III,Nintendo Switch
+Catan Console Edition,Nintendo Switch
+Catan Console Edition,Nintendo Switch
+Catastronauts!,Nintendo Switch
+Catherine: Full Body,Nintendo Switch
+Cave Story+,Nintendo Switch
+Cel Damage Hd,Nintendo Switch
+Celeste,Nintendo Switch
+Celeste,Nintendo Switch
+Celeste,Nintendo Switch
+Celeste,Nintendo Switch
+Chained Echoes,Nintendo Switch
+Chicken Police,Nintendo Switch
+Child Of Light Ultimate Edition,Nintendo Switch
+Chocobo Gp,Nintendo Switch
+Choo-Choo Charles,Nintendo Switch
+Chrono Cross – The Radical Dreamers Edition,Nintendo Switch
+Circuit Superstars,Nintendo Switch
+Citizen Sleeper,Nintendo Switch
+Citizen Sleeper,Nintendo Switch
+Civilization II,Nintendo Switch
+Clubhouse Games,Nintendo Switch
+Cluster Truck,Nintendo Switch
+Cobalt Core,Nintendo Switch
+Code Of Princess Ex,Nintendo Switch
+Code Realize Wintertide Miracles,Nintendo Switch
+Coffee Talk,Nintendo Switch
+Collection Of Mana,Nintendo Switch
+Commandos 2 – HD Remaster,Nintendo Switch
+Commandos 3 – HD Remaster,Nintendo Switch
+Company Of Heroes,Nintendo Switch
+Contra Operation Galuga,Nintendo Switch
+Contra Operation Galuga,Nintendo Switch
+Core Keeper,Nintendo Switch
+Corpse Party,Nintendo Switch
+Crash Bandicoot 4,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Team Racing: Nitro-Fueled,Nintendo Switch
+Crash Team Racing: Nitro-Fueled,Nintendo Switch
+Crash Team Racing: Nitro-Fueled,Nintendo Switch
+Crashlands,Nintendo Switch
+Crawl,Nintendo Switch
+Creepy Tale,Nintendo Switch
+Cris Tales,Nintendo Switch
+Crisis Core: Final Fantasy II Reunion,Nintendo Switch
+Crosscode,Nintendo Switch
+Crow Country,Nintendo Switch
+Crow Country,Nintendo Switch
+Crown Trick,Nintendo Switch
+Cruis’n Blast,Nintendo Switch
+Cruis’n Blast,Nintendo Switch
+Crumble,Nintendo Switch
+Crymachina,Nintendo Switch
+Crypt Custodian,Nintendo Switch
+Crypt Custodian,Nintendo Switch
+Crysis Remastered,Nintendo Switch
+Crystal Breaker,Nintendo Switch
+Ctr: Nitro Fueled,Nintendo Switch
+Cult Of The Lamb,Nintendo Switch
+Cult Of The Lamb,Nintendo Switch
+Cult Of The Lamb,Nintendo Switch
+Cuphead,Nintendo Switch
+Cuphead In The Delicious Last Course,Nintendo Switch
+Curse Of The Dead Gods,Nintendo Switch
+Cursed To Golf,Nintendo Switch
+Cyberage,Nintendo Switch
+Dadish,Nintendo Switch
+Dadish 3D,Nintendo Switch
+Danganronpa: Trigger Happy Havoc Anniversary Edition,Nintendo Switch
+Dark Devotion,Nintendo Switch
+Dark Souls 1,Nintendo Switch
+Dark Souls Remastered,Nintendo Switch
+Darkest Dungeon II,Nintendo Switch
+Darkest Dungeon II,Nintendo Switch
+Darksiders I,Nintendo Switch
+Darksiders II,Nintendo Switch
+Darksiders Warmastered Edition,Nintendo Switch
+Darkwood,Nintendo Switch
+Date Everything!,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dawn Of The Monsters,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead End Job,Nintendo Switch
+Death Elevator 2,Nintendo Switch
+Death Mark,Nintendo Switch
+Death Tales,Nintendo Switch
+Death’s Door,Nintendo Switch
+Death’s Gambit: Afterlife,Nintendo Switch
+Deemo -Reborn-,Nintendo Switch
+Deltarune,Nintendo Switch
+Deltarune,Nintendo Switch
+Demon Turf,Nintendo Switch
+Demon’s Tilt,Nintendo Switch
+Destroy All Humans!,Nintendo Switch
+Destroy All Humans!,Nintendo Switch
+Destroy All Humans!,Nintendo Switch
+Detective Pikachu Returns,Nintendo Switch
+Detective Pikachu Returns,Nintendo Switch
+Devil Engine Complete Edition,Nintendo Switch
+Devil May Cry 1,Nintendo Switch
+Devil May Cry 3 Special Edition,Nintendo Switch
+Dex,Nintendo Switch
+Diablo 2: Resurrected,Nintendo Switch
+Diablo 3: Eternal Collection,Nintendo Switch
+Diablo 3: Eternal Collection,Nintendo Switch
+Diablo III,Nintendo Switch
+Diablo III,Nintendo Switch
+Dicey Dungeons,Nintendo Switch
+Die After Sunset,Nintendo Switch
+Diesel Legacy: The Brazen Age,Nintendo Switch
+Digimon Cyber Sleuth,Nintendo Switch
+Digimon Story Cyber Sleuth: Complete Edition,Nintendo Switch
+Digimon Survive,Nintendo Switch
+Digimon World -Next Order-,Nintendo Switch
+Disco Elysium – The Final Cut,Nintendo Switch
+Disco Elysium – The Final Cut,Nintendo Switch
+Disgaea 5 Complete,Nintendo Switch
+Disney Dreamlight Valley,Nintendo Switch
+Disney Epic Mickey: Rebrushed,Nintendo Switch
+Disney Illusion Island,Nintendo Switch
+Divinity Original Sin 2,Nintendo Switch
+Doctor Who: Edge Of Reality,Nintendo Switch
+Dodgeball Academia,Nintendo Switch
+Dogman: Mission Impawssible,Nintendo Switch
+Dogurai,Nintendo Switch
+Don’t Starve Nintendo Switch Edition,Nintendo Switch
+Don’t Starve Together,Nintendo Switch
+Donkey Kong Country Returns HD,Nintendo Switch
+Donkey Kong Country Returns HD,Nintendo Switch
+Donkey Kong Country: Tropical Freeze,Nintendo Switch
+Donkey Kong Country: Tropical Freeze,Nintendo Switch
+Donkey Kong Country: Tropical Freeze,Nintendo Switch
+Donut Dodo,Nintendo Switch
+Donuts’n’justice,Nintendo Switch
+Doom (2016),Nintendo Switch
+Doom + Doom 2,Nintendo Switch
+Doom 64,Nintendo Switch
+Doraemon Dorayaki Shop Story,Nintendo Switch
+Dorfromantik,Nintendo Switch
+Double Dragon Neon,Nintendo Switch
+Dragon Ball FighterZ,Nintendo Switch
+Dragon Ball FighterZ,Nintendo Switch
+Dragon Ball FighterZ,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Dragon Marked For Death: Advanced Attackers,Nintendo Switch
+Dragon Quest Builders,Nintendo Switch
+Dragon Quest Builders 2,Nintendo Switch
+Dragon Quest III HD-2D Remake,Nintendo Switch
+Dragon Quest III HD-2D Remake,Nintendo Switch
+Dragon Quest III HD-2D Remake,Nintendo Switch
+Dragon Quest Monsters,Nintendo Switch
+Dragon Quest X,Nintendo Switch
+Dragon Quest XI S: Echoes Of An Elusive Age,Nintendo Switch
+Dragon’s Dogma: Dark Arisen,Nintendo Switch
+Draw A Stickman: Epic,Nintendo Switch
+Dreamscaper,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Drone Pilot: Extreme Flight Simulator,Nintendo Switch
+Dros,Nintendo Switch
+Drova Forsaken Kin,Nintendo Switch
+Duck Detective: The Secret Salami,Nintendo Switch
+Duck Detective: The Secret Salami,Nintendo Switch
+Duck Game,Nintendo Switch
+Dungeonoid 2: Awakening,Nintendo Switch
+Dungeons And Doomknights,Nintendo Switch
+Dungeons Of Dreadrock – The Dead King’s Secret,Nintendo Switch
+Dungeons Of Dreadrock – The Dead King’s Secret,Nintendo Switch
+Dungreed,Nintendo Switch
+Dusk,Nintendo Switch
+Dusk Diver,Nintendo Switch
+Dust & Neon,Nintendo Switch
+Dust & Neon,Nintendo Switch
+Dust: An Elysian Tail,Nintendo Switch
+Dustoff Heli Rescue 2,Nintendo Switch
+Dying Light Definitive Collection,Nintendo Switch
+Dysmantle,Nintendo Switch
+Ea Sports Fc 25,Nintendo Switch
+Ea Sports Fc 25,Nintendo Switch
+Ea Sports Fc 25,Nintendo Switch
+Eastward,Nintendo Switch
+Eastward,Nintendo Switch
+Eastward: Octopia!,Nintendo Switch
+Echo Generation,Nintendo Switch
+Echoes Of The Plum Grove,Nintendo Switch
+Elderand,Nintendo Switch
+Eldest Souls,Nintendo Switch
+Elsie,Nintendo Switch
+Elypse,Nintendo Switch
+Elypse,Nintendo Switch
+Elypse,Nintendo Switch
+Emio: The Smiling Man – Famicom Detective Club,Nintendo Switch
+Empty Shell,Nintendo Switch
+Enclave HD,Nintendo Switch
+Ender Lilies: Quietus Of The Knights,Nintendo Switch
+Ender Magnolia Bloom In The Mist,Nintendo Switch
+Enraged Red Ogre,Nintendo Switch
+Enter The Gungeon,Nintendo Switch
+Enter The Gungeon,Nintendo Switch
+Eternal Edge,Nintendo Switch
+Eternights,Nintendo Switch
+Etrian Odyssey HD,Nintendo Switch
+Evasion From Hell,Nintendo Switch
+Everafter Falls,Nintendo Switch
+Everafter Falls,Nintendo Switch
+Everhood,Nintendo Switch
+Everspace,Nintendo Switch
+Exhausted Man,Nintendo Switch
+Exzeus Collection,Nintendo Switch
+F.I.S.T. Forged In Shadow Torch,Nintendo Switch
+Factorio,Nintendo Switch
+Fading Afternoon,Nintendo Switch
+Fairy Tail,Nintendo Switch
+Fallen Legion: Rise To Glory,Nintendo Switch
+Fantasian Neo Dimension,Nintendo Switch
+Fantasy Life – The Girl Who Steals Time,Nintendo Switch
+Fantasy Life – The Girl Who Steals Time,Nintendo Switch
+Fantasy Life – The Girl Who Steals Time,Nintendo Switch
+Far: Changing Tides,Nintendo Switch
+Fast Rmx,Nintendo Switch
+Fatal Frame: Maiden Of Black Water,Nintendo Switch
+Fatal Frame: Mask Of The Lunar Eclipse,Nintendo Switch
+Fate/samurai Remnant,Nintendo Switch
+Fate/Stay Night Remastered,Nintendo Switch
+Fez,Nintendo Switch
+Fifa 18,Nintendo Switch
+Fifa 18,Nintendo Switch
+Fifa 19,Nintendo Switch
+Fifa 23,Nintendo Switch
+Fighting Ex Layer Another Dash,Nintendo Switch
+Final Fantasy,Nintendo Switch
+Final Fantasy Crystal Chronicles Remastered,Nintendo Switch
+Final Fantasy II,Nintendo Switch
+Final Fantasy III,Nintendo Switch
+Final Fantasy IV,Nintendo Switch
+Final Fantasy Vi,Nintendo Switch
+Final Fantasy X HD Remaster,Nintendo Switch
+Final Fantasy X HD Remaster,Nintendo Switch
+Final Fantasy XII,Nintendo Switch
+Final Fantasy XV Pocket Edition,Nintendo Switch
+Final Vendetta,Nintendo Switch
+Finding Paradise,Nintendo Switch
+Fire Emblem Engage,Nintendo Switch
+Fire Emblem Warriors: Three Hopes,Nintendo Switch
+Fire Emblem: Engage,Nintendo Switch
+Fire Emblem: Three Houses,Nintendo Switch
+Firewatch,Nintendo Switch
+Firewatch,Nintendo Switch
+Five Nights At Freddy’s: Help Wanted 2,Nintendo Switch
+Five Nights At Freddy’s: Help Wanted 2,Nintendo Switch
+Five Nights At Freddy’s: Into The Pit,Nintendo Switch
+Five Nights At Freddy´s: Security Breach,Nintendo Switch
+Flat Kingdom Paper’s Cut Edition,Nintendo Switch
+Flynn Son Of Crimson,Nintendo Switch
+Fnaf Sb,Nintendo Switch
+Fobia,Nintendo Switch
+Food Delivery Battle,Nintendo Switch
+For A Vast Future,Nintendo Switch
+For The King,Nintendo Switch
+Forager,Nintendo Switch
+Forager,Nintendo Switch
+Forager,Nintendo Switch
+Forgive Me Father,Nintendo Switch
+Forgotten Anne,Nintendo Switch
+Fortress S,Nintendo Switch
+Freddi Fish 4: The Case Of The Hogfish Rustlers Of Briny Gulch,Nintendo Switch
+Freddy Spaghetti,Nintendo Switch
+Freedom Planet,Nintendo Switch
+Freedom Wars Remastered,Nintendo Switch
+Frog Detective: The Entire Mystery,Nintendo Switch
+Frogue,Nintendo Switch
+Frogun Deluxe Edition,Nintendo Switch
+From Heaven To Earth,Nintendo Switch
+Funko Fusion,Nintendo Switch
+Furi Definitive Edition,Nintendo Switch
+G.I. Joe: Wrath Of Cobra,Nintendo Switch
+Garden Story,Nintendo Switch
+Gear Club Unlimited 2,Nintendo Switch
+Genesis Noir,Nintendo Switch
+Ghost Of A Tale,Nintendo Switch
+Ghost Song,Nintendo Switch
+Ghost Sync,Nintendo Switch
+Ghost Trick: Phantom Detective,Nintendo Switch
+Ghostbusters: The Video Game – Remastered,Nintendo Switch
+Ghostrunner,Nintendo Switch
+Ghosts And Apples,Nintendo Switch
+Ghosts And Goblins Resurrection,Nintendo Switch
+Goblin Sword,Nintendo Switch
+Godstrike,Nintendo Switch
+Going Under,Nintendo Switch
+Golf Story,Nintendo Switch
+Golf With Your Friends,Nintendo Switch
+Good Job!,Nintendo Switch
+Gori: Cuddly Carnage,Nintendo Switch
+Gothic 2 Complete Classic,Nintendo Switch
+Grand Mountain Adventure,Nintendo Switch
+Grand Mountain Adventure: Wonderlands,Nintendo Switch
+Grandia HD Collection,Nintendo Switch
+Grapple Dog,Nintendo Switch
+Graveyard Keeper,Nintendo Switch
+Graveyard Keeper,Nintendo Switch
+Graveyard Keeper,Nintendo Switch
+Gravity Duck,Nintendo Switch
+Greak: Memories Of Azur,Nintendo Switch
+Grim Fandango Remastered,Nintendo Switch
+Grim Fandango Remastered,Nintendo Switch
+Grime,Nintendo Switch
+Grime – Definitive Edition,Nintendo Switch
+Gripper,Nintendo Switch
+Gris,Nintendo Switch
+Groove Coaster Wai Wai Party,Nintendo Switch
+Grounded,Nintendo Switch
+Grow: Song Of The Evertree,Nintendo Switch
+Gta: San Andreas – Definitive Edition,Nintendo Switch
+Guacamelee! 2,Nintendo Switch
+Guacamelee! Super Turbo Championship Edition,Nintendo Switch
+Guayota,Nintendo Switch
+Guilty Gear Strive,Nintendo Switch
+Gun Gore & Cannoli 2,Nintendo Switch
+Gunman Clive HD,Nintendo Switch
+Guns Of Fury,Nintendo Switch
+Guns Of Fury,Nintendo Switch
+Guns Of Fury,Nintendo Switch
+Gunslugs,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Happy’s Humble Burger Farm,Nintendo Switch
+Hatsune Miku: Project Diva Mega Mix,Nintendo Switch
+Have A Nice Death,Nintendo Switch
+Have A Nice Death,Nintendo Switch
+Heavenly Bodies,Nintendo Switch
+Heavenly Bodies,Nintendo Switch
+Hell Is Other Demons,Nintendo Switch
+Hell Pie,Nintendo Switch
+Hellblade: Senua’s Sacrifice,Nintendo Switch
+Hellboy Web Of Wyrd,Nintendo Switch
+Hello Kitty Island Adventure,Nintendo Switch
+Hello Neighbor,Nintendo Switch
+Hellpoint,Nintendo Switch
+Heretic’s Fork,Nintendo Switch
+High On Life,Nintendo Switch
+Hitman Blood Money Reprisal,Nintendo Switch
+Hitman Blood Money Reprisal,Nintendo Switch
+Hob: The Definitive Edition,Nintendo Switch
+Hogwarts Legacy: Deluxe Edition,Nintendo Switch
+Hollow Knight,Nintendo Switch
+Hollow Knight,Nintendo Switch
+Hollow Knight,Nintendo Switch
+Horizon Chase 2,Nintendo Switch
+Horizon Chase Turbo,Nintendo Switch
+Hotline Miami 1 & 2,Nintendo Switch
+Hotline Miami 1 & 2,Nintendo Switch
+Hotline Miami 1 & 2,Nintendo Switch
+Hotshot Racing,Nintendo Switch
+Hotshot Racing,Nintendo Switch
+Hotshot Racing,Nintendo Switch
+Hue,Nintendo Switch
+Huntdown,Nintendo Switch
+Hunter X,Nintendo Switch
+Hunterxhunter Nenximpact,Nintendo Switch
+Hyper Light Drifter,Nintendo Switch
+Hypnospace Outlaw,Nintendo Switch
+Hyrule Warriors: Age Of Calamity,Nintendo Switch
+Hyrule Warriors: Definitive Edition,Nintendo Switch
+Hyrule Warriors: Definitive Edition,Nintendo Switch
+I Am The Hero,Nintendo Switch
+Iconoclasts,Nintendo Switch
+Ikenfell,Nintendo Switch
+Immortals Fenyx Rising,Nintendo Switch
+In Other Waters,Nintendo Switch
+In Sound Mind,Nintendo Switch
+Inmost,Nintendo Switch
+Inscryption,Nintendo Switch
+Inscryption,Nintendo Switch
+Inside,Nintendo Switch
+Into The Breach,Nintendo Switch
+Into The Breach,Nintendo Switch
+Inukari – Chase Of Deception,Nintendo Switch
+Iris And The Giant,Nintendo Switch
+Iron Meat,Nintendo Switch
+Ironfall Invasion,Nintendo Switch
+Islanders,Nintendo Switch
+It Takes Two,Nintendo Switch
+Ittle Dew,Nintendo Switch
+Jack Move,Nintendo Switch
+Jamestown+,Nintendo Switch
+Jet Lancer,Nintendo Switch
+Jet Lancer,Nintendo Switch
+John Wick Hex,Nintendo Switch
+Jojo’s Bizarre Adventure: All-Star Battle R Deluxe Edition,Nintendo Switch
+Jujutsu Kaisen Cursed Clash,Nintendo Switch
+Jurassic World Evolution,Nintendo Switch
+Just Shapes & Beats,Nintendo Switch
+Kamen Rider Memory Of Heroez,Nintendo Switch
+Kamen Rider Memory Of Heroez Premium Sound Edition,Nintendo Switch
+Kamen Rider Memory Of Heroez Sound Edition,Nintendo Switch
+Kamibako – Mythology Of Cube,Nintendo Switch
+Kamiko,Nintendo Switch
+Kanjozoku 2,Nintendo Switch
+Katamari Damacy Reroll,Nintendo Switch
+Katana Zero,Nintendo Switch
+Katana Zero,Nintendo Switch
+Katrielle And The Millionaires’ Conspiracy,Nintendo Switch
+Kaze And The Wild Masks,Nintendo Switch
+Keeper’s Toll,Nintendo Switch
+Keeper’s Toll,Nintendo Switch
+Kero Blaster,Nintendo Switch
+Kill Knight,Nintendo Switch
+Kill The Crows,Nintendo Switch
+Kill The Crows,Nintendo Switch
+King Krieg Survivors,Nintendo Switch
+Kingdom 2 Crowns,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby Star Allies,Nintendo Switch
+Kirby Star Allies,Nintendo Switch
+Kirby’s Dream Buffet,Nintendo Switch
+Kirby’s Return To Dreamland Deluxe,Nintendo Switch
+Klonoa Phantasy Reveire Series,Nintendo Switch
+Kudzu,Nintendo Switch
+La Noire,Nintendo Switch
+Lacuna,Nintendo Switch
+Legacy Of Kain Soul Reaver 1&2 Remastered,Nintendo Switch
+Legend Of Grimrock,Nintendo Switch
+Legend Of Zelda – Links Awakening,Nintendo Switch
+Legend Of Zelda – Links Awakening,Nintendo Switch
+Legend Of Zelda – Links Awakening,Nintendo Switch
+Legend Of Zelda: Breath Of The Wild,Nintendo Switch
+Lego Builder’s Journey,Nintendo Switch
+Lego City Undercover,Nintendo Switch
+Lego Harry Potter Collection,Nintendo Switch
+Lego Jurassic World,Nintendo Switch
+Lego Marvel Superheroes,Nintendo Switch
+Lego Marvel Superheroes 2,Nintendo Switch
+Lego Star Wars: The Skywalker Saga,Nintendo Switch
+Leo’s Fortune,Nintendo Switch
+Leo’s Fortune,Nintendo Switch
+Life Is Strange Double Exposure,Nintendo Switch
+Life Is Strange Remastered,Nintendo Switch
+Life Is Strange: Before The Storm Remastered,Nintendo Switch
+Link’s Awakening,Nintendo Switch
+"Little Kitty, Big City",Nintendo Switch
+Little Nightmares,Nintendo Switch
+Little Nightmares Ii,Nintendo Switch
+Littlewood,Nintendo Switch
+Live A Live,Nintendo Switch
+Live A Live,Nintendo Switch
+Live A Live,Nintendo Switch
+Live A Live,Nintendo Switch
+Llamasoft: The Jeff Minter Collection,Nintendo Switch
+Loco Motive,Nintendo Switch
+Lollipop Chainsaw Repro,Nintendo Switch
+Lone Fungus,Nintendo Switch
+Lone Ruin,Nintendo Switch
+Lonely Mountains Downhill,Nintendo Switch
+Lonely Mountains Downhill,Nintendo Switch
+Lonely Mountains Downhill,Nintendo Switch
+Lost In Random,Nintendo Switch
+Lovers In A Dangerous Spacetime,Nintendo Switch
+Luigi’s Mansion 3,Nintendo Switch
+Luigi’s Mansion 3,Nintendo Switch
+Luigi’s Mansion 3,Nintendo Switch
+Luna’s Fishing Garden,Nintendo Switch
+Lunar Remastered Collection,Nintendo Switch
+Lunar Remastered Collection,Nintendo Switch
+Lysfanga – The Time Shift Warrior,Nintendo Switch
+Mahoyo: Witch On The Holy Night,Nintendo Switch
+Maid Of The Dead,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario + Rabbids Kingdom Battle,Nintendo Switch
+Mario + Rabbids Kingdom Battle,Nintendo Switch
+Mario + Rabbids Sparks Of Hope,Nintendo Switch
+Mario Golf Super Rush,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Odyssey,Nintendo Switch
+Mario Odyssey,Nintendo Switch
+Mario Party Superstars,Nintendo Switch
+Mario Party Superstars,Nintendo Switch
+Mario Strikers Battle League,Nintendo Switch
+Mario Tennis Aces,Nintendo Switch
+Mario vs. Donkey Kong,Nintendo Switch
+Marsupilami – Hoobadventure,Nintendo Switch
+Marvel Ultimate Alliance 3: The Black Order,Nintendo Switch
+Marvel vs. Capcom Fighting Collection: Arcade Classics,Nintendo Switch
+Mary Skelter 2,Nintendo Switch
+Master Detective Archive: Rain Code,Nintendo Switch
+Mega Man Legacy Collection 2,Nintendo Switch
+Mega Man X Legacy Collection,Nintendo Switch
+Mega Man X Legacy Collection 2,Nintendo Switch
+Megam Man Legacy Collection,Nintendo Switch
+Megaton Musashi W: Wired,Nintendo Switch
+Megaton Musashi W: Wired,Nintendo Switch
+Metal Gear Solid – Master Collection Version,Nintendo Switch
+Metal Slug Tactics,Nintendo Switch
+Metal Slug Tactics,Nintendo Switch
+Metallic Child,Nintendo Switch
+Metro 2033 Redux,Nintendo Switch
+Metroid Dread,Nintendo Switch
+Metroid Dread,Nintendo Switch
+Metroid Dread,Nintendo Switch
+Metroid Prime Remastered,Nintendo Switch
+Metroid Prime Remastered,Nintendo Switch
+Metroid Prime Remastered,Nintendo Switch
+Mighty Morphin Power Rangers: Rita’s Rewind,Nintendo Switch
+Mighty Morphin Power Rangers: Rita’s Rewind,Nintendo Switch
+Miitopia,Nintendo Switch
+Minecraft Dungeons,Nintendo Switch
+Minecraft Legends,Nintendo Switch
+Minecraft Story Mode – The Complete Adventure,Nintendo Switch
+Minecraft: Nintendo Switch Edition (legacy Console),Nintendo Switch
+Minecraft: Nintendo Switch Edition (Legacy Console),Nintendo Switch
+Mining Mechs,Nintendo Switch
+Minit,Nintendo Switch
+Mistover,Nintendo Switch
+Monster Boy And The Cursed Kingdom,Nintendo Switch
+Monster Hunter Generations Ultimate,Nintendo Switch
+Monster Hunter Generations Ultimate,Nintendo Switch
+Monster Hunter Generations Ultimate,Nintendo Switch
+Monster Hunter Rise,Nintendo Switch
+Monster Hunter Stories,Nintendo Switch
+Monster Train,Nintendo Switch
+Monster Train 2,Nintendo Switch
+Monster Train 2,Nintendo Switch
+Moonlighter,Nintendo Switch
+Moonstone Island,Nintendo Switch
+Moonstone Island,Nintendo Switch
+Mutazione,Nintendo Switch
+My Sims,Nintendo Switch
+My Sims,Nintendo Switch
+My Time At Sandrock,Nintendo Switch
+N++,Nintendo Switch
+Naiad,Nintendo Switch
+Naruto Shippuden Ultimate Ninja Storm 4 Road To Boruto,Nintendo Switch
+Naruto Ultimate Ninja Storm Collection,Nintendo Switch
+Naruto X Boruto Ultimate Ninja Storm Connections,Nintendo Switch
+Nascar Heat Ultimate Edition+,Nintendo Switch
+Neckbreak,Nintendo Switch
+Need For Speed Hot Pursuit Remastered,Nintendo Switch
+Need For Speed Hot Pursuit Remastered,Nintendo Switch
+Needy Girl Overdose,Nintendo Switch
+Neo: The World Ends With You,Nintendo Switch
+Neon Abyss,Nintendo Switch
+Neon Blood,Nintendo Switch
+Neon White,Nintendo Switch
+Nerd Survivors,Nintendo Switch
+Neuro Voider,Nintendo Switch
+Neva,Nintendo Switch
+New Pokémon Snap,Nintendo Switch
+New Pokémon Snap,Nintendo Switch
+New Super Lucky’s Tale,Nintendo Switch
+New Super Mario Bros. U Deluxe,Nintendo Switch
+Nexomon,Nintendo Switch
+Ni No Kuni Wrath Of The White Witch,Nintendo Switch
+Nickelodeon All-Star Brawl 2,Nintendo Switch
+Nickelodeon Kart Racers,Nintendo Switch
+Night In The Woods,Nintendo Switch
+Night Slashers Remake,Nintendo Switch
+Nights Of Azure 2,Nintendo Switch
+Nine Sols,Nintendo Switch
+Ninja Gaiden Sigma,Nintendo Switch
+Ninja Gaiden Sigma,Nintendo Switch
+Ninja Slayer: Neo-Saitama In Flames,Nintendo Switch
+Nintendo World Championship,Nintendo Switch
+No More Heroes,Nintendo Switch
+No More Heroes 2: Desperate Struggle,Nintendo Switch
+No More Heroes 3,Nintendo Switch
+Nuclear Blaze,Nintendo Switch
+Octodad: Dadliest Catch,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Oddworld: New ‘n’ Tasty!,Nintendo Switch
+Okami HD,Nintendo Switch
+Okinawa Rush,Nintendo Switch
+Old School Musical,Nintendo Switch
+Olliolli World,Nintendo Switch
+Omega Labyrinth Life,Nintendo Switch
+Omori,Nintendo Switch
+One Piece Pirate Warriors 3,Nintendo Switch
+One Piece Unlimited World Red Deluxe Edition,Nintendo Switch
+One Step From Eden,Nintendo Switch
+Onimusha: Warlords,Nintendo Switch
+Ori And The Blind Forest,Nintendo Switch
+Ori And The Blind Forest,Nintendo Switch
+Ori And The Blind Forest,Nintendo Switch
+Ori And The Blind Forest (Definitive Edition),Nintendo Switch
+Ori And The Will Of The Wisps,Nintendo Switch
+Otherwar,Nintendo Switch
+Otxo,Nintendo Switch
+Our Summer Festivals 2,Nintendo Switch
+Our Summer Festivals 2,Nintendo Switch
+Outer Wilds,Nintendo Switch
+Overcooked 2 + All Dlc,Nintendo Switch
+Owlboy,Nintendo Switch
+Paint The Town Red,Nintendo Switch
+Panzer Paladin,Nintendo Switch
+Paper Mario: The Origami King,Nintendo Switch
+Paper Mario: The Thousand-Year Door,Nintendo Switch
+Paper Mario: The Thousand-Year Door,Nintendo Switch
+Papwr Mario The Thousand Year Door,Nintendo Switch
+Party Hard,Nintendo Switch
+Party Hard,Nintendo Switch
+Passpartout,Nintendo Switch
+Passpartout 2,Nintendo Switch
+Pato Box,Nintendo Switch
+Patrick’s Parabox,Nintendo Switch
+Pentiment,Nintendo Switch
+Pepper Grinder,Nintendo Switch
+Persona 3 Portable,Nintendo Switch
+Persona 4 Arena Ultimax,Nintendo Switch
+Persona 4 Golden,Nintendo Switch
+Persona 4 Golden,Nintendo Switch
+Persona 4 Golden,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Strikers,Nintendo Switch
+Persona 5 Tactica,Nintendo Switch
+Pga Tour 2k21,Nintendo Switch
+Phoenix Wright: Ace Attorney Trilogy,Nintendo Switch
+Phoenotopia Awakening,Nintendo Switch
+Pikmin 1,Nintendo Switch
+Pikmin 2,Nintendo Switch
+Pikmin 3 Deluxe,Nintendo Switch
+Pikmin 3 Deluxe,Nintendo Switch
+Pikmin 4,Nintendo Switch
+Pikmin 4,Nintendo Switch
+Pikuniku,Nintendo Switch
+Pixel Cup Soccer Ultimate Edition,Nintendo Switch
+Pixel Retro Drift,Nintendo Switch
+Pizza Tower,Nintendo Switch
+Pizza Tower,Nintendo Switch
+Planescape Tournament And Icewind Dale,Nintendo Switch
+Plateup!,Nintendo Switch
+Poison Control,Nintendo Switch
+Pokemon,Nintendo Switch
+Pokemon Arceus,Nintendo Switch
+Pokemon Brilliant Diamond,Nintendo Switch
+Pokemon Brilliant Diamond,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Mystery Dungeon DX,Nintendo Switch
+Pokemon Scarlet,Nintendo Switch
+Pokemon Scarlet,Nintendo Switch
+Pokemon Scarlet,Nintendo Switch
+Pokemon Shining Pearl,Nintendo Switch
+Pokemon Shining Pearl,Nintendo Switch
+Pokemon Shining Pearl,Nintendo Switch
+Pokemon Snap,Nintendo Switch
+Pokemon Sword,Nintendo Switch
+Pokemon Sword,Nintendo Switch
+Pokemon Violet,Nintendo Switch
+Pokemon Violet,Nintendo Switch
+Pokemon Violet,Nintendo Switch
+Pokemon: Let’s Go Eevee!,Nintendo Switch
+Pokemon: Let’s Go Pikachu!,Nintendo Switch
+Pokemon: Shield,Nintendo Switch
+Pokemon: Sword,Nintendo Switch
+Pokemon: Sword,Nintendo Switch
+Pokken Tournament Dx,Nintendo Switch
+Portal,Nintendo Switch
+Portal,Nintendo Switch
+Portal,Nintendo Switch
+Portal 2,Nintendo Switch
+Post Void,Nintendo Switch
+Postal: Brain Damaged,Nintendo Switch
+Potion Craft,Nintendo Switch
+Power Rangers: Battle For The Grid,Nintendo Switch
+Power Rangers: Battle For The Grid,Nintendo Switch
+Powerwash Simulator,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Princess Peach: Showtime!,Nintendo Switch
+Princess Peach: Showtime!,Nintendo Switch
+Princess Peach: Showtime!,Nintendo Switch
+Prodeus,Nintendo Switch
+Pumpkin Jack,Nintendo Switch
+Punch A Bunch,Nintendo Switch
+Quake 2,Nintendo Switch
+R-Type Final 2,Nintendo Switch
+Racine,Nintendo Switch
+Rain World,Nintendo Switch
+Rainbow Moon,Nintendo Switch
+Rayman Legends,Nintendo Switch
+Rayman Legends: Definitive Edition,Nintendo Switch
+Rebel Transmute,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+Red Wings American Aces,Nintendo Switch
+Resident Evil 0,Nintendo Switch
+Resident Evil 4,Nintendo Switch
+Resident Evil HD Remake,Nintendo Switch
+Resident Evil Revelations,Nintendo Switch
+Resident Evil Revelations,Nintendo Switch
+Resident Evil Revelations 2,Nintendo Switch
+Retro City Rampage Dx,Nintendo Switch
+Retrorealms,Nintendo Switch
+Retrorealms,Nintendo Switch
+Return,Nintendo Switch
+Return Of The Obra Dinn,Nintendo Switch
+Return Of The Obra Dinn,Nintendo Switch
+Revita,Nintendo Switch
+Riptide Gp Renegade,Nintendo Switch
+Rise Of The Third Power,Nintendo Switch
+Risk Of Rain 2,Nintendo Switch
+Risk Of Rain 2,Nintendo Switch
+Risk Of Rain Returns,Nintendo Switch
+Risk Of Rain Returns,Nintendo Switch
+Rival Megagun,Nintendo Switch
+Rival Megagun,Nintendo Switch
+River City Girls,Nintendo Switch
+River City Girls 2,Nintendo Switch
+Road 96,Nintendo Switch
+Rocket League,Nintendo Switch
+Rogue Heroes: Ruins Of Tasos,Nintendo Switch
+Rogue Legacy 2,Nintendo Switch
+Rogue Legacy 2,Nintendo Switch
+Roller Coaster Tycoon 3 Complete,Nintendo Switch
+Rollercoaster Tycoon Classic,Nintendo Switch
+Romance Of The Three Kingdoms 8 : Remake,Nintendo Switch
+Romancing Saga 2: Revenge Of The Seven,Nintendo Switch
+Roots Of Pacha,Nintendo Switch
+Ruiner,Nintendo Switch
+Rune Factory 3,Nintendo Switch
+Rune Factory 4s,Nintendo Switch
+Rune Factory 5,Nintendo Switch
+Runnyk,Nintendo Switch
+Runnyk,Nintendo Switch
+Rusted Moss,Nintendo Switch
+S.T.A.L.K.E.R.: Call Of Prypiat,Nintendo Switch
+S.T.A.L.K.E.R.: Clear Sky,Nintendo Switch
+S.T.A.L.K.E.R.: Shadow Of Chornobyl,Nintendo Switch
+Saga Frontier 2 Remastered,Nintendo Switch
+Saga Frontier Remastered,Nintendo Switch
+Saints Row IV,Nintendo Switch
+Saints Row: The Third – The Full Package,Nintendo Switch
+Sakuna: Of Rice And Ruin,Nintendo Switch
+Salt And Sanctuary,Nintendo Switch
+Sam & Max: Save The World,Nintendo Switch
+Samurai Jack: Battle Through Time,Nintendo Switch
+Samurai Shodown,Nintendo Switch
+Sanabi,Nintendo Switch
+Savant – Ascent Remix,Nintendo Switch
+Schim,Nintendo Switch
+Schim,Nintendo Switch
+Sclash,Nintendo Switch
+Scott Pilgrim vs. The World: The Game – Complete Edition,Nintendo Switch
+ScourgeBringer,Nintendo Switch
+ScourgeBringer,Nintendo Switch
+Sd Gundam G Generation Genesis,Nintendo Switch
+Sea Of Stars,Nintendo Switch
+Sea Of Stars,Nintendo Switch
+Sea Of Stars,Nintendo Switch
+Seers Isle,Nintendo Switch
+Sega Ages – Virtua Racing,Nintendo Switch
+Senran Kagura Peach Ball,Nintendo Switch
+Senran Kagura Peach Ball,Nintendo Switch
+Serial Cleaner,Nintendo Switch
+Shadow Labyrinth,Nintendo Switch
+Shadowrun Returns,Nintendo Switch
+Shantae Half Genie Hero,Nintendo Switch
+Shantae: 1/2 Genie Hero – Ultimate Edition,Nintendo Switch
+Shantae: 1/2 Genie Hero – Ultimate Edition,Nintendo Switch
+Shashingo: Learn Japanese With Photography,Nintendo Switch
+Shin Megami Tensei III Nocturne HD Remaster,Nintendo Switch
+Shin Megami Tensei III Nocturne HD Remaster,Nintendo Switch
+Shin Megami Tensei Vengeance,Nintendo Switch
+Shin Megami Tensei Vengeance,Nintendo Switch
+Shin-Chan: Shiro And The Coal Town,Nintendo Switch
+Shiren The Wanderer: The Mystery Dungeon Of Serpentcoil Island,Nintendo Switch
+Shogun Showdown,Nintendo Switch
+Shovel Knight King Of Cards,Nintendo Switch
+Shovel Knight Shovel Of Hope,Nintendo Switch
+Shovel Knight: Treasure Trove,Nintendo Switch
+Sifu,Nintendo Switch
+Signalis,Nintendo Switch
+Signalis,Nintendo Switch
+Skater Xl,Nintendo Switch
+Skater Xl,Nintendo Switch
+Skul: The Hero Slayer,Nintendo Switch
+Skullgirls: 2nd Encore,Nintendo Switch
+Sky Oceans: Wings For Hire,Nintendo Switch
+Sky Rogue,Nintendo Switch
+Skylanders Imaginators,Nintendo Switch
+Skylanders Imaginators,Nintendo Switch
+Skylanders Imaginators,Nintendo Switch
+Skyrim,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slayers X: Terminal Aftermath: Vengance Of The Slayer,Nintendo Switch
+Slime 3k – Rise Against Despot,Nintendo Switch
+Slime Rancher,Nintendo Switch
+Sludge Life,Nintendo Switch
+Snake Pass,Nintendo Switch
+Sniper Elite 3: Ultimate Edition,Nintendo Switch
+Sniper Elite 4,Nintendo Switch
+Sniper Elite 4,Nintendo Switch
+Snk Heroines Tag Team Frenzy,Nintendo Switch
+SNK vs. Capcom: SVC Chaos,Nintendo Switch
+Snowboarding The Next Phase,Nintendo Switch
+Solar Ash,Nintendo Switch
+Sonic Frontiers,Nintendo Switch
+Sonic Frontiers,Nintendo Switch
+Sonic Generations,Nintendo Switch
+Sonic Mania,Nintendo Switch
+Sonic Origins,Nintendo Switch
+Sonic Superstars,Nintendo Switch
+Sonic Superstars,Nintendo Switch
+Sonic Wings Reunion,Nintendo Switch
+Sonic X Shadow Generations,Nintendo Switch
+Sonic X Shadow Generations,Nintendo Switch
+Sonic X Shadow Generations,Nintendo Switch
+South Park: The Fractured Butt Whole,Nintendo Switch
+South Park: The Stick Of Truth,Nintendo Switch
+South Park: The Stick Of Truth,Nintendo Switch
+Speed Overflow,Nintendo Switch
+Speed Overflow,Nintendo Switch
+Spelunky,Nintendo Switch
+Spelunky 2,Nintendo Switch
+Spelunky 2,Nintendo Switch
+Spintires: Mud Runner (Mudrunner – American Wilds),Nintendo Switch
+Spirit Hunter: Death Mark 2,Nintendo Switch
+Splatoon 3,Nintendo Switch
+Spongebob Squarepants: The Cosmic Shake,Nintendo Switch
+Spyro Reignited Trilogy,Nintendo Switch
+Spyro Reignited Trilogy,Nintendo Switch
+Spyro Reignited Trilogy,Nintendo Switch
+Stacklands,Nintendo Switch
+Stacklands,Nintendo Switch
+Star Ocean: First Departure R,Nintendo Switch
+Star Ocean: The Second Story R,Nintendo Switch
+Star Ocean: The Second Story R,Nintendo Switch
+Star Of Providence,Nintendo Switch
+Star Overdrive,Nintendo Switch
+Star Wars – Knights Of The Old Republic,Nintendo Switch
+Star Wars – Knights Of The Old Republic II,Nintendo Switch
+Star Wars The Force Unleashed,Nintendo Switch
+Star Wars: Dark Forces,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Steamworld Build,Nintendo Switch
+Steamworld Dig,Nintendo Switch
+Steamworld Heist II,Nintendo Switch
+Steins Gate: My Darlings Embrace,Nintendo Switch
+Steins;Gate Elite,Nintendo Switch
+Stella Of The End,Nintendo Switch
+Story Of Seasons: Friends Of Mineral Town,Nintendo Switch
+Story Of Seasons: Pioneers Of Olive Town,Nintendo Switch
+Stranger Things,Nintendo Switch
+Stray,Nintendo Switch
+Streets Of Rage 4,Nintendo Switch
+Streets Of Rage 4,Nintendo Switch
+Streets Of Rogue,Nintendo Switch
+Strike Suit Zero,Nintendo Switch
+Subnautica,Nintendo Switch
+Subnautica,Nintendo Switch
+Suika Game,Nintendo Switch
+Suika Game,Nintendo Switch
+Suikoden I & Ii Hd Remaster: Gate Rune And Dunan Unification Wars,Nintendo Switch
+Super Bomberman R,Nintendo Switch
+Super Bomberman R 2,Nintendo Switch
+Super Lone Survivor,Nintendo Switch
+Super Mario 3d All Stars,Nintendo Switch
+Super Mario 3D All Stars,Nintendo Switch
+Super Mario 3D World + Bowser’s Fury,Nintendo Switch
+Super Mario 3D World + Bowser’s Fury,Nintendo Switch
+Super Mario 3D World + Bowser’s Fury,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Maker 2,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Party Jamboree,Nintendo Switch
+Super Mario RPG,Nintendo Switch
+Super Mario RPG,Nintendo Switch
+Super Mario RPG,Nintendo Switch
+Super Mario Wonder,Nintendo Switch
+Super Meat Boy,Nintendo Switch
+Super Monkey Ball Banana Rumble,Nintendo Switch
+Super Monkey Ball Banana Rumble,Nintendo Switch
+Super Robot Wars,Nintendo Switch
+Super Smash Bros Ultimate,Nintendo Switch
+Super Smash Bros Ultimate,Nintendo Switch
+Super Smash Bros Ultimate,Nintendo Switch
+Super Woden GP 2,Nintendo Switch
+Superhot,Nintendo Switch
+Sword Of The Vagrant,Nintendo Switch
+Symphonia,Nintendo Switch
+Tactics Ogre Reborn,Nintendo Switch
+Tales Of Vesperia,Nintendo Switch
+Teenage Mutant Ninja Turtles: Mutants Unleashed,Nintendo Switch
+Teenage Mutant Ninja Turtles: Shredders Revenge,Nintendo Switch
+Teenage Mutant Ninja Turtles: Shredders Revenge,Nintendo Switch
+Teenage Mutant Ninja Turtles: Splintered Fate,Nintendo Switch
+Teenage Mutant Ninja Turtles: Splintered Fate,Nintendo Switch
+Teenage Mutant Ninja Turtles: Splintered Fate,Nintendo Switch
+Tennis In The Face,Nintendo Switch
+Terminal Velocity,Nintendo Switch
+Terraria,Nintendo Switch
+Terraria,Nintendo Switch
+Terraria,Nintendo Switch
+Teslagrad,Nintendo Switch
+Tetris 99,Nintendo Switch
+Tetris Effect,Nintendo Switch
+Thank Goodness You’re Here!,Nintendo Switch
+The Binding Of Isaac: Afterbirth+,Nintendo Switch
+The Binding Of Isaac: Repentance,Nintendo Switch
+The Binding Of Isaac: Repentance,Nintendo Switch
+The Binding Of Isaac: Repentance,Nintendo Switch
+The Case Of The Golden Idol,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Flame In The Flood,Nintendo Switch
+The Hong Kong Massacre,Nintendo Switch
+The House In Fata Morgana: Dreams Of The Revenants Edition,Nintendo Switch
+The House Of The Dead Remake,Nintendo Switch
+The Hundred Line: Last Defense Academy,Nintendo Switch
+The King of Fighters XIII: Global Match,Nintendo Switch
+The King of Fighters XIII: Global Match,Nintendo Switch
+The Last Campfire,Nintendo Switch
+The Legend Of Heroes: Trails From Zero,Nintendo Switch
+The Legend Of Heroes: Trails From Zero,Nintendo Switch
+The Legend Of Heroes: Trails To Azure,Nintendo Switch
+The Legend Of Heroes: Trials Through Daybreak,Nintendo Switch
+The Legend Of Zelda: Breath Of The Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend Of Zelda: Echoes Of Wisdom,Nintendo Switch
+The Legend Of Zelda: Echoes Of Wisdom,Nintendo Switch
+The Legend Of Zelda: Skyward Sword HD,Nintendo Switch
+The Legend Of Zelda: Skyward Sword HD,Nintendo Switch
+The Legend Of Zelda: Skyward Sword HD,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Messenger,Nintendo Switch
+The Messenger,Nintendo Switch
+The Messenger,Nintendo Switch
+The Outer Worlds,Nintendo Switch
+The Outer Worlds,Nintendo Switch
+The Pathless,Nintendo Switch
+The Pedestrian,Nintendo Switch
+The Plucky Squire,Nintendo Switch
+The Plucky Squire,Nintendo Switch
+The Settlers: New Allies,Nintendo Switch
+The Smurfs 2 : The Prisoner Of The Green Stone,Nintendo Switch
+The Smurfs Mission Villeaf,Nintendo Switch
+The Stanley Parable: Ultra Deluxe,Nintendo Switch
+The Tale Of Bistun,Nintendo Switch
+The Thing Remastered,Nintendo Switch
+The Wandering Village,Nintendo Switch
+The Wardrobe: Even Better Edition,Nintendo Switch
+The Wild At Heart,Nintendo Switch
+The Witcher 3: Wild Hunt,Nintendo Switch
+The World Ends With You: Final Remix,Nintendo Switch
+There Is No Game,Nintendo Switch
+Thief Simulator,Nintendo Switch
+This War Of Mine Complete Edition,Nintendo Switch
+Thronefall,Nintendo Switch
+Thunder Ray,Nintendo Switch
+Titan Quest,Nintendo Switch
+To The Moon,Nintendo Switch
+Toem,Nintendo Switch
+Toki,Nintendo Switch
+Toki,Nintendo Switch
+Tokyo Mirage Sessions #Fe Encore,Nintendo Switch
+Tomb Raider I-III Remastered,Nintendo Switch
+Tomb Raider I-III Remastered,Nintendo Switch
+Tonight We Riot,Nintendo Switch
+Tony Hawk’s Pro Skater 1+2,Nintendo Switch
+Tony Hawk’s Pro Skater 1+2,Nintendo Switch
+Torchlight 2,Nintendo Switch
+Torchlight 3,Nintendo Switch
+Torchlight II,Nintendo Switch
+Torchlight II,Nintendo Switch
+Torchlight II,Nintendo Switch
+Totally Accurate Battle Simulator,Nintendo Switch
+Transistor,Nintendo Switch
+Trek To Yomi,Nintendo Switch
+Trials Of Mana,Nintendo Switch
+Triangle Strategy,Nintendo Switch
+Triangle Strategy,Nintendo Switch
+Trinity Trigger,Nintendo Switch
+Trombone Champ,Nintendo Switch
+Trouser Critters Long Dagger,Nintendo Switch
+Trouser Critters Long Dagger,Nintendo Switch
+Trouser Critters Shiny Clam Rocks,Nintendo Switch
+Tsukihime – A Piece Of Blue Glass Moon,Nintendo Switch
+Tunic,Nintendo Switch
+Tunic,Nintendo Switch
+Turbo Overkill,Nintendo Switch
+Turbo Overkill,Nintendo Switch
+Twelve Minutes,Nintendo Switch
+Two Point Hospital,Nintendo Switch
+Ubermosh: Omega,Nintendo Switch
+Ugly,Nintendo Switch
+Ultimate Marvel vs. Capcom 3,Nintendo Switch
+Ultra Street Fighter II: The Final Challengers,Nintendo Switch
+Ultra Street Fighter II: The Final Challengers,Nintendo Switch
+Umineko No Naku Koro Ni Catbox,Nintendo Switch
+Unavowed,Nintendo Switch
+Undead Horde,Nintendo Switch
+Undead Horde 2,Nintendo Switch
+Under Defeat,Nintendo Switch
+Undermine,Nintendo Switch
+Undernauts: Labyrinth Of Yomi,Nintendo Switch
+Undertale,Nintendo Switch
+Undertale,Nintendo Switch
+Unicorn Overlord,Nintendo Switch
+Unicorn Overlord,Nintendo Switch
+Unmetal,Nintendo Switch
+Unsighted,Nintendo Switch
+Urban Myth Dissolution Center,Nintendo Switch
+Valiant Hearts: The Great War,Nintendo Switch
+Valkyria Chronicles,Nintendo Switch
+Valkyria Chronicles 4,Nintendo Switch
+Vampire Hunters,Nintendo Switch
+Vampire Survivors,Nintendo Switch
+Velocity 2x,Nintendo Switch
+Victory Heat Rally,Nintendo Switch
+Victory Heat Rally,Nintendo Switch
+Void Bastards,Nintendo Switch
+Void Prison,Nintendo Switch
+Void Prison,Nintendo Switch
+Void Scrappers,Nintendo Switch
+Void Scrappers,Nintendo Switch
+Void Scrappers,Nintendo Switch
+Voidwrought,Nintendo Switch
+Voltaire: The Vegan Vampire,Nintendo Switch
+Wall World,Nintendo Switch
+Wargroove,Nintendo Switch
+"Warhammer 40,000: Boltgun",Nintendo Switch
+Wavetale,Nintendo Switch
+We Love Katamari Reroll+ Royal Reverie,Nintendo Switch
+What Lies In The Multiverse,Nintendo Switch
+What Remains Of Edith Finch,Nintendo Switch
+What The Golf,Nintendo Switch
+Wild Bastards,Nintendo Switch
+Wild Bastards,Nintendo Switch
+Windjammers 2,Nintendo Switch
+Wolffang Skullfang,Nintendo Switch
+World Of Goo,Nintendo Switch
+World Of Horror,Nintendo Switch
+Worms Armageddon: Anniversary Edition,Nintendo Switch
+Wytchwood,Nintendo Switch
+XCOM 2,Nintendo Switch
+Xenoblade Chronicles 2,Nintendo Switch
+Xenoblade Chronicles X: Definitive Edition,Nintendo Switch
+Xenoblade Chronicles X: Definitive Edition,Nintendo Switch
+XIII,Nintendo Switch
+Yakuza Kiwami,Nintendo Switch
+Yakuza Kiwami,Nintendo Switch
+Yo-Kai Watch 1 For Nintendo Switch,Nintendo Switch
+Yokai Watch 1,Nintendo Switch
+Yokai Watch 4,Nintendo Switch
+Yoku’s Island Express,Nintendo Switch
+Yooka-Laylee And The Impossible Lair,Nintendo Switch
+Yoshi’s Crafted World,Nintendo Switch
+You Suck At Parking,Nintendo Switch
+Youtubers Life,Nintendo Switch
+Ys IX: Monstrum Nox,Nintendo Switch
+Ys IX: Monstrum Nox,Nintendo Switch
+Ys Memoire: The Oath In Felghana,Nintendo Switch
+Ys Memoire: The Oath In Felghana,Nintendo Switch
+Ys Origin,Nintendo Switch
+Ys Viii,Nintendo Switch
+Planet Of Lana,Nintendo Switch
+Xenoblade Chronicles Definitive Edition,Nintendo Switch
+Castle Crashers,Nintendo Switch
+The Legend Of Heroes: Trails From Zero,Nintendo Switch
+Front Mission 3,Nintendo Switch
+9th Dawn Remake,Nintendo Switch
+A Short Hike,Nintendo Switch
+Ace Attorney Investigations Collection,Nintendo Switch
+Advance Wars 1+2 Re-boot Camp,Nintendo Switch
+Animal Crossing New Horizons,Nintendo Switch
+Animal Well,Nintendo Switch
+Annalynn,Nintendo Switch
+Another Code Recollection,Nintendo Switch
+Ao Tennis 2,Nintendo Switch
+Astral Ascent,Nintendo Switch
+Astral Chain,Nintendo Switch
+Axiom Verge,Nintendo Switch
+20 Minutes Till Dawn,Nintendo Switch
+30xx,Nintendo Switch
+Anomaly Agent,Nintendo Switch
+Armored Lab Force Vulvehicles,Nintendo Switch
+Ato,Nintendo Switch
+"Warhammer 40,000: Boltgun",Nintendo Switch
+Balatro,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+Ender Magnolia Bloom In The Mist,Nintendo Switch
+Pinball Fx,Nintendo Switch
+Cookie Clicker,Nintendo Switch
+The Legend Of Zelda: Echoes Of Wisdom,Nintendo Switch
+Raidou Remastered The Mystery Of The Soulless Army,Nintendo Switch
+Outlast,Nintendo Switch
+Ufo 50,Nintendo Switch
+Ufo 50,Nintendo Switch
+Saints Row Iv,Nintendo Switch
+Warriors Abyss,Nintendo Switch
+Naruto Ultimate Ninja Storm 2,Nintendo Switch
+Minecraft: Nintendo Switch Edition (legacy Console),Nintendo Switch
+Factorio,Nintendo Switch
+Pokken Tournament Dx,Nintendo Switch
+Hatsune Miku: Project Diva Mega Mix,Nintendo Switch
+Dragon Ball Xenoverse 2,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Enclave Hd,Nintendo Switch
+Outward – Definitive Edition,Nintendo Switch
+Sifu,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+Mega Man 11,Nintendo Switch
+Dragon Ball Fighterz,Nintendo Switch
+Dragon Ball Fighterz,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+8-bit Adventures 2,Nintendo Switch
+,Nintendo Switch
+.Hack//G.U. Last Recode,Nintendo Switch
+#DRIVE,Perfect,Turnip 24.3.0 9v2,Eden,1.0,,2025/07/23,Nintendo Switch
+8-Bit Adventures 2,Nintendo Switch
+12 Is Better Than 6,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+13 Sentinels: Aegis Rim,Nintendo Switch
+20 Minutes Till Dawn,Nintendo Switch
+30xx,Nintendo Switch
+60 Seconds Reatomized,Nintendo Switch
+80’s Overdrive,Nintendo Switch
+198x,Nintendo Switch
+3000th Duel,Nintendo Switch
+A Boy And His Blob,Nintendo Switch
+A Hat In Time,Nintendo Switch
+A Highland Song,Nintendo Switch
+A Juggler’s Tale,Nintendo Switch
+A Little To The Left,Nintendo Switch
+A Memoir Blue,Nintendo Switch
+A Short Hike,Nintendo Switch
+A Sketchbook About Her Sun,Nintendo Switch
+Abomi Nation,Nintendo Switch
+Abzu,Nintendo Switch
+Ace Attorney Investigations Collection,Nintendo Switch
+Ace Attorney Investigations Collection,Nintendo Switch
+Ace Combat 7: Skies Unknown,Nintendo Switch
+Advance Wars 1+2: Re-boot Camp,Nintendo Switch
+Advance Wars 1+2: Re-Boot Camp,Nintendo Switch
+Aeon Drive,Nintendo Switch
+Aery Early Birds Bundle,Nintendo Switch
+Aew Fight Forever,Nintendo Switch
+Afterimage,Nintendo Switch
+Agatha Christie – Murder On The Orient Express,Nintendo Switch
+Ak-Xolotl,Nintendo Switch
+Akane,Nintendo Switch
+Alan Wake Remastered,Nintendo Switch
+Alba,Nintendo Switch
+Alex Kidd In Miracle World Dx,Nintendo Switch
+Alien Hominid HD,Nintendo Switch
+Alien: Isolation,Nintendo Switch
+Alphadia Genesis 2,Nintendo Switch
+Alwa’s Awakening,Nintendo Switch
+Angry Video Game Nerd I & II Deluxe,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Crossing: New Horizons,Nintendo Switch
+Animal Well,Nintendo Switch
+Animal Well,Nintendo Switch
+Animal Well,Nintendo Switch
+Animus: Revenant,Nintendo Switch
+Anno: Mutationem,Nintendo Switch
+Anno: Mutationem,Nintendo Switch
+Anodyne 2 : Return To Dust,Nintendo Switch
+Anomaly Agent,Nintendo Switch
+Anomaly Collapse,Nintendo Switch
+Another Code: Recollection,Nintendo Switch
+Another Code: Recollection,Nintendo Switch
+Another Crab’s Treasure,Nintendo Switch
+Ape Out,Nintendo Switch
+Apico,Nintendo Switch
+Apollo Justice: Ace Attorney Trilogy,Nintendo Switch
+Aragami: Shadow Edition,Nintendo Switch
+Arcade Paradise,Nintendo Switch
+Arcade Tanks World: Tank Battle Simulator,Nintendo Switch
+Archvale,Nintendo Switch
+Arietta Of Spirits,Nintendo Switch
+Arms,Nintendo Switch
+Army Of Ruin,Nintendo Switch
+Arrog,Nintendo Switch
+Art Of Rally,Nintendo Switch
+Asdivine Hearts,Nintendo Switch
+Aspire: Ina’s Tale,Nintendo Switch
+Assassin’s Creed 2,Nintendo Switch
+Assassin’s Creed 4,Nintendo Switch
+Assassin’s Creed 4,Nintendo Switch
+Assassin’s Creed: The Ezio Collection,Nintendo Switch
+Assassin’s Creed: The Rebel Collection,Nintendo Switch
+Assassin’s Creed: The Rebel Collection,Nintendo Switch
+Astalon: Tears Of The Earth,Nintendo Switch
+Astalon: Tears Of The Earth,Nintendo Switch
+Astebreed,Nintendo Switch
+Asterix & Obelix Xxl3: The Crystal Menhir,Nintendo Switch
+Asterix & Obelix Xxxl: The Ram From Hibernia,Nintendo Switch
+Astlibra Revision,Nintendo Switch
+Astral Ascent,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Chain,Nintendo Switch
+Astral Flux,Nintendo Switch
+Astral Flux,Nintendo Switch
+Astroneer,Nintendo Switch
+Atelier Ayesha: The Alchemist of Dusk DX,Nintendo Switch
+Atelier Marie Remake: The Alchemist of Salburg,Nintendo Switch
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Nintendo Switch
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Nintendo Switch
+Atelier Ryza: Ever Darkness & The Secret Hideout,Nintendo Switch
+Atelier Shallie: Alchemists of the Dusk Sea DX,Nintendo Switch
+Atone: Heart Of The Elder Tree,Nintendo Switch
+Avicci Invector,Nintendo Switch
+Azura’s Crystals,Nintendo Switch
+Azure Striker Gunvolt: Striker Pack,Nintendo Switch
+Baba Is You,Nintendo Switch
+Badland: Game Of The Year Edition,Nintendo Switch
+Bakeru,Nintendo Switch
+Balatro,Nintendo Switch
+Balatro,Nintendo Switch
+Balatro,Nintendo Switch
+Baldo The Guardian Owls,Nintendo Switch
+Baldur’s Gate And Baldur’s Gate II: Enhanced Editions,Nintendo Switch
+Barbie Dreamhouse Adventures,Nintendo Switch
+Bastion,Nintendo Switch
+Bastion,Nintendo Switch
+Bat Boy,Nintendo Switch
+Batman Arkham Asylum,Nintendo Switch
+Batman Arkham Asylum,Nintendo Switch
+Batman Arkham Asylum,Nintendo Switch
+Batman Arkham City,Nintendo Switch
+Batman Arkham City,Nintendo Switch
+Batman: The Telltale Series,Nintendo Switch
+Battle Brothers,Nintendo Switch
+Battle Chasers: Nightwar,Nintendo Switch
+Battle Kid: Fortress Of Peril,Nintendo Switch
+Bayonetta,Nintendo Switch
+Bayonetta,Nintendo Switch
+Bayonetta 2,Nintendo Switch
+Bayonetta 3,Nintendo Switch
+Bayonetta Origins: Cereza And The Lost Demon,Nintendo Switch
+Beasts Of Maravilla Island,Nintendo Switch
+Beat Cop,Nintendo Switch
+Belle Boomerang,Nintendo Switch
+Beyblade X Xone,Nintendo Switch
+Beyblade X Xone,Nintendo Switch
+Beyond A Steel Sky,Nintendo Switch
+Beyond Good And Evil – 20th Anniversary Edition,Nintendo Switch
+Big Helmet Heroes,Nintendo Switch
+"Big Kitty, Little City",Nintendo Switch
+Biomutant,Nintendo Switch
+Bioshock Remastered,Nintendo Switch
+Bite The Bullet,Nintendo Switch
+Black Skylands,Nintendo Switch
+Black Witchcraft,Nintendo Switch
+Black Witchcraft,Nintendo Switch
+Blade Assault,Nintendo Switch
+Blade Chimera,Nintendo Switch
+Blade Chimera,Nintendo Switch
+Blade Runner Enhanced Edition,Nintendo Switch
+Bladed Fury,Nintendo Switch
+Blair Witch,Nintendo Switch
+Blanc,Nintendo Switch
+Blasphemous,Nintendo Switch
+Blasphemous,Nintendo Switch
+Blasphemous 2,Nintendo Switch
+Blasphemous 2,Nintendo Switch
+Blast Brigade vs. The Evil Legion Of Dr. Cread,Nintendo Switch
+Blazing Strike,Nintendo Switch
+Bloodstained – Curse Of The Moon,Nintendo Switch
+Bloodstained: Ritual Of The Night,Nintendo Switch
+Bloomtown: A Different Story,Nintendo Switch
+Bluey: The Videogame,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bomb Rush Cyberfunk,Nintendo Switch
+Bonds Of The Skies,Nintendo Switch
+Boomerang Fu,Nintendo Switch
+Boot Hill Heroes,Nintendo Switch
+Borderlands,Nintendo Switch
+Borderlands 2,Nintendo Switch
+Borderlands: The Pre-Sequel Ultimate Edition,Nintendo Switch
+Boreal Tenebrae,Nintendo Switch
+Born Of Bread,Nintendo Switch
+Born Of Bread,Nintendo Switch
+Boti: Byteland Overclocked,Nintendo Switch
+Braid Anniversary Edition,Nintendo Switch
+Bramble The Mountain King,Nintendo Switch
+Bravely Default II,Nintendo Switch
+Breathedge,Nintendo Switch
+Brewmaster Beer Brewing Simulator,Nintendo Switch
+Broforce,Nintendo Switch
+Brotato,Nintendo Switch
+Brothers,Nintendo Switch
+Bud Spencer & Terence Hill – Slaps And Beans 2,Nintendo Switch
+Bug Fables,Nintendo Switch
+Bugsnax,Nintendo Switch
+Bulletstorm Duke Of Switch Edition,Nintendo Switch
+Bulletstorm Duke Of Switch Edition,Nintendo Switch
+Burnout Legends,Nintendo Switch
+Burnout Paradise Remastered,Nintendo Switch
+Burnout Paradise Remastered,Nintendo Switch
+Butcher,Nintendo Switch
+Bzzzt,Nintendo Switch
+Bzzzt,Nintendo Switch
+Cadence Of Hyrule: Crypt Of The Necrodancer,Nintendo Switch
+Call Of Juarez: Gunslinger,Nintendo Switch
+Capcom Fighting Collection 2,Nintendo Switch
+Captai,Nintendo Switch
+Captain Toad: Treasure Tracker,Nintendo Switch
+Captain Toad: Treasure Tracker,Nintendo Switch
+Caravan Sandwich,Nintendo Switch
+Carrion,Nintendo Switch
+Carto,Nintendo Switch
+Cassette Beasts,Nintendo Switch
+Castlestorm,Nintendo Switch
+Castlestorm 2,Nintendo Switch
+Castlevania Anniversary Collection,Nintendo Switch
+Castlevania Dominus Collection,Nintendo Switch
+Cat Quest,Nintendo Switch
+Cat Quest III,Nintendo Switch
+Cat Quest III,Nintendo Switch
+Catan Console Edition,Nintendo Switch
+Catan Console Edition,Nintendo Switch
+Catastronauts!,Nintendo Switch
+Catherine: Full Body,Nintendo Switch
+Cave Story+,Nintendo Switch
+Cel Damage Hd,Nintendo Switch
+Celeste,Nintendo Switch
+Celeste,Nintendo Switch
+Celeste,Nintendo Switch
+Celeste,Nintendo Switch
+Chained Echoes,Nintendo Switch
+Chicken Police,Nintendo Switch
+Child Of Light Ultimate Edition,Nintendo Switch
+Chocobo Gp,Nintendo Switch
+Choo-Choo Charles,Nintendo Switch
+Chrono Cross – The Radical Dreamers Edition,Nintendo Switch
+Circuit Superstars,Nintendo Switch
+Citizen Sleeper,Nintendo Switch
+Citizen Sleeper,Nintendo Switch
+Civilization II,Nintendo Switch
+Clubhouse Games,Nintendo Switch
+Cluster Truck,Nintendo Switch
+Cobalt Core,Nintendo Switch
+Code Of Princess Ex,Nintendo Switch
+Code Realize Wintertide Miracles,Nintendo Switch
+Coffee Talk,Nintendo Switch
+Collection Of Mana,Nintendo Switch
+Commandos 2 – HD Remaster,Nintendo Switch
+Commandos 3 – HD Remaster,Nintendo Switch
+Company Of Heroes,Nintendo Switch
+Contra Operation Galuga,Nintendo Switch
+Contra Operation Galuga,Nintendo Switch
+Core Keeper,Nintendo Switch
+Corpse Party,Nintendo Switch
+Crash Bandicoot 4,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Bandicoot N. Sane Trilogy,Nintendo Switch
+Crash Team Racing: Nitro-Fueled,Nintendo Switch
+Crash Team Racing: Nitro-Fueled,Nintendo Switch
+Crash Team Racing: Nitro-Fueled,Nintendo Switch
+Crashlands,Nintendo Switch
+Crawl,Nintendo Switch
+Creepy Tale,Nintendo Switch
+Cris Tales,Nintendo Switch
+Crisis Core: Final Fantasy II Reunion,Nintendo Switch
+Crosscode,Nintendo Switch
+Crow Country,Nintendo Switch
+Crow Country,Nintendo Switch
+Crown Trick,Nintendo Switch
+Cruis’n Blast,Nintendo Switch
+Cruis’n Blast,Nintendo Switch
+Crumble,Nintendo Switch
+Crymachina,Nintendo Switch
+Crypt Custodian,Nintendo Switch
+Crypt Custodian,Nintendo Switch
+Crysis Remastered,Nintendo Switch
+Crystal Breaker,Nintendo Switch
+Ctr: Nitro Fueled,Nintendo Switch
+Cult Of The Lamb,Nintendo Switch
+Cult Of The Lamb,Nintendo Switch
+Cult Of The Lamb,Nintendo Switch
+Cuphead,Nintendo Switch
+Cuphead In The Delicious Last Course,Nintendo Switch
+Curse Of The Dead Gods,Nintendo Switch
+Cursed To Golf,Nintendo Switch
+Cyberage,Nintendo Switch
+Dadish,Nintendo Switch
+Dadish 3D,Nintendo Switch
+Danganronpa: Trigger Happy Havoc Anniversary Edition,Nintendo Switch
+Dark Devotion,Nintendo Switch
+Dark Souls 1,Nintendo Switch
+Dark Souls Remastered,Nintendo Switch
+Darkest Dungeon II,Nintendo Switch
+Darkest Dungeon II,Nintendo Switch
+Darksiders I,Nintendo Switch
+Darksiders II,Nintendo Switch
+Darksiders Warmastered Edition,Nintendo Switch
+Darkwood,Nintendo Switch
+Date Everything!,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dave The Diver,Nintendo Switch
+Dawn Of The Monsters,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead Cells,Nintendo Switch
+Dead End Job,Nintendo Switch
+Death Elevator 2,Nintendo Switch
+Death Mark,Nintendo Switch
+Death Tales,Nintendo Switch
+Death’s Door,Nintendo Switch
+Death’s Gambit: Afterlife,Nintendo Switch
+Deemo -Reborn-,Nintendo Switch
+Deltarune,Nintendo Switch
+Deltarune,Nintendo Switch
+Demon Turf,Nintendo Switch
+Demon’s Tilt,Nintendo Switch
+Destroy All Humans!,Nintendo Switch
+Destroy All Humans!,Nintendo Switch
+Destroy All Humans!,Nintendo Switch
+Detective Pikachu Returns,Nintendo Switch
+Detective Pikachu Returns,Nintendo Switch
+Devil Engine Complete Edition,Nintendo Switch
+Devil May Cry 1,Nintendo Switch
+Devil May Cry 3 Special Edition,Nintendo Switch
+Dex,Nintendo Switch
+Diablo 2: Resurrected,Nintendo Switch
+Diablo 3: Eternal Collection,Nintendo Switch
+Diablo 3: Eternal Collection,Nintendo Switch
+Diablo III,Nintendo Switch
+Diablo III,Nintendo Switch
+Dicey Dungeons,Nintendo Switch
+Die After Sunset,Nintendo Switch
+Diesel Legacy: The Brazen Age,Nintendo Switch
+Digimon Cyber Sleuth,Nintendo Switch
+Digimon Story Cyber Sleuth: Complete Edition,Nintendo Switch
+Digimon Survive,Nintendo Switch
+Digimon World -Next Order-,Nintendo Switch
+Disco Elysium – The Final Cut,Nintendo Switch
+Disco Elysium – The Final Cut,Nintendo Switch
+Disgaea 5 Complete,Nintendo Switch
+Disney Dreamlight Valley,Nintendo Switch
+Disney Epic Mickey: Rebrushed,Nintendo Switch
+Disney Illusion Island,Nintendo Switch
+Divinity Original Sin 2,Nintendo Switch
+Doctor Who: Edge Of Reality,Nintendo Switch
+Dodgeball Academia,Nintendo Switch
+Dogman: Mission Impawssible,Nintendo Switch
+Dogurai,Nintendo Switch
+Don’t Starve Nintendo Switch Edition,Nintendo Switch
+Don’t Starve Together,Nintendo Switch
+Donkey Kong Country Returns HD,Nintendo Switch
+Donkey Kong Country Returns HD,Nintendo Switch
+Donkey Kong Country: Tropical Freeze,Nintendo Switch
+Donkey Kong Country: Tropical Freeze,Nintendo Switch
+Donkey Kong Country: Tropical Freeze,Nintendo Switch
+Donut Dodo,Nintendo Switch
+Donuts’n’justice,Nintendo Switch
+Doom (2016),Nintendo Switch
+Doom + Doom 2,Nintendo Switch
+Doom 64,Nintendo Switch
+Doraemon Dorayaki Shop Story,Nintendo Switch
+Dorfromantik,Nintendo Switch
+Double Dragon Neon,Nintendo Switch
+Dragon Ball FighterZ,Nintendo Switch
+Dragon Ball FighterZ,Nintendo Switch
+Dragon Ball FighterZ,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Dragon Marked For Death: Advanced Attackers,Nintendo Switch
+Dragon Quest Builders,Nintendo Switch
+Dragon Quest Builders 2,Nintendo Switch
+Dragon Quest III HD-2D Remake,Nintendo Switch
+Dragon Quest III HD-2D Remake,Nintendo Switch
+Dragon Quest III HD-2D Remake,Nintendo Switch
+Dragon Quest Monsters,Nintendo Switch
+Dragon Quest X,Nintendo Switch
+Dragon Quest XI S: Echoes Of An Elusive Age,Nintendo Switch
+Dragon’s Dogma: Dark Arisen,Nintendo Switch
+Draw A Stickman: Epic,Nintendo Switch
+Dreamscaper,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Dredge,Nintendo Switch
+Drone Pilot: Extreme Flight Simulator,Nintendo Switch
+Dros,Nintendo Switch
+Drova Forsaken Kin,Nintendo Switch
+Duck Detective: The Secret Salami,Nintendo Switch
+Duck Detective: The Secret Salami,Nintendo Switch
+Duck Game,Nintendo Switch
+Dungeonoid 2: Awakening,Nintendo Switch
+Dungeons And Doomknights,Nintendo Switch
+Dungeons Of Dreadrock – The Dead King’s Secret,Nintendo Switch
+Dungeons Of Dreadrock – The Dead King’s Secret,Nintendo Switch
+Dungreed,Nintendo Switch
+Dusk,Nintendo Switch
+Dusk Diver,Nintendo Switch
+Dust & Neon,Nintendo Switch
+Dust & Neon,Nintendo Switch
+Dust: An Elysian Tail,Nintendo Switch
+Dustoff Heli Rescue 2,Nintendo Switch
+Dying Light Definitive Collection,Nintendo Switch
+Dysmantle,Nintendo Switch
+Ea Sports Fc 25,Nintendo Switch
+Ea Sports Fc 25,Nintendo Switch
+Ea Sports Fc 25,Nintendo Switch
+Eastward,Nintendo Switch
+Eastward,Nintendo Switch
+Eastward: Octopia!,Nintendo Switch
+Echo Generation,Nintendo Switch
+Echoes Of The Plum Grove,Nintendo Switch
+Elderand,Nintendo Switch
+Eldest Souls,Nintendo Switch
+Elsie,Nintendo Switch
+Elypse,Nintendo Switch
+Elypse,Nintendo Switch
+Elypse,Nintendo Switch
+Emio: The Smiling Man – Famicom Detective Club,Nintendo Switch
+Empty Shell,Nintendo Switch
+Enclave HD,Nintendo Switch
+Ender Lilies: Quietus Of The Knights,Nintendo Switch
+Ender Magnolia Bloom In The Mist,Nintendo Switch
+Enraged Red Ogre,Nintendo Switch
+Enter The Gungeon,Nintendo Switch
+Enter The Gungeon,Nintendo Switch
+Eternal Edge,Nintendo Switch
+Eternights,Nintendo Switch
+Etrian Odyssey HD,Nintendo Switch
+Evasion From Hell,Nintendo Switch
+Everafter Falls,Nintendo Switch
+Everafter Falls,Nintendo Switch
+Everhood,Nintendo Switch
+Everspace,Nintendo Switch
+Exhausted Man,Nintendo Switch
+Exzeus Collection,Nintendo Switch
+F.I.S.T. Forged In Shadow Torch,Nintendo Switch
+Factorio,Nintendo Switch
+Fading Afternoon,Nintendo Switch
+Fairy Tail,Nintendo Switch
+Fallen Legion: Rise To Glory,Nintendo Switch
+Fantasian Neo Dimension,Nintendo Switch
+Fantasy Life – The Girl Who Steals Time,Nintendo Switch
+Fantasy Life – The Girl Who Steals Time,Nintendo Switch
+Fantasy Life – The Girl Who Steals Time,Nintendo Switch
+Far: Changing Tides,Nintendo Switch
+Fast Rmx,Nintendo Switch
+Fatal Frame: Maiden Of Black Water,Nintendo Switch
+Fatal Frame: Mask Of The Lunar Eclipse,Nintendo Switch
+Fate/samurai Remnant,Nintendo Switch
+Fate/Stay Night Remastered,Nintendo Switch
+Fez,Nintendo Switch
+Fifa 18,Nintendo Switch
+Fifa 18,Nintendo Switch
+Fifa 19,Nintendo Switch
+Fifa 23,Nintendo Switch
+Fighting Ex Layer Another Dash,Nintendo Switch
+Final Fantasy,Nintendo Switch
+Final Fantasy Crystal Chronicles Remastered,Nintendo Switch
+Final Fantasy II,Nintendo Switch
+Final Fantasy III,Nintendo Switch
+Final Fantasy IV,Nintendo Switch
+Final Fantasy Vi,Nintendo Switch
+Final Fantasy X HD Remaster,Nintendo Switch
+Final Fantasy X HD Remaster,Nintendo Switch
+Final Fantasy XII,Nintendo Switch
+Final Fantasy XV Pocket Edition,Nintendo Switch
+Final Vendetta,Nintendo Switch
+Finding Paradise,Nintendo Switch
+Fire Emblem Engage,Nintendo Switch
+Fire Emblem Warriors: Three Hopes,Nintendo Switch
+Fire Emblem: Engage,Nintendo Switch
+Fire Emblem: Three Houses,Nintendo Switch
+Firewatch,Nintendo Switch
+Firewatch,Nintendo Switch
+Five Nights At Freddy’s: Help Wanted 2,Nintendo Switch
+Five Nights At Freddy’s: Help Wanted 2,Nintendo Switch
+Five Nights At Freddy’s: Into The Pit,Nintendo Switch
+Five Nights At Freddy´s: Security Breach,Nintendo Switch
+Flat Kingdom Paper’s Cut Edition,Nintendo Switch
+Flynn Son Of Crimson,Nintendo Switch
+Fnaf Sb,Nintendo Switch
+Fobia,Nintendo Switch
+Food Delivery Battle,Nintendo Switch
+For A Vast Future,Nintendo Switch
+For The King,Nintendo Switch
+Forager,Nintendo Switch
+Forager,Nintendo Switch
+Forager,Nintendo Switch
+Forgive Me Father,Nintendo Switch
+Forgotten Anne,Nintendo Switch
+Fortress S,Nintendo Switch
+Freddi Fish 4: The Case Of The Hogfish Rustlers Of Briny Gulch,Nintendo Switch
+Freddy Spaghetti,Nintendo Switch
+Freedom Planet,Nintendo Switch
+Freedom Wars Remastered,Nintendo Switch
+Frog Detective: The Entire Mystery,Nintendo Switch
+Frogue,Nintendo Switch
+Frogun Deluxe Edition,Nintendo Switch
+From Heaven To Earth,Nintendo Switch
+Funko Fusion,Nintendo Switch
+Furi Definitive Edition,Nintendo Switch
+G.I. Joe: Wrath Of Cobra,Nintendo Switch
+Garden Story,Nintendo Switch
+Gear Club Unlimited 2,Nintendo Switch
+Genesis Noir,Nintendo Switch
+Ghost Of A Tale,Nintendo Switch
+Ghost Song,Nintendo Switch
+Ghost Sync,Nintendo Switch
+Ghost Trick: Phantom Detective,Nintendo Switch
+Ghostbusters: The Video Game – Remastered,Nintendo Switch
+Ghostrunner,Nintendo Switch
+Ghosts And Apples,Nintendo Switch
+Ghosts And Goblins Resurrection,Nintendo Switch
+Goblin Sword,Nintendo Switch
+Godstrike,Nintendo Switch
+Going Under,Nintendo Switch
+Golf Story,Nintendo Switch
+Golf With Your Friends,Nintendo Switch
+Good Job!,Nintendo Switch
+Gori: Cuddly Carnage,Nintendo Switch
+Gothic 2 Complete Classic,Nintendo Switch
+Grand Mountain Adventure,Nintendo Switch
+Grand Mountain Adventure: Wonderlands,Nintendo Switch
+Grandia HD Collection,Nintendo Switch
+Grapple Dog,Nintendo Switch
+Graveyard Keeper,Nintendo Switch
+Graveyard Keeper,Nintendo Switch
+Graveyard Keeper,Nintendo Switch
+Gravity Duck,Nintendo Switch
+Greak: Memories Of Azur,Nintendo Switch
+Grim Fandango Remastered,Nintendo Switch
+Grim Fandango Remastered,Nintendo Switch
+Grime,Nintendo Switch
+Grime – Definitive Edition,Nintendo Switch
+Gripper,Nintendo Switch
+Gris,Nintendo Switch
+Groove Coaster Wai Wai Party,Nintendo Switch
+Grounded,Nintendo Switch
+Grow: Song Of The Evertree,Nintendo Switch
+Gta: San Andreas – Definitive Edition,Nintendo Switch
+Guacamelee! 2,Nintendo Switch
+Guacamelee! Super Turbo Championship Edition,Nintendo Switch
+Guayota,Nintendo Switch
+Guilty Gear Strive,Nintendo Switch
+Gun Gore & Cannoli 2,Nintendo Switch
+Gunman Clive HD,Nintendo Switch
+Guns Of Fury,Nintendo Switch
+Guns Of Fury,Nintendo Switch
+Guns Of Fury,Nintendo Switch
+Gunslugs,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Hades,Nintendo Switch
+Happy’s Humble Burger Farm,Nintendo Switch
+Hatsune Miku: Project Diva Mega Mix,Nintendo Switch
+Have A Nice Death,Nintendo Switch
+Have A Nice Death,Nintendo Switch
+Heavenly Bodies,Nintendo Switch
+Heavenly Bodies,Nintendo Switch
+Hell Is Other Demons,Nintendo Switch
+Hell Pie,Nintendo Switch
+Hellblade: Senua’s Sacrifice,Nintendo Switch
+Hellboy Web Of Wyrd,Nintendo Switch
+Hello Kitty Island Adventure,Nintendo Switch
+Hello Neighbor,Nintendo Switch
+Hellpoint,Nintendo Switch
+Heretic’s Fork,Nintendo Switch
+High On Life,Nintendo Switch
+Hitman Blood Money Reprisal,Nintendo Switch
+Hitman Blood Money Reprisal,Nintendo Switch
+Hob: The Definitive Edition,Nintendo Switch
+Hogwarts Legacy: Deluxe Edition,Nintendo Switch
+Hollow Knight,Nintendo Switch
+Hollow Knight,Nintendo Switch
+Hollow Knight,Nintendo Switch
+Horizon Chase 2,Nintendo Switch
+Horizon Chase Turbo,Nintendo Switch
+Hotline Miami 1 & 2,Nintendo Switch
+Hotline Miami 1 & 2,Nintendo Switch
+Hotline Miami 1 & 2,Nintendo Switch
+Hotshot Racing,Nintendo Switch
+Hotshot Racing,Nintendo Switch
+Hotshot Racing,Nintendo Switch
+Hue,Nintendo Switch
+Huntdown,Nintendo Switch
+Hunter X,Nintendo Switch
+Hunterxhunter Nenximpact,Nintendo Switch
+Hyper Light Drifter,Nintendo Switch
+Hypnospace Outlaw,Nintendo Switch
+Hyrule Warriors: Age Of Calamity,Nintendo Switch
+Hyrule Warriors: Definitive Edition,Nintendo Switch
+Hyrule Warriors: Definitive Edition,Nintendo Switch
+I Am The Hero,Nintendo Switch
+Iconoclasts,Nintendo Switch
+Ikenfell,Nintendo Switch
+Immortals Fenyx Rising,Nintendo Switch
+In Other Waters,Nintendo Switch
+In Sound Mind,Nintendo Switch
+Inmost,Nintendo Switch
+Inscryption,Nintendo Switch
+Inscryption,Nintendo Switch
+Inside,Nintendo Switch
+Into The Breach,Nintendo Switch
+Into The Breach,Nintendo Switch
+Inukari – Chase Of Deception,Nintendo Switch
+Iris And The Giant,Nintendo Switch
+Iron Meat,Nintendo Switch
+Ironfall Invasion,Nintendo Switch
+Islanders,Nintendo Switch
+It Takes Two,Nintendo Switch
+Ittle Dew,Nintendo Switch
+Jack Move,Nintendo Switch
+Jamestown+,Nintendo Switch
+Jet Lancer,Nintendo Switch
+Jet Lancer,Nintendo Switch
+John Wick Hex,Nintendo Switch
+Jojo’s Bizarre Adventure: All-Star Battle R Deluxe Edition,Nintendo Switch
+Jujutsu Kaisen Cursed Clash,Nintendo Switch
+Jurassic World Evolution,Nintendo Switch
+Just Shapes & Beats,Nintendo Switch
+Kamen Rider Memory Of Heroez,Nintendo Switch
+Kamen Rider Memory Of Heroez Premium Sound Edition,Nintendo Switch
+Kamen Rider Memory Of Heroez Sound Edition,Nintendo Switch
+Kamibako – Mythology Of Cube,Nintendo Switch
+Kamiko,Nintendo Switch
+Kanjozoku 2,Nintendo Switch
+Katamari Damacy Reroll,Nintendo Switch
+Katana Zero,Nintendo Switch
+Katana Zero,Nintendo Switch
+Katrielle And The Millionaires’ Conspiracy,Nintendo Switch
+Kaze And The Wild Masks,Nintendo Switch
+Keeper’s Toll,Nintendo Switch
+Keeper’s Toll,Nintendo Switch
+Kero Blaster,Nintendo Switch
+Kill Knight,Nintendo Switch
+Kill The Crows,Nintendo Switch
+Kill The Crows,Nintendo Switch
+King Krieg Survivors,Nintendo Switch
+Kingdom 2 Crowns,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby And The Forgotten Land,Nintendo Switch
+Kirby Star Allies,Nintendo Switch
+Kirby Star Allies,Nintendo Switch
+Kirby’s Dream Buffet,Nintendo Switch
+Kirby’s Return To Dreamland Deluxe,Nintendo Switch
+Klonoa Phantasy Reveire Series,Nintendo Switch
+Kudzu,Nintendo Switch
+La Noire,Nintendo Switch
+Lacuna,Nintendo Switch
+Legacy Of Kain Soul Reaver 1&2 Remastered,Nintendo Switch
+Legend Of Grimrock,Nintendo Switch
+Legend Of Zelda – Links Awakening,Nintendo Switch
+Legend Of Zelda – Links Awakening,Nintendo Switch
+Legend Of Zelda – Links Awakening,Nintendo Switch
+Legend Of Zelda: Breath Of The Wild,Nintendo Switch
+Lego Builder’s Journey,Nintendo Switch
+Lego City Undercover,Nintendo Switch
+Lego Harry Potter Collection,Nintendo Switch
+Lego Jurassic World,Nintendo Switch
+Lego Marvel Superheroes,Nintendo Switch
+Lego Marvel Superheroes 2,Nintendo Switch
+Lego Star Wars: The Skywalker Saga,Nintendo Switch
+Leo’s Fortune,Nintendo Switch
+Leo’s Fortune,Nintendo Switch
+Life Is Strange Double Exposure,Nintendo Switch
+Life Is Strange Remastered,Nintendo Switch
+Life Is Strange: Before The Storm Remastered,Nintendo Switch
+Link’s Awakening,Nintendo Switch
+"Little Kitty, Big City",Nintendo Switch
+Little Nightmares,Nintendo Switch
+Little Nightmares Ii,Nintendo Switch
+Littlewood,Nintendo Switch
+Live A Live,Nintendo Switch
+Live A Live,Nintendo Switch
+Live A Live,Nintendo Switch
+Live A Live,Nintendo Switch
+Llamasoft: The Jeff Minter Collection,Nintendo Switch
+Loco Motive,Nintendo Switch
+Lollipop Chainsaw Repro,Nintendo Switch
+Lone Fungus,Nintendo Switch
+Lone Ruin,Nintendo Switch
+Lonely Mountains Downhill,Nintendo Switch
+Lonely Mountains Downhill,Nintendo Switch
+Lonely Mountains Downhill,Nintendo Switch
+Lost In Random,Nintendo Switch
+Lovers In A Dangerous Spacetime,Nintendo Switch
+Luigi’s Mansion 3,Nintendo Switch
+Luigi’s Mansion 3,Nintendo Switch
+Luigi’s Mansion 3,Nintendo Switch
+Luna’s Fishing Garden,Nintendo Switch
+Lunar Remastered Collection,Nintendo Switch
+Lunar Remastered Collection,Nintendo Switch
+Lysfanga – The Time Shift Warrior,Nintendo Switch
+Mahoyo: Witch On The Holy Night,Nintendo Switch
+Maid Of The Dead,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario & Luigi: Brothership,Nintendo Switch
+Mario + Rabbids Kingdom Battle,Nintendo Switch
+Mario + Rabbids Kingdom Battle,Nintendo Switch
+Mario + Rabbids Sparks Of Hope,Nintendo Switch
+Mario Golf Super Rush,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Mario Odyssey,Nintendo Switch
+Mario Odyssey,Nintendo Switch
+Mario Party Superstars,Nintendo Switch
+Mario Party Superstars,Nintendo Switch
+Mario Strikers Battle League,Nintendo Switch
+Mario Tennis Aces,Nintendo Switch
+Mario vs. Donkey Kong,Nintendo Switch
+Marsupilami – Hoobadventure,Nintendo Switch
+Marvel Ultimate Alliance 3: The Black Order,Nintendo Switch
+Marvel vs. Capcom Fighting Collection: Arcade Classics,Nintendo Switch
+Mary Skelter 2,Nintendo Switch
+Master Detective Archive: Rain Code,Nintendo Switch
+Mega Man Legacy Collection 2,Nintendo Switch
+Mega Man X Legacy Collection,Nintendo Switch
+Mega Man X Legacy Collection 2,Nintendo Switch
+Megam Man Legacy Collection,Nintendo Switch
+Megaton Musashi W: Wired,Nintendo Switch
+Megaton Musashi W: Wired,Nintendo Switch
+Metal Gear Solid – Master Collection Version,Nintendo Switch
+Metal Slug Tactics,Nintendo Switch
+Metal Slug Tactics,Nintendo Switch
+Metallic Child,Nintendo Switch
+Metro 2033 Redux,Nintendo Switch
+Metroid Dread,Nintendo Switch
+Metroid Dread,Nintendo Switch
+Metroid Dread,Nintendo Switch
+Metroid Prime Remastered,Nintendo Switch
+Metroid Prime Remastered,Nintendo Switch
+Metroid Prime Remastered,Nintendo Switch
+Mighty Morphin Power Rangers: Rita’s Rewind,Nintendo Switch
+Mighty Morphin Power Rangers: Rita’s Rewind,Nintendo Switch
+Miitopia,Nintendo Switch
+Minecraft Dungeons,Nintendo Switch
+Minecraft Legends,Nintendo Switch
+Minecraft Story Mode – The Complete Adventure,Nintendo Switch
+Minecraft: Nintendo Switch Edition (legacy Console),Nintendo Switch
+Minecraft: Nintendo Switch Edition (Legacy Console),Nintendo Switch
+Mining Mechs,Nintendo Switch
+Minit,Nintendo Switch
+Mistover,Nintendo Switch
+Monster Boy And The Cursed Kingdom,Nintendo Switch
+Monster Hunter Generations Ultimate,Nintendo Switch
+Monster Hunter Generations Ultimate,Nintendo Switch
+Monster Hunter Generations Ultimate,Nintendo Switch
+Monster Hunter Rise,Nintendo Switch
+Monster Hunter Stories,Nintendo Switch
+Monster Train,Nintendo Switch
+Monster Train 2,Nintendo Switch
+Monster Train 2,Nintendo Switch
+Moonlighter,Nintendo Switch
+Moonstone Island,Nintendo Switch
+Moonstone Island,Nintendo Switch
+Mutazione,Nintendo Switch
+My Sims,Nintendo Switch
+My Sims,Nintendo Switch
+My Time At Sandrock,Nintendo Switch
+N++,Nintendo Switch
+Naiad,Nintendo Switch
+Naruto Shippuden Ultimate Ninja Storm 4 Road To Boruto,Nintendo Switch
+Naruto Ultimate Ninja Storm Collection,Nintendo Switch
+Naruto X Boruto Ultimate Ninja Storm Connections,Nintendo Switch
+Nascar Heat Ultimate Edition+,Nintendo Switch
+Neckbreak,Nintendo Switch
+Need For Speed Hot Pursuit Remastered,Nintendo Switch
+Need For Speed Hot Pursuit Remastered,Nintendo Switch
+Needy Girl Overdose,Nintendo Switch
+Neo: The World Ends With You,Nintendo Switch
+Neon Abyss,Nintendo Switch
+Neon Blood,Nintendo Switch
+Neon White,Nintendo Switch
+Nerd Survivors,Nintendo Switch
+Neuro Voider,Nintendo Switch
+Neva,Nintendo Switch
+New Pokémon Snap,Nintendo Switch
+New Pokémon Snap,Nintendo Switch
+New Super Lucky’s Tale,Nintendo Switch
+New Super Mario Bros. U Deluxe,Nintendo Switch
+Nexomon,Nintendo Switch
+Ni No Kuni Wrath Of The White Witch,Nintendo Switch
+Nickelodeon All-Star Brawl 2,Nintendo Switch
+Nickelodeon Kart Racers,Nintendo Switch
+Night In The Woods,Nintendo Switch
+Night Slashers Remake,Nintendo Switch
+Nights Of Azure 2,Nintendo Switch
+Nine Sols,Nintendo Switch
+Ninja Gaiden Sigma,Nintendo Switch
+Ninja Gaiden Sigma,Nintendo Switch
+Ninja Slayer: Neo-Saitama In Flames,Nintendo Switch
+Nintendo World Championship,Nintendo Switch
+No More Heroes,Nintendo Switch
+No More Heroes 2: Desperate Struggle,Nintendo Switch
+No More Heroes 3,Nintendo Switch
+Nuclear Blaze,Nintendo Switch
+Octodad: Dadliest Catch,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Octopath Traveler II,Nintendo Switch
+Oddworld: New ‘n’ Tasty!,Nintendo Switch
+Okami HD,Nintendo Switch
+Okinawa Rush,Nintendo Switch
+Old School Musical,Nintendo Switch
+Olliolli World,Nintendo Switch
+Omega Labyrinth Life,Nintendo Switch
+Omori,Nintendo Switch
+One Piece Pirate Warriors 3,Nintendo Switch
+One Piece Unlimited World Red Deluxe Edition,Nintendo Switch
+One Step From Eden,Nintendo Switch
+Onimusha: Warlords,Nintendo Switch
+Ori And The Blind Forest,Nintendo Switch
+Ori And The Blind Forest,Nintendo Switch
+Ori And The Blind Forest,Nintendo Switch
+Ori And The Blind Forest (Definitive Edition),Nintendo Switch
+Ori And The Will Of The Wisps,Nintendo Switch
+Otherwar,Nintendo Switch
+Otxo,Nintendo Switch
+Our Summer Festivals 2,Nintendo Switch
+Our Summer Festivals 2,Nintendo Switch
+Outer Wilds,Nintendo Switch
+Overcooked 2 + All Dlc,Nintendo Switch
+Owlboy,Nintendo Switch
+Paint The Town Red,Nintendo Switch
+Panzer Paladin,Nintendo Switch
+Paper Mario: The Origami King,Nintendo Switch
+Paper Mario: The Thousand-Year Door,Nintendo Switch
+Paper Mario: The Thousand-Year Door,Nintendo Switch
+Papwr Mario The Thousand Year Door,Nintendo Switch
+Party Hard,Nintendo Switch
+Party Hard,Nintendo Switch
+Passpartout,Nintendo Switch
+Passpartout 2,Nintendo Switch
+Pato Box,Nintendo Switch
+Patrick’s Parabox,Nintendo Switch
+Pentiment,Nintendo Switch
+Pepper Grinder,Nintendo Switch
+Persona 3 Portable,Nintendo Switch
+Persona 4 Arena Ultimax,Nintendo Switch
+Persona 4 Golden,Nintendo Switch
+Persona 4 Golden,Nintendo Switch
+Persona 4 Golden,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Royal,Nintendo Switch
+Persona 5 Strikers,Nintendo Switch
+Persona 5 Tactica,Nintendo Switch
+Pga Tour 2k21,Nintendo Switch
+Phoenix Wright: Ace Attorney Trilogy,Nintendo Switch
+Phoenotopia Awakening,Nintendo Switch
+Pikmin 1,Nintendo Switch
+Pikmin 2,Nintendo Switch
+Pikmin 3 Deluxe,Nintendo Switch
+Pikmin 3 Deluxe,Nintendo Switch
+Pikmin 4,Nintendo Switch
+Pikmin 4,Nintendo Switch
+Pikuniku,Nintendo Switch
+Pixel Cup Soccer Ultimate Edition,Nintendo Switch
+Pixel Retro Drift,Nintendo Switch
+Pizza Tower,Nintendo Switch
+Pizza Tower,Nintendo Switch
+Planescape Tournament And Icewind Dale,Nintendo Switch
+Plateup!,Nintendo Switch
+Poison Control,Nintendo Switch
+Pokemon,Nintendo Switch
+Pokemon Arceus,Nintendo Switch
+Pokemon Brilliant Diamond,Nintendo Switch
+Pokemon Brilliant Diamond,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Legends: Arceus,Nintendo Switch
+Pokemon Mystery Dungeon DX,Nintendo Switch
+Pokemon Scarlet,Nintendo Switch
+Pokemon Scarlet,Nintendo Switch
+Pokemon Scarlet,Nintendo Switch
+Pokemon Shining Pearl,Nintendo Switch
+Pokemon Shining Pearl,Nintendo Switch
+Pokemon Shining Pearl,Nintendo Switch
+Pokemon Snap,Nintendo Switch
+Pokemon Sword,Nintendo Switch
+Pokemon Sword,Nintendo Switch
+Pokemon Violet,Nintendo Switch
+Pokemon Violet,Nintendo Switch
+Pokemon Violet,Nintendo Switch
+Pokemon: Let’s Go Eevee!,Nintendo Switch
+Pokemon: Let’s Go Pikachu!,Nintendo Switch
+Pokemon: Shield,Nintendo Switch
+Pokemon: Sword,Nintendo Switch
+Pokemon: Sword,Nintendo Switch
+Pokken Tournament Dx,Nintendo Switch
+Portal,Nintendo Switch
+Portal,Nintendo Switch
+Portal,Nintendo Switch
+Portal 2,Nintendo Switch
+Post Void,Nintendo Switch
+Postal: Brain Damaged,Nintendo Switch
+Potion Craft,Nintendo Switch
+Power Rangers: Battle For The Grid,Nintendo Switch
+Power Rangers: Battle For The Grid,Nintendo Switch
+Powerwash Simulator,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Prince Of Persia: The Lost Crown,Nintendo Switch
+Princess Peach: Showtime!,Nintendo Switch
+Princess Peach: Showtime!,Nintendo Switch
+Princess Peach: Showtime!,Nintendo Switch
+Prodeus,Nintendo Switch
+Pumpkin Jack,Nintendo Switch
+Punch A Bunch,Nintendo Switch
+Quake 2,Nintendo Switch
+R-Type Final 2,Nintendo Switch
+Racine,Nintendo Switch
+Rain World,Nintendo Switch
+Rainbow Moon,Nintendo Switch
+Rayman Legends,Nintendo Switch
+Rayman Legends: Definitive Edition,Nintendo Switch
+Rebel Transmute,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+Red Wings American Aces,Nintendo Switch
+Resident Evil 0,Nintendo Switch
+Resident Evil 4,Nintendo Switch
+Resident Evil HD Remake,Nintendo Switch
+Resident Evil Revelations,Nintendo Switch
+Resident Evil Revelations,Nintendo Switch
+Resident Evil Revelations 2,Nintendo Switch
+Retro City Rampage Dx,Nintendo Switch
+Retrorealms,Nintendo Switch
+Retrorealms,Nintendo Switch
+Return,Nintendo Switch
+Return Of The Obra Dinn,Nintendo Switch
+Return Of The Obra Dinn,Nintendo Switch
+Revita,Nintendo Switch
+Riptide Gp Renegade,Nintendo Switch
+Rise Of The Third Power,Nintendo Switch
+Risk Of Rain 2,Nintendo Switch
+Risk Of Rain 2,Nintendo Switch
+Risk Of Rain Returns,Nintendo Switch
+Risk Of Rain Returns,Nintendo Switch
+Rival Megagun,Nintendo Switch
+Rival Megagun,Nintendo Switch
+River City Girls,Nintendo Switch
+River City Girls 2,Nintendo Switch
+Road 96,Nintendo Switch
+Rocket League,Nintendo Switch
+Rogue Heroes: Ruins Of Tasos,Nintendo Switch
+Rogue Legacy 2,Nintendo Switch
+Rogue Legacy 2,Nintendo Switch
+Roller Coaster Tycoon 3 Complete,Nintendo Switch
+Rollercoaster Tycoon Classic,Nintendo Switch
+Romance Of The Three Kingdoms 8 : Remake,Nintendo Switch
+Romancing Saga 2: Revenge Of The Seven,Nintendo Switch
+Roots Of Pacha,Nintendo Switch
+Ruiner,Nintendo Switch
+Rune Factory 3,Nintendo Switch
+Rune Factory 4s,Nintendo Switch
+Rune Factory 5,Nintendo Switch
+Runnyk,Nintendo Switch
+Runnyk,Nintendo Switch
+Rusted Moss,Nintendo Switch
+S.T.A.L.K.E.R.: Call Of Prypiat,Nintendo Switch
+S.T.A.L.K.E.R.: Clear Sky,Nintendo Switch
+S.T.A.L.K.E.R.: Shadow Of Chornobyl,Nintendo Switch
+Saga Frontier 2 Remastered,Nintendo Switch
+Saga Frontier Remastered,Nintendo Switch
+Saints Row IV,Nintendo Switch
+Saints Row: The Third – The Full Package,Nintendo Switch
+Sakuna: Of Rice And Ruin,Nintendo Switch
+Salt And Sanctuary,Nintendo Switch
+Sam & Max: Save The World,Nintendo Switch
+Samurai Jack: Battle Through Time,Nintendo Switch
+Samurai Shodown,Nintendo Switch
+Sanabi,Nintendo Switch
+Savant – Ascent Remix,Nintendo Switch
+Schim,Nintendo Switch
+Schim,Nintendo Switch
+Sclash,Nintendo Switch
+Scott Pilgrim vs. The World: The Game – Complete Edition,Nintendo Switch
+ScourgeBringer,Nintendo Switch
+ScourgeBringer,Nintendo Switch
+Sd Gundam G Generation Genesis,Nintendo Switch
+Sea Of Stars,Nintendo Switch
+Sea Of Stars,Nintendo Switch
+Sea Of Stars,Nintendo Switch
+Seers Isle,Nintendo Switch
+Sega Ages – Virtua Racing,Nintendo Switch
+Senran Kagura Peach Ball,Nintendo Switch
+Senran Kagura Peach Ball,Nintendo Switch
+Serial Cleaner,Nintendo Switch
+Shadow Labyrinth,Nintendo Switch
+Shadowrun Returns,Nintendo Switch
+Shantae Half Genie Hero,Nintendo Switch
+Shantae: 1/2 Genie Hero – Ultimate Edition,Nintendo Switch
+Shantae: 1/2 Genie Hero – Ultimate Edition,Nintendo Switch
+Shashingo: Learn Japanese With Photography,Nintendo Switch
+Shin Megami Tensei III Nocturne HD Remaster,Nintendo Switch
+Shin Megami Tensei III Nocturne HD Remaster,Nintendo Switch
+Shin Megami Tensei Vengeance,Nintendo Switch
+Shin Megami Tensei Vengeance,Nintendo Switch
+Shin-Chan: Shiro And The Coal Town,Nintendo Switch
+Shiren The Wanderer: The Mystery Dungeon Of Serpentcoil Island,Nintendo Switch
+Shogun Showdown,Nintendo Switch
+Shovel Knight King Of Cards,Nintendo Switch
+Shovel Knight Shovel Of Hope,Nintendo Switch
+Shovel Knight: Treasure Trove,Nintendo Switch
+Sifu,Nintendo Switch
+Signalis,Nintendo Switch
+Signalis,Nintendo Switch
+Skater Xl,Nintendo Switch
+Skater Xl,Nintendo Switch
+Skul: The Hero Slayer,Nintendo Switch
+Skullgirls: 2nd Encore,Nintendo Switch
+Sky Oceans: Wings For Hire,Nintendo Switch
+Sky Rogue,Nintendo Switch
+Skylanders Imaginators,Nintendo Switch
+Skylanders Imaginators,Nintendo Switch
+Skylanders Imaginators,Nintendo Switch
+Skyrim,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slay The Spire,Nintendo Switch
+Slayers X: Terminal Aftermath: Vengance Of The Slayer,Nintendo Switch
+Slime 3k – Rise Against Despot,Nintendo Switch
+Slime Rancher,Nintendo Switch
+Sludge Life,Nintendo Switch
+Snake Pass,Nintendo Switch
+Sniper Elite 3: Ultimate Edition,Nintendo Switch
+Sniper Elite 4,Nintendo Switch
+Sniper Elite 4,Nintendo Switch
+Snk Heroines Tag Team Frenzy,Nintendo Switch
+SNK vs. Capcom: SVC Chaos,Nintendo Switch
+Snowboarding The Next Phase,Nintendo Switch
+Solar Ash,Nintendo Switch
+Sonic Frontiers,Nintendo Switch
+Sonic Frontiers,Nintendo Switch
+Sonic Generations,Nintendo Switch
+Sonic Mania,Nintendo Switch
+Sonic Origins,Nintendo Switch
+Sonic Superstars,Nintendo Switch
+Sonic Superstars,Nintendo Switch
+Sonic Wings Reunion,Nintendo Switch
+Sonic X Shadow Generations,Nintendo Switch
+Sonic X Shadow Generations,Nintendo Switch
+Sonic X Shadow Generations,Nintendo Switch
+South Park: The Fractured Butt Whole,Nintendo Switch
+South Park: The Stick Of Truth,Nintendo Switch
+South Park: The Stick Of Truth,Nintendo Switch
+Speed Overflow,Nintendo Switch
+Speed Overflow,Nintendo Switch
+Spelunky,Nintendo Switch
+Spelunky 2,Nintendo Switch
+Spelunky 2,Nintendo Switch
+Spintires: Mud Runner (Mudrunner – American Wilds),Nintendo Switch
+Spirit Hunter: Death Mark 2,Nintendo Switch
+Splatoon 3,Nintendo Switch
+Spongebob Squarepants: The Cosmic Shake,Nintendo Switch
+Spyro Reignited Trilogy,Nintendo Switch
+Spyro Reignited Trilogy,Nintendo Switch
+Spyro Reignited Trilogy,Nintendo Switch
+Stacklands,Nintendo Switch
+Stacklands,Nintendo Switch
+Star Ocean: First Departure R,Nintendo Switch
+Star Ocean: The Second Story R,Nintendo Switch
+Star Ocean: The Second Story R,Nintendo Switch
+Star Of Providence,Nintendo Switch
+Star Overdrive,Nintendo Switch
+Star Wars – Knights Of The Old Republic,Nintendo Switch
+Star Wars – Knights Of The Old Republic II,Nintendo Switch
+Star Wars The Force Unleashed,Nintendo Switch
+Star Wars: Dark Forces,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Stardew Valley,Nintendo Switch
+Steamworld Build,Nintendo Switch
+Steamworld Dig,Nintendo Switch
+Steamworld Heist II,Nintendo Switch
+Steins Gate: My Darlings Embrace,Nintendo Switch
+Steins;Gate Elite,Nintendo Switch
+Stella Of The End,Nintendo Switch
+Story Of Seasons: Friends Of Mineral Town,Nintendo Switch
+Story Of Seasons: Pioneers Of Olive Town,Nintendo Switch
+Stranger Things,Nintendo Switch
+Stray,Nintendo Switch
+Streets Of Rage 4,Nintendo Switch
+Streets Of Rage 4,Nintendo Switch
+Streets Of Rogue,Nintendo Switch
+Strike Suit Zero,Nintendo Switch
+Subnautica,Nintendo Switch
+Subnautica,Nintendo Switch
+Suika Game,Nintendo Switch
+Suika Game,Nintendo Switch
+Suikoden I & Ii Hd Remaster: Gate Rune And Dunan Unification Wars,Nintendo Switch
+Super Bomberman R,Nintendo Switch
+Super Bomberman R 2,Nintendo Switch
+Super Lone Survivor,Nintendo Switch
+Super Mario 3d All Stars,Nintendo Switch
+Super Mario 3D All Stars,Nintendo Switch
+Super Mario 3D World + Bowser’s Fury,Nintendo Switch
+Super Mario 3D World + Bowser’s Fury,Nintendo Switch
+Super Mario 3D World + Bowser’s Fury,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Bros. Wonder,Nintendo Switch
+Super Mario Maker 2,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Odyssey,Nintendo Switch
+Super Mario Party Jamboree,Nintendo Switch
+Super Mario RPG,Nintendo Switch
+Super Mario RPG,Nintendo Switch
+Super Mario RPG,Nintendo Switch
+Super Mario Wonder,Nintendo Switch
+Super Meat Boy,Nintendo Switch
+Super Monkey Ball Banana Rumble,Nintendo Switch
+Super Monkey Ball Banana Rumble,Nintendo Switch
+Super Robot Wars,Nintendo Switch
+Super Smash Bros Ultimate,Nintendo Switch
+Super Smash Bros Ultimate,Nintendo Switch
+Super Smash Bros Ultimate,Nintendo Switch
+Super Woden GP 2,Nintendo Switch
+Superhot,Nintendo Switch
+Sword Of The Vagrant,Nintendo Switch
+Symphonia,Nintendo Switch
+Tactics Ogre Reborn,Nintendo Switch
+Tales Of Vesperia,Nintendo Switch
+Teenage Mutant Ninja Turtles: Mutants Unleashed,Nintendo Switch
+Teenage Mutant Ninja Turtles: Shredders Revenge,Nintendo Switch
+Teenage Mutant Ninja Turtles: Shredders Revenge,Nintendo Switch
+Teenage Mutant Ninja Turtles: Splintered Fate,Nintendo Switch
+Teenage Mutant Ninja Turtles: Splintered Fate,Nintendo Switch
+Teenage Mutant Ninja Turtles: Splintered Fate,Nintendo Switch
+Tennis In The Face,Nintendo Switch
+Terminal Velocity,Nintendo Switch
+Terraria,Nintendo Switch
+Terraria,Nintendo Switch
+Terraria,Nintendo Switch
+Teslagrad,Nintendo Switch
+Tetris 99,Nintendo Switch
+Tetris Effect,Nintendo Switch
+Thank Goodness You’re Here!,Nintendo Switch
+The Binding Of Isaac: Afterbirth+,Nintendo Switch
+The Binding Of Isaac: Repentance,Nintendo Switch
+The Binding Of Isaac: Repentance,Nintendo Switch
+The Binding Of Isaac: Repentance,Nintendo Switch
+The Case Of The Golden Idol,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Elder Scrolls: Skyrim,Nintendo Switch
+The Flame In The Flood,Nintendo Switch
+The Hong Kong Massacre,Nintendo Switch
+The House In Fata Morgana: Dreams Of The Revenants Edition,Nintendo Switch
+The House Of The Dead Remake,Nintendo Switch
+The Hundred Line: Last Defense Academy,Nintendo Switch
+The King of Fighters XIII: Global Match,Nintendo Switch
+The King of Fighters XIII: Global Match,Nintendo Switch
+The Last Campfire,Nintendo Switch
+The Legend Of Heroes: Trails From Zero,Nintendo Switch
+The Legend Of Heroes: Trails From Zero,Nintendo Switch
+The Legend Of Heroes: Trails To Azure,Nintendo Switch
+The Legend Of Heroes: Trials Through Daybreak,Nintendo Switch
+The Legend Of Zelda: Breath Of The Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend of Zelda: Breath of the Wild,Nintendo Switch
+The Legend Of Zelda: Echoes Of Wisdom,Nintendo Switch
+The Legend Of Zelda: Echoes Of Wisdom,Nintendo Switch
+The Legend Of Zelda: Skyward Sword HD,Nintendo Switch
+The Legend Of Zelda: Skyward Sword HD,Nintendo Switch
+The Legend Of Zelda: Skyward Sword HD,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Messenger,Nintendo Switch
+The Messenger,Nintendo Switch
+The Messenger,Nintendo Switch
+The Outer Worlds,Nintendo Switch
+The Outer Worlds,Nintendo Switch
+The Pathless,Nintendo Switch
+The Pedestrian,Nintendo Switch
+The Plucky Squire,Nintendo Switch
+The Plucky Squire,Nintendo Switch
+The Settlers: New Allies,Nintendo Switch
+The Smurfs 2 : The Prisoner Of The Green Stone,Nintendo Switch
+The Smurfs Mission Villeaf,Nintendo Switch
+The Stanley Parable: Ultra Deluxe,Nintendo Switch
+The Tale Of Bistun,Nintendo Switch
+The Thing Remastered,Nintendo Switch
+The Wandering Village,Nintendo Switch
+The Wardrobe: Even Better Edition,Nintendo Switch
+The Wild At Heart,Nintendo Switch
+The Witcher 3: Wild Hunt,Nintendo Switch
+The World Ends With You: Final Remix,Nintendo Switch
+There Is No Game,Nintendo Switch
+Thief Simulator,Nintendo Switch
+This War Of Mine Complete Edition,Nintendo Switch
+Thronefall,Nintendo Switch
+Thunder Ray,Nintendo Switch
+Titan Quest,Nintendo Switch
+To The Moon,Nintendo Switch
+Toem,Nintendo Switch
+Toki,Nintendo Switch
+Toki,Nintendo Switch
+Tokyo Mirage Sessions #Fe Encore,Nintendo Switch
+Tomb Raider I-III Remastered,Nintendo Switch
+Tomb Raider I-III Remastered,Nintendo Switch
+Tonight We Riot,Nintendo Switch
+Tony Hawk’s Pro Skater 1+2,Nintendo Switch
+Tony Hawk’s Pro Skater 1+2,Nintendo Switch
+Torchlight 2,Nintendo Switch
+Torchlight 3,Nintendo Switch
+Torchlight II,Nintendo Switch
+Torchlight II,Nintendo Switch
+Torchlight II,Nintendo Switch
+Totally Accurate Battle Simulator,Nintendo Switch
+Transistor,Nintendo Switch
+Trek To Yomi,Nintendo Switch
+Trials Of Mana,Nintendo Switch
+Triangle Strategy,Nintendo Switch
+Triangle Strategy,Nintendo Switch
+Trinity Trigger,Nintendo Switch
+Trombone Champ,Nintendo Switch
+Trouser Critters Long Dagger,Nintendo Switch
+Trouser Critters Long Dagger,Nintendo Switch
+Trouser Critters Shiny Clam Rocks,Nintendo Switch
+Tsukihime – A Piece Of Blue Glass Moon,Nintendo Switch
+Tunic,Nintendo Switch
+Tunic,Nintendo Switch
+Turbo Overkill,Nintendo Switch
+Turbo Overkill,Nintendo Switch
+Twelve Minutes,Nintendo Switch
+Two Point Hospital,Nintendo Switch
+Ubermosh: Omega,Nintendo Switch
+Ugly,Nintendo Switch
+Ultimate Marvel vs. Capcom 3,Nintendo Switch
+Ultra Street Fighter II: The Final Challengers,Nintendo Switch
+Ultra Street Fighter II: The Final Challengers,Nintendo Switch
+Umineko No Naku Koro Ni Catbox,Nintendo Switch
+Unavowed,Nintendo Switch
+Undead Horde,Nintendo Switch
+Undead Horde 2,Nintendo Switch
+Under Defeat,Nintendo Switch
+Undermine,Nintendo Switch
+Undernauts: Labyrinth Of Yomi,Nintendo Switch
+Undertale,Nintendo Switch
+Undertale,Nintendo Switch
+Unicorn Overlord,Nintendo Switch
+Unicorn Overlord,Nintendo Switch
+Unmetal,Nintendo Switch
+Unsighted,Nintendo Switch
+Urban Myth Dissolution Center,Nintendo Switch
+Valiant Hearts: The Great War,Nintendo Switch
+Valkyria Chronicles,Nintendo Switch
+Valkyria Chronicles 4,Nintendo Switch
+Vampire Hunters,Nintendo Switch
+Vampire Survivors,Nintendo Switch
+Velocity 2x,Nintendo Switch
+Victory Heat Rally,Nintendo Switch
+Victory Heat Rally,Nintendo Switch
+Void Bastards,Nintendo Switch
+Void Prison,Nintendo Switch
+Void Prison,Nintendo Switch
+Void Scrappers,Nintendo Switch
+Void Scrappers,Nintendo Switch
+Void Scrappers,Nintendo Switch
+Voidwrought,Nintendo Switch
+Voltaire: The Vegan Vampire,Nintendo Switch
+Wall World,Nintendo Switch
+Wargroove,Nintendo Switch
+"Warhammer 40,000: Boltgun",Nintendo Switch
+Wavetale,Nintendo Switch
+We Love Katamari Reroll+ Royal Reverie,Nintendo Switch
+What Lies In The Multiverse,Nintendo Switch
+What Remains Of Edith Finch,Nintendo Switch
+What The Golf,Nintendo Switch
+Wild Bastards,Nintendo Switch
+Wild Bastards,Nintendo Switch
+Windjammers 2,Nintendo Switch
+Wolffang Skullfang,Nintendo Switch
+World Of Goo,Nintendo Switch
+World Of Horror,Nintendo Switch
+Worms Armageddon: Anniversary Edition,Nintendo Switch
+Wytchwood,Nintendo Switch
+XCOM 2,Nintendo Switch
+Xenoblade Chronicles 2,Nintendo Switch
+Xenoblade Chronicles X: Definitive Edition,Nintendo Switch
+Xenoblade Chronicles X: Definitive Edition,Nintendo Switch
+XIII,Nintendo Switch
+Yakuza Kiwami,Nintendo Switch
+Yakuza Kiwami,Nintendo Switch
+Yo-Kai Watch 1 For Nintendo Switch,Nintendo Switch
+Yokai Watch 1,Nintendo Switch
+Yokai Watch 4,Nintendo Switch
+Yoku’s Island Express,Nintendo Switch
+Yooka-Laylee And The Impossible Lair,Nintendo Switch
+Yoshi’s Crafted World,Nintendo Switch
+You Suck At Parking,Nintendo Switch
+Youtubers Life,Nintendo Switch
+Ys IX: Monstrum Nox,Nintendo Switch
+Ys IX: Monstrum Nox,Nintendo Switch
+Ys Memoire: The Oath In Felghana,Nintendo Switch
+Ys Memoire: The Oath In Felghana,Nintendo Switch
+Ys Origin,Nintendo Switch
+Ys Viii,Nintendo Switch
+Planet Of Lana,Nintendo Switch
+Xenoblade Chronicles Definitive Edition,Nintendo Switch
+Castle Crashers,Nintendo Switch
+The Legend Of Heroes: Trails From Zero,Nintendo Switch
+Front Mission 3,Nintendo Switch
+9th Dawn Remake,Nintendo Switch
+A Short Hike,Nintendo Switch
+Ace Attorney Investigations Collection,Nintendo Switch
+Advance Wars 1+2 Re-boot Camp,Nintendo Switch
+Animal Crossing New Horizons,Nintendo Switch
+Animal Well,Nintendo Switch
+Annalynn,Nintendo Switch
+Another Code Recollection,Nintendo Switch
+Ao Tennis 2,Nintendo Switch
+Astral Ascent,Nintendo Switch
+Astral Chain,Nintendo Switch
+Axiom Verge,Nintendo Switch
+20 Minutes Till Dawn,Nintendo Switch
+30xx,Nintendo Switch
+Anomaly Agent,Nintendo Switch
+Armored Lab Force Vulvehicles,Nintendo Switch
+Ato,Nintendo Switch
+"Warhammer 40,000: Boltgun",Nintendo Switch
+Balatro,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+The Legend Of Zelda: Tears Of The Kingdom,Nintendo Switch
+Ender Magnolia Bloom In The Mist,Nintendo Switch
+Pinball Fx,Nintendo Switch
+Cookie Clicker,Nintendo Switch
+The Legend Of Zelda: Echoes Of Wisdom,Nintendo Switch
+Raidou Remastered The Mystery Of The Soulless Army,Nintendo Switch
+Outlast,Nintendo Switch
+Ufo 50,Nintendo Switch
+Ufo 50,Nintendo Switch
+Saints Row Iv,Nintendo Switch
+Warriors Abyss,Nintendo Switch
+Naruto Ultimate Ninja Storm 2,Nintendo Switch
+Minecraft: Nintendo Switch Edition (legacy Console),Nintendo Switch
+Factorio,Nintendo Switch
+Pokken Tournament Dx,Nintendo Switch
+Hatsune Miku: Project Diva Mega Mix,Nintendo Switch
+Dragon Ball Xenoverse 2,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Dragon Ball Z: Kakarot,Nintendo Switch
+Enclave Hd,Nintendo Switch
+Outward – Definitive Edition,Nintendo Switch
+Sifu,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+Mega Man 11,Nintendo Switch
+Dragon Ball Fighterz,Nintendo Switch
+Dragon Ball Fighterz,Nintendo Switch
+Red Dead Redemption,Nintendo Switch
+8-bit Adventures 2,Nintendo Switch
+Mario Kart 8 Deluxe,Nintendo Switch
+Metroid Dread,Nintendo Switch
+Zelda Botw,Nintendo Switch
+Tetris Effect,Nintendo Switch
+Super Mario Wonder,Nintendo Switch
+Shadow Labyrinth,Nintendo Switch
+Astral Chain,Nintendo Switch
+Cyber Shadow,Nintendo Switch
+The House Of Dead 2 Remake,Nintendo Switch
+Metroid Prime Remastered,Nintendo Switch
+Super Mario 3d World,Nintendo Switch
+Bomberman R2,Nintendo Switch
+Asd,Nintendo Switch
+The Legend Of Zelda: Breath Of The Wild,Nintendo Switch

--- a/prisma/seeders/data/rp5_flip2_odin2_switch_listing.csv
+++ b/prisma/seeders/data/rp5_flip2_odin2_switch_listing.csv
@@ -1,0 +1,2825 @@
+﻿Game,Performance,Drive,Emulator,Update,Notes,Device
+8-Bit Adventures 2,Poor,Turnip 24.3.0 9v2,Citron,1.0,Can’t get this game to launch :/ rolls immediately in to black screen,Pocket 5
+12 Is Better Than 6,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Plays perfect docked mode looks amazing on oled.,Pocket 5
+13 Sentinels: Aegis Rim,Perfect,Turnip 24.3.0 9v2,Citron,1.1,Handheld 1x Lock to 30 fps (50% Limit speed percent) for a smoother experience.,Pocket 5
+13 Sentinels: Aegis Rim,Great,Turnip 24.1.0 R18,Citron,1.0,"Docked, 1x resolution, some dips in FPS but no crashes.",Pocket 5
+13 Sentinels: Aegis Rim,Great,Turnip 24.3.0 9v2,Sudachi,1.1,"Played mostly on 1x resolution. Mostly 60 fps, would drop to 40-30 fps in battles. Dropped to 20 in the final battle. Some crashes when there would be a lot of stuff in the background. Had to drop 0.75x resolution when deleting shader cache wouldn’t work. Settings: Accuracy Level: High (to get mostly 60 fps out of battle), Window Adapting Filter: AMD Fidelity FX Super Resolution (if 0.75x res), Audio: cubeb (if audio stutters)",Pocket 5
+13 Sentinels: Aegis Rim,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,"Excellent. Sometimes the audio stutters the slightest bit, but goes away on restart.",Pocket 5
+13 Sentinels: Aegis Rim,Perfect,Qualcomm 0.746.0,Yuzu,1.1,"Works perfect with update, docked mode 30fps solid",Pocket 5
+13 Sentinels: Aegis Rim,Great,Turnip 24.3.0 9v2,Citron,1.0,I would say this works pretty great and is ery much playable. On Suyu I had a crash but Citron seems to be working.,Pocket 5
+20 Minutes Till Dawn,Perfect,Qualcomm 0.746.0,Yuzu,v1.1.1,Yuzu 278 (dc529a89a) Default for all parameters,Pocket 5
+30xx,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,perfect,Pocket 5
+60 Seconds Reatomized,Great,Qualcomm 0.746.0,Yuzu,1.0.2,weird game but runs 50-55fps in docked mode,Pocket 5
+80’s Overdrive,Great,Qualcomm 0.746.0,Yuzu,1.1.0,Smooth 60 but minor audio stutters,Pocket 5
+198x,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+3000th Duel,Great,Turnip 24.3.0 9v2,Citron,"Update 1.1.2, DLC 1","Only had a few bugs where the game turned black when going into the next room, and also some random crashes. Noticed bugs only happened when resuming game from sleep.",Pocket 5
+A Boy And His Blob,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps,Pocket 5
+A Hat In Time,Great,Qualcomm 0.746.0,Yuzu,"1.0.4 + DLC 1, 2",Almost perfect in handheld mode but a few framerate dips,Pocket 5
+A Highland Song,Perfect,Qualcomm 0.746.0,Sudachi,1.2.3b,Stable between 30 and 60 FPS,Pocket 5
+A Juggler’s Tale,Poor,Turnip 25.2.0 R4,Yuzu,1.0,"Tested docked and handheld, in sudachi and yuzu, with qualcomm and Turnips this game will not get into the game on any",Pocket 5
+A Little To The Left,Perfect,Qualcomm 0.746.0,Yuzu,1.0,plays perfectly,Pocket 5
+A Memoir Blue,Poor,Qualcomm 0.746.0,Yuzu,1.0,Tried Sudachi and Yuzu with qualcomm and Turnip but cannot get past a couple mins in game without a crash,Pocket 5
+A Short Hike,Perfect,Turnip 24.3.0 9v2,Yuzu,1.9.21.1,"60 fps, Plays great!",Pocket 5
+A Sketchbook About Her Sun,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Abomi Nation,Great,Qualcomm 0.746.0,Yuzu,1.0,27fps works almost perfect in docked mode,Pocket 5
+Abzu,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Plays ery well,Pocket 5
+Ace Attorney Investigations Collection,Perfect,Qualcomm 0.746.0,Yuzu,1.0,100% speed,Pocket 5
+Ace Attorney Investigations Collection,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.0.1,play perfect,Pocket 5
+Ace Combat 7: Skies Unknown,Poor,Turnip 25.0.0 R8,Sudachi,1.0,Load well and you can play 60 fps but the colors are all glitched like in a psychedelic dream…,Pocket 5
+Advance Wars 1+2: Re-boot Camp,Perfect,Qualcomm 819.1,Yuzu,1.0,,Pocket 5
+Advance Wars 1+2: Re-Boot Camp,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Seems to run just like it does on secret console,Pocket 5
+Aeon Drive,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked mode,Pocket 5
+Aery Early Birds Bundle,Poor,Qualcomm 0.746.0,Yuzu,1.0,Yuzu and Sudachi with Turnip 25 and Qualcom all crash,Pocket 5
+Aew Fight Forever,Great,Turnip 24.3.0 9v2,Yuzu,Latest,Plays surprisingly great with latest update and DLC. Occasionally freezes for about a second during a match but nothing crazy,Pocket 5
+Afterimage,Great,Turnip 24.3.0 9v2,Sudachi,1.2.0,same settings works on Yuzu and Suyu,Pocket 5
+Agatha Christie – Murder On The Orient Express,Great,Qualcomm 819.1,Citron,1.1.11,"Freezes constantly and graphical glitches with System & Turnips. Runs @ 40-60fps with Qualcomm 819.1 driver, Accuracy Level : High, Resolution 1x, -Sync: Off, Disk Shader Cache: On, Force Maximum Clocks: On, Asynchronous Shaders: On",Pocket 5
+Ak-Xolotl,Perfect,Turnip 24.3.0 9v2,Citron,2.0.1,,Pocket 5
+Akane,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Alan Wake Remastered,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,After the Menü Crashes in Game. Also no luck on Citron,Pocket 5
+Alba,Playable,Qualcomm 0.746.0,Sudachi,1.0,"Works in handheld mode, Weird issue where sometimes it freezes and you have to swipe up from the bottom as if you are going to close the app to make it un freeze",Pocket 5
+Alex Kidd In Miracle World Dx,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Alien Hominid HD,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Flawless in docked mode, looks amazing on OLED",Pocket 5
+Alien: Isolation,Poor,Qualcomm 0.746.0,Yuzu,1.0/1.1.5,Did not work on Yuzu or Sudachi with either driver,Pocket 5
+Alphadia Genesis 2,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Alwa’s Awakening,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.5.3.21,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Angry Video Game Nerd I & II Deluxe,Perfect,Qualcomm 0.746.0,Yuzu,1.3.1,Perfect 60fps in docked mode,Pocket 5
+Animal Crossing: New Horizons,Perfect,Turnip 24.3.0 9v2,Citron,2.0.6 + DLC,Citron is back in development! Settings: Docked 1x Res. 30FPS Locked Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Animal Crossing: New Horizons,Perfect,Turnip 24.3.0 9v2,Citron,2.0.6 + DLC,Citron is back in development! Settings: Docked 1x Res. 30FPS Locked Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Animal Crossing: New Horizons,Perfect,Qualcomm 0.746.0,Yuzu,2.0.6,,Pocket 5
+Animal Crossing: New Horizons,Perfect,Turnip 24.3.0 9v2,Yuzu,2.0.6 + all DLC,Runs locked 30fps even in Docked mode.,Pocket 5
+Animal Well,Perfect,Turnip 24.3.0 9v2,Citron,"1.0,7",Citron is back in development! 60 FPS Settings: Docked 1x Res. Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Animal Well,Perfect,Turnip 24.3.0 9v2,Sudachi,1.02,Standard docked. Accuracy normal,Pocket 5
+Animal Well,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,Standard mode / Docked,Pocket 5
+Animus: Revenant,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.5,Yuzu 278 (dc529a89a) Video precision : High,Pocket 5
+Anno: Mutationem,Great,Turnip 24.3.0 9v2,Sudachi,1.05.08,"Worked great with Turnip driver and Accuracy level set to high. Opening cutscene is glitched, but after that, it runs at a stable 60fps.",Pocket 5
+Anno: Mutationem,Poor,Turnip 24.3.0 9v2,Citron,1.05.08,"Menu loads, but crashes when starting the story",Pocket 5
+Anodyne 2 : Return To Dust,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Anomaly Agent,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Anomaly Collapse,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Worked perfectly with Qualcomm 0.746.0 but not with any Turnip drivers. Shut down after hitting “start game”,Pocket 5
+Another Code: Recollection,Poor,Qualcomm 0.746.0,Citron,1.0,Crashes anytime you try to use Camera,Pocket 5
+Another Code: Recollection,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Runs at a smooth 30 in Docked mode without a hitch. Has the occasional weird graphical artifact, but they’re rather minor.",Pocket 5
+Another Crab’s Treasure,Playable,Turnip 24.1.0 R18,Citron,1.0.101.1,"*Crashes after main menu no matter what setting/driver I use at 1x, so you absolutely have to drop to .75x resolution (Both Docked or Undocked work). I had Disk Shader Cache, Force maximum clocks, and Use asynchronous shaders ticked on, as well as 16x Anisotopic filtering, AMD FidelityFX for Window adapting filter, and 100% FSR Sharpness. Everything else is default.",Pocket 5
+Ape Out,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Apico,Perfect,Turnip 24.3.4-Unified (@Mr_Purple_666),Citron,1.3.2d,"Perfect 60 FPS like on Secret Console/PC Docked Mode ON, Accuracy Level HIGH, Disk Shader Cache ON, Asynchronous Shaders ON RP5 on Standard mode",Pocket 5
+Apollo Justice: Ace Attorney Trilogy,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.1,Sudachi didn’t work,Pocket 5
+Aragami: Shadow Edition,Great,Qualcomm 0.746.0,Yuzu,1.0.1,Runs great handheld mode 30-60fps,Pocket 5
+Arcade Paradise,Perfect,Qualcomm 0.746.0,Yuzu,1.11,Perfect 60fps in handheld mode,Pocket 5
+Arcade Tanks World: Tank Battle Simulator,Great,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Archvale,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps in docked mode,Pocket 5
+Arietta Of Spirits,Perfect,Qualcomm 0.746.0,Yuzu,1.2.8.0,Perfect 60fps in docked mode,Pocket 5
+Arms,Great,Turnip 24.3.0 9v2,Citron,5.4.1,"Occasionally stuttering, FPS ranges 40-60 Docked. Some minor graphical issues (Disappears after loading)",Pocket 5
+Army Of Ruin,Great,Qualcomm 805,Sudachi,1.0,"Played in docked mode, with no OC results in some stuttering in later levels due to the amount of monsters. usually 30FPS below level 12/13 dips to ~24 for a few moments at the start of each level. Played with the OC boot.img results in perfect 30FPS in later levels in docked mode. Trying to play a 2x resolution in handheld results in crashing when picking up boss boxes.",Pocket 5
+Arrog,Great,Qualcomm 0.746.0,Yuzu,1.0.2,Don’t understand this game but it is smooth and runs well,Pocket 5
+Art Of Rally,Perfect,Turnip 24.3.0 9v2,Citron,1.1.8 + DLC,"Perfect, locked 30 FPS. Docked Mode ON, Accuracy Level HIGH, Disk Shader Cache ON, Asynchronous Shaders ON RP5 in Performance mode (not High Performance). Very occasional micro-stutters, only brief and temporarily.",Pocket 5
+Asdivine Hearts,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 30fps in docked mode,Pocket 5
+Aspire: Ina’s Tale,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked and looks amazing on OLED,Pocket 5
+Assassin’s Creed 2,Poor,Qualcomm 0.746.0,Yuzu,1.0,Has severe graphical glitching not playable on Sudachi or Yuzu,Pocket 5
+Assassin’s Creed 4,Playable,Turnip 24.3.0 9v2,Citron,1.0,"graphics accuracy on high docked mode off, fsr enabled.",Pocket 5
+Assassin’s Creed 4,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Actually runs at decent framerate in handheld mode but lots of isual glitches,Pocket 5
+Assassin’s Creed: The Ezio Collection,Playable,Turnip 24.3.0 9v2,Suyu,1.3,"Technically possible to get into the game and get 20-30fps fairly consistently. Frames hit 0 a lot and you need to swipe up the app into the recent apps screen and back down to make the frames start up again, but otherwise it’s 20-30fps. You will have to do this A LOT. Also isually it’s ERY glitchy. But I did manage to make it into AC2 up to the point where you meet the girl at night after jumping into the hay, didn’t crash. Can’t boot DLC.",Pocket 5
+Assassin’s Creed: The Rebel Collection,Great,Turnip 24.3.0 9v2,Citron,1.0,"working with constant 25-30FPS, resolution 1x, accuracy level to High, DS on, FMC ON, UAS ON",Pocket 5
+Assassin’s Creed: The Rebel Collection,Playable,Turnip 24.3.0 9v2,Suyu,1.0,".75x resolution, disk shader cache = true, force maximum clocks = true. Pretty finicky, seems to only crash sometimes when trying to boot, won’t boot at all if the settings aren’t right. Hits 20-30fps fairly consistantly, but does hit 0 FPS and hang there pretty often. Swipe the app up into recent apps and back down to jumpstart FPS again. Managed to boot into both games. Got onto land and killed the assassin after some parkour in black flag and ran around and did some parkour/cut scenes in rogue. Rogue seems to be less buggy, but both are isually ery buggy.",Pocket 5
+Astalon: Tears Of The Earth,Perfect,Qualcomm 0.746.0,Yuzu,1.0.12.1,Perfect 60fps in docked mode,Pocket 5
+Astalon: Tears Of The Earth,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Astebreed,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Black screen on Yuzu and Sudachi with either driver,Pocket 5
+Asterix & Obelix Xxl3: The Crystal Menhir,Perfect,Turnip 24.3.0 9v2,Eden,1.0,27-30 fps Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Asterix & Obelix Xxxl: The Ram From Hibernia,Perfect,Turnip 24.3.0 9v2,Eden,1.0,30 fps (The main menu runs at 18 fps) Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Astlibra Revision,Perfect,Turnip 24.3.0 9v2,Citron,1.0.5,Runs at full speed 60fps in docked mode,Pocket 5
+Astral Ascent,Poor,Qualcomm 0.746.0,Citron,1.0.13,Playable with graphical glitches for 30 minutes then crashes. Sudachi plays perfectly but crashes when accessing the merchant’s menu.,Pocket 5
+Astral Chain,Great,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Astral Chain,Great,Qualcomm 744.12,Citron,1.0,v744.12 gives me the best performance. less dips. Handheld. Async & max clocks on,Pocket 5
+Astral Chain,Great,Qualcomm 0.746.0,Yuzu,1.0,"Dips to 20fps in docked mode, but handheld mode is mostly 30 with an occasional dip to 25 but great experience.",Pocket 5
+Astral Chain,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"FPS can fluctuate (12-25 FPS) but is mostly playable, based on playing the intro.",Pocket 5
+Astral Flux,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Astral Flux,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Astroneer,Poor,Qualcomm 0.746.0,Yuzu,1.0,No boot in Yuzu or Sudachi with either driver,Pocket 5
+Atelier Ayesha: The Alchemist of Dusk DX,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Full speed at 30fps in handheld mode. Not a single frame drop.,Pocket 5
+Atelier Marie Remake: The Alchemist of Salburg,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Can get into town and run around. Frames gravitate around 20fps. bit sluggish but I would consider it playable.,Pocket 5
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"Frames at 22-25 , mostly 23 , playable at this state",Pocket 5
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Great,Turnip 24.3.0 9v2,Sudachi,1.0,0.75x resolution Disk shader cache ON Async Shaders ON Runs at constant 30fps,Pocket 5
+Atelier Ryza: Ever Darkness & The Secret Hideout,Great,Turnip 24.3.0 9v2,Eden,1.0.8,Minor Graphic Visual Glitch 0.75x resolution Disk shader cache ON Async Shaders ON,Pocket 5
+Atelier Shallie: Alchemists of the Dusk Sea DX,Great,Turnip 24.3.0 9v2,Suyu,1.0,From what I can tell it’s running almost perfect but does have some slight drops. Nothing that is super noticeable. I did have one moment where I was stuck on a loading loop but a reboot seemed to fix it.,Pocket 5
+Atone: Heart Of The Elder Tree,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps in docked mode,Pocket 5
+Avicci Invector,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Seems like its gonna work during calibration but then goes to 0fps black screen in Yuzu and Sudachi,Pocket 5
+Azura’s Crystals,Poor,Turnip 24.3.0 9v2,Citron,1.0,Game starts but crashes after the girl goes out of the house in all emulators,Pocket 5
+Azure Striker Gunvolt: Striker Pack,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Full 60 FPS Docked Mode looks gorgeous,Pocket 5
+Baba Is You,Perfect,Qualcomm 0.746.0,Eden,1.0,,Pocket 5
+Badland: Game Of The Year Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps in docked mode, looks great on OLED",Pocket 5
+Bakeru,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Video precision : High,Pocket 5
+Balatro,Perfect,Turnip 23.2.0,Sudachi,1.0,,Pocket 5
+Balatro,Perfect,Turnip 24.3.0 R5,Sudachi,Update 1.0.9,Other drivers should run fine but you will lose the background graphics in game,Pocket 5
+Balatro,Perfect,Turnip 24.3.0 9v2,Citron,1.1.0,Citron is back in development! *IT SOMETIMES GETS STUCK ON LOADING JUST EXIT AND LAUNCH THE GAME UNTIL IT STARTS* 60 FPS Settings: Docked 1x Res. Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Baldo The Guardian Owls,Perfect,Qualcomm 0.746.0,Yuzu,1.0.15,Perfect 60fps docked,Pocket 5
+Baldur’s Gate And Baldur’s Gate II: Enhanced Editions,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,Runs wonderfully,Pocket 5
+Barbie Dreamhouse Adventures,Perfect,Turnip 24.3.0 9v2,Citron,2023.07.11,"Force Maximum clock, Use async shaders",Pocket 5
+Bastion,Perfect,Qualcomm 0.746.0,Citron,1.0,Standard setup file works perfect for me. Docked is the only additional change.,Pocket 5
+Bastion,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Bat Boy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a),Pocket 5
+Batman Arkham Asylum,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,It’s running really great @30fps on 1x resolution. But at some points or after a couple of minutes in the game it’ll freeze and the only way to progress is to delete the compiled shaders. So it’s kinda annoying that you have to close the emulator and delete the shaders for every 3-5 minutes.,Pocket 5
+Batman Arkham Asylum,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"30FPS @ Handheld, 0.75x Resolution",Pocket 5
+Batman Arkham Asylum,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.1,25-30 FPS Docked Mode Resolution x0.75,Pocket 5
+Batman Arkham City,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"very playable, some slowdown in combat, much fan noise",Pocket 5
+Batman Arkham City,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,30 Fps Handeld Mode Resolution x1,Pocket 5
+Batman: The Telltale Series,Playable,Qualcomm 0.746.0,Citron,1.0,Slight graphic artifacts and frame drops that have a chance to get you killed in the quick time events.,Pocket 5
+Battle Brothers,Perfect,Qualcomm 0.746.0,Sudachi,1.13.0,,Pocket 5
+Battle Chasers: Nightwar,Great,Turnip 24.3.0 9v2,Sudachi,1.0.2,"Some minor graphical glitches when entering combat, nothing gamebreaking",Pocket 5
+Battle Kid: Fortress Of Peril,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Bayonetta,Great,Turnip 24.3.0 9v2,Citron,1.1,Works really well. Handheld x1. Could change fps to cap at 45 to improve eperience via “Limit speed percent” to 70-75%. I run at 100% and do experience frame drops. The most intensive part of the game is the opening part where you will see drops to nearly 30 fps but the rest of the game is 55-45 fps.,Pocket 5
+Bayonetta,Great,Turnip 24.3.0 9v2,Sudachi,v1.1,minor fps drops when facing multiple enemies,Pocket 5
+Bayonetta 2,Great,Turnip 24.3.0 9v2,Sudachi,1.2,Lag during some cutscenes but plays great,Pocket 5
+Bayonetta 3,Poor,Turnip 24.3.0 9v2,Sudachi,1.2.0,Crashes when booting up game. Also crashes when changing drivers to Turnip 25.0.0 R4 or Qualcomm 777,Pocket 5
+Bayonetta Origins: Cereza And The Lost Demon,Great,Qualcomm 0.746.0,Yuzu,1.0,"Stable 30fps docked mode, some minor isual glitches occasionally but a great experience",Pocket 5
+Beasts Of Maravilla Island,Poor,Qualcomm 0.746.0,Yuzu,1.0.3,"It boots but every 20 seconds or so it completely freezes for several seconds I would consider unplayable, might be playable after shaders compile.",Pocket 5
+Beat Cop,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,60 fps Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Belle Boomerang,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Beyblade X Xone,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.6,crash after character selection,Pocket 5
+Beyblade X Xone,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.6,Crash after character selection,Pocket 5
+Beyond A Steel Sky,Perfect,Turnip 25.0.0 R5,Sudachi,1.0,"Handheld mode, perfect 30fps for first 25 min of game",Pocket 5
+Beyond Good And Evil – 20th Anniversary Edition,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"25fps docked mode some slowdown, better off playing on Gamecube",Pocket 5
+Big Helmet Heroes,Great,Turnip 24.3.0 9v2,Citron,1.0,Sometimes a crash may occur when the game loads a new location,Pocket 5
+"Big Kitty, Little City",Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Biomutant,Poor,Qualcomm 0.746.0,Yuzu,1.0,No launch in Sudachi or Yuzu with either driver,Pocket 5
+Bioshock Remastered,Poor,Qualcomm 0.746.0,Yuzu,1.0,"Tried Sudachi and Yuzu with both drivers with and without update, everything is 10fps with major isual glitching.",Pocket 5
+Bite The Bullet,Perfect,Qualcomm 0.746.0,Yuzu,1.2.1,Perfect 60fps in docked mode,Pocket 5
+Black Skylands,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 30fps, weird game",Pocket 5
+Black Witchcraft,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Plays Perfectly no audio glitches or lag,Pocket 5
+Black Witchcraft,Great,Turnip 24.3.0 9v2,Yuzu,1.0,mine wont play audio? gameplay is smooth though,Pocket 5
+Blade Assault,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 30fps docked mode,Pocket 5
+Blade Chimera,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.35,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Blade Chimera,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Slow loading at first or in between scenes sometimes but works perfect,Pocket 5
+Blade Runner Enhanced Edition,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Bladed Fury,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Plays great completed 2 levels: Some frame drops here and there but honestly faced this on switch as well,Pocket 5
+Blair Witch,Poor,Qualcomm 0.746.0,Yuzu,1.0,No luck in Yuzu or Sudachi with either driver,Pocket 5
+Blanc,Poor,Qualcomm 0.746.0,Yuzu,1.0,tried multiple settings but never got a stable frame rate and it has constant glitching in all drivers,Pocket 5
+Blasphemous,Perfect,Qualcomm 0.746.0,Citron,1.0.8 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On,Pocket 5
+Blasphemous,Perfect,Qualcomm 0.746.0,Yuzu,1.0.8,"1dlc installed, perfect 60fps docked",Pocket 5
+Blasphemous 2,Perfect,Turnip 24.3.0 9v2,Citron,1.0.3,Citron is back in development! Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Blasphemous 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Play amazingggg,Pocket 5
+Blast Brigade vs. The Evil Legion Of Dr. Cread,Great,Qualcomm 0.746.0,Citron,1.0.4,"Experienced framerate drops using any Turnip, but it seems to work perfectly with the system driver.",Pocket 5
+Blazing Strike,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,amazing game like tekken runs perfect,Pocket 5
+Bloodstained – Curse Of The Moon,Perfect,Qualcomm 0.746.0,Citron,ver 1.1,,Pocket 5
+Bloodstained: Ritual Of The Night,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"If you Update the Game, it becomes unplayable with many graphical glitches. er.1.0 runs almost at 60fps in Handheld with no glitches.",Pocket 5
+Bloomtown: A Different Story,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a),Pocket 5
+Bluey: The Videogame,Perfect,Turnip 24.3.0 9v2,Citron,1.0.6,"60FPS 1x resolution, Adapting Filter: AMD FidelityFX, AA Method: FXAA, Force Max Clock, Use Asynch shaders",Pocket 5
+Bomb Rush Cyberfunk,Perfect,Turnip 24.1.0 R18,Citron,v1.0.19975 (v262144),"Docked mode, 1080p almost locked 60fps (rare drops to high 50s) Enable the in-game “Unleash the beast” setting for 60fps – default is 30fps. Citron latest ersion. Stock drivers and 9v2 had shadow graphical issues which are resolved using this driver. All other settings are default. Here is the download link for the 24.1.0 – Rev. 18 driver: https://github.com/K11MCH1/AdrenoToolsDrivers/releases/ download/v24.1.0_R18/Turnip-24.1.0.adpkg_R18.a6xx.zip",Pocket 5
+Bomb Rush Cyberfunk,Perfect,Qualcomm 0.746.0,Citron,1.0.19975 + DLC,Citron is back in development! 30 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Bomb Rush Cyberfunk,Great,Qualcomm 0.746.0,Yuzu,1.0.19175,,Pocket 5
+Bomb Rush Cyberfunk,Perfect,Qualcomm 0.746.0,Yuzu,1.0.19975,Perfect 30fps in docked mode,Pocket 5
+Bonds Of The Skies,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Boomerang Fu,Great,Turnip 24.3.0 9v2,Yuzu,1.3.4,"Sometimes “soft” freezes, and I have to swipe up to task manager and it kicks back in. Also controllers have to swipe to open controller menu at player select screen every time to get them to kick back on.",Pocket 5
+Boot Hill Heroes,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60 in docked mode,Pocket 5
+Borderlands,Great,Qualcomm 0.746.0,Yuzu,1.0.2,Runs great in docked mode almost constant 30fps occasional dips,Pocket 5
+Borderlands 2,Perfect,Turnip 24.3.0 9v2,Yuzu,2921a2426,Yuzu with this particular ersion only. Other ersions will be stuck on intro. Run perfect 30fps.,Pocket 5
+Borderlands: The Pre-Sequel Ultimate Edition,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.1,"Runs 20-30fps and has frequent pauses, playable if you have a lot of patience",Pocket 5
+Boreal Tenebrae,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Perfect in handheld mode,Pocket 5
+Born Of Bread,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"colors look like their blown out on first load, exit & restart fixed",Pocket 5
+Born Of Bread,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Boti: Byteland Overclocked,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Handheld mode gets mostly 30fps but there is def some glitching and dips,Pocket 5
+Braid Anniversary Edition,Perfect,Qualcomm 0.746.0,Sudachi,1.5.0,Docked runs at 40-60 FPS,Pocket 5
+Bramble The Mountain King,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Black screen on Yuzu and Sudachi with both drivers,Pocket 5
+Bravely Default II,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,some fps dips and sound crackling,Pocket 5
+Breathedge,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.2,Crashes after intro in Yuzu and Sudachi with both drivers,Pocket 5
+Brewmaster Beer Brewing Simulator,Poor,Qualcomm 0.746.0,Sudachi,1.0,Game won’t load at all,Pocket 5
+Broforce,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1.3132,Runs perfect. Solid fps the entire first mission and in menus.,Pocket 5
+Brotato,Perfect,Qualcomm 0.746.0,Yuzu,1.0.0.3h,Perfect 60fps in docked mode,Pocket 5
+Brothers,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Perfect 60fps but some audio glitching that will bother you if you are sensitive to that, also the dual trigger dual stick controls of this game are ery uncomfortable on RP5",Pocket 5
+Bud Spencer & Terence Hill – Slaps And Beans 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,60 fps Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Bug Fables,Perfect,Turnip 24.3.0 9v2,Citron,1.2.0.1,Runs perfectly at full speed,Pocket 5
+Bugsnax,Great,Qualcomm 0.746.0,Yuzu,1.0.2,Almost perfect I am getting one weird black box isual glitch in the background but it plays great,Pocket 5
+Bulletstorm Duke Of Switch Edition,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Bulletstorm Duke Of Switch Edition,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Burnout Legends,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Some minor slowdowns but almost always above 50fps,Pocket 5
+Burnout Paradise Remastered,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,Audio engine – cubeb,Pocket 5
+Burnout Paradise Remastered,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Not quite locked on 60FPS but plays smooth.,Pocket 5
+Butcher,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Bzzzt,Perfect,Qualcomm 0.746.0,Citron,1.0,Plays perfectly,Pocket 5
+Bzzzt,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps fun game!,Pocket 5
+Cadence Of Hyrule: Crypt Of The Necrodancer,Perfect,Qualcomm 0.746.0,Yuzu,1.4.0,Perfect 60fps in docked mode,Pocket 5
+Call Of Juarez: Gunslinger,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.3,"Mode: Handheld, 30FPS locked",Pocket 5
+Capcom Fighting Collection 2,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,Docked 1x No issues Prod.Key 20+,Pocket 5
+Captai,Great,Turnip 25.2.0 R9,Eden,1.3.0,Great. Playable up to 35 FPS,Pocket 5
+Captain Toad: Treasure Tracker,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Captain Toad: Treasure Tracker,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,"locked 60 fps, Plays great!",Pocket 5
+Caravan Sandwich,Poor,Turnip 24.3.0 9v2,Citron,1.0,crashes on load,Pocket 5
+Carrion,Perfect,Qualcomm 805,Sudachi,1.0,,Pocket 5
+Carto,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,Perfect 60fps in docked mode,Pocket 5
+Cassette Beasts,Great,Qualcomm 0.746.0,Yuzu,1.3.0,"1 DLC installed, almost perfect 30fps in handheld mode but threre are some dips, still a ery good experience.",Pocket 5
+Castlestorm,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Default settings.,Pocket 5
+Castlestorm 2,Poor,Turnip 24.3.0 9v2,Yuzu,1.2.0.0,"50 fps in main game at 0.75x handheld, 60 in arcade mode. Crashes after a minute.",Pocket 5
+Castlevania Anniversary Collection,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Castlevania Dominus Collection,Perfect,Turnip 24.3.0 9v2,Citron,1.1,,Pocket 5
+Cat Quest,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked mode,Pocket 5
+Cat Quest III,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Cat Quest III,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Catan Console Edition,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Catan Console Edition,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Catastronauts!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Catherine: Full Body,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.1,,Pocket 5
+Cave Story+,Perfect,Qualcomm 0.746.0,Yuzu,1.3,Perfect 60fps docked,Pocket 5
+Cel Damage Hd,Poor,Qualcomm 0.746.0,Yuzu,1.0,Boots to a black screen on Yuzu and Sudachi with both drivers,Pocket 5
+Celeste,Poor,Turnip 25.2.0 R9,Sudachi,1.4.0.0,Crashes when meeting the old man and first dialog starts,Pocket 5
+Celeste,Perfect,Qualcomm 0.746.0,Sudachi,1.4.0.0,,Pocket 5
+Celeste,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Perfect performance with no additional changes in the settings needed. 60 FPS.,Pocket 5
+Celeste,Perfect,Turnip 24.3.0 9v2,Citron,1.4.1.1,,Pocket 5
+Chained Echoes,Perfect,Qualcomm 0.746.0,Yuzu,1.31,Does not boot with Turnip 9v2,Pocket 5
+Chicken Police,Playable,Qualcomm 0.746.0,Yuzu,1.0.3,A little choppy but its playable in docked mode,Pocket 5
+Child Of Light Ultimate Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps docked, looks amazing on OLED",Pocket 5
+Chocobo Gp,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.4.1 + DLC,Yuzu 278 (dc529a89a) Runs at ~60fps docked Mays crash in the intro loop (just press A button to bypass) Works with other Turnips but not default / Qualcomm,Pocket 5
+Choo-Choo Charles,Playable,Turnip 25.0.0 R5,Yuzu,1.0,Actually plays well in handheld mode but there is no audio and some isual glitches,Pocket 5
+Chrono Cross – The Radical Dreamers Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Circuit Superstars,Perfect,Qualcomm 0.746.0,Sudachi,1.0,"The game works perfectly after several championships. It has only frozen when I tried to close the emulator, and it got stuck. But the game was saved.”",Pocket 5
+Citizen Sleeper,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Citizen Sleeper,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Civilization II,Great,Turnip 24.1.0 R18,Sudachi,1.0,"Needs the last Sudachi ersion, game loads and works great, but the map appears cloudy, but texts can be read",Pocket 5
+Clubhouse Games,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Runs well in Standard performance mode,Pocket 5
+Cluster Truck,Perfect,Qualcomm 0.746.0,Citron,1.0,Almost Perfect 60 FPS Docked in levels Some minor FPS dips occasionally Only low FPS in menu,Pocket 5
+Cobalt Core,Poor,Qualcomm 0.746.0,Sudachi,1.0,Tried multiple drivers and settings. Hangs at the start up loading screen.,Pocket 5
+Code Of Princess Ex,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Code Realize Wintertide Miracles,Perfect,Turnip 24.1.0 R18,Yuzu,1.0,"docked mode. 60fps most of the time except when recalling the log, but this is an issue i faced on official hardware as well. save often, game was prone to ery occasional crashes but switching to handheld mode might help. i never used skip text function, but i saw online people saying it would crash the game on official hardware so skip with caution.",Pocket 5
+Coffee Talk,Perfect,Qualcomm 0.746.0,Yuzu,1.47,Perfect 60fps in docked mode,Pocket 5
+Collection Of Mana,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect docked,Pocket 5
+Commandos 2 – HD Remaster,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Undocked Video precision : High Force max frequencies : Yes,Pocket 5
+Commandos 3 – HD Remaster,Great,Turnip 24.3.0 9v2,Yuzu,v1.00.053,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Company Of Heroes,Great,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Contra Operation Galuga,Great,Turnip 24.3.0 9v2,Sudachi,1.0.882291,"Default settings. Locked 30 fps at 1x in arcade mode, crashes after defeating the first boss. In campaign mode, it crashes before the boss.",Pocket 5
+Contra Operation Galuga,Great,Turnip 23.2.0,Citron,1.0,Some drops in FPS during startup and initial animation screen. But once the game is loaded I get a solid 30FPS for all game play as well as animation and dialog scenes. Borderline perfect.,Pocket 5
+Core Keeper,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Update breaks the game and doesn’t run. Stay on base ersion. Turnip doesn’t work. Yuzu doesn’t work. Sudachi and Suyu offer same performance. Perfect 50-60 FPS (Game’s target is 30).,Pocket 5
+Corpse Party,Perfect,Qualcomm 0.746.0,Yuzu,1.03,Perfect 60fps in docked mode,Pocket 5
+Crash Bandicoot 4,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"2DLC, handheld mode, .75x resolution, gets 25-30fps ery fun on rp5",Pocket 5
+Crash Bandicoot N. Sane Trilogy,Great,Turnip 24.1.0 R17,Citron,be191f740,"Most of the game runs perfect, but there are some small parts where it runs at ~10fps, so far I’ve seen this at the end of the bonus stages and whenever a specific enemy is on screen 1x (handheld) sync- immediate (off). Use asynchronous shaders – yes. CPU accuracy – unsafe.",Pocket 5
+Crash Bandicoot N. Sane Trilogy,Great,Turnip 24.1.0 R18,Yuzu,1.0,it runs around 30 fps for most of it but did freeze in the second level of crash warped but that might be a one time thing,Pocket 5
+Crash Bandicoot N. Sane Trilogy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"0.75x Docked rendering (810p), Force maximum clocks and asynchronous shader set to on, rest default. RP5 in High Performance mode. Above gives solid and smooth 30fps (at least in 1st and 3rd part of the trilogy, I haven’t tested 2nd part yet).",Pocket 5
+Crash Bandicoot N. Sane Trilogy,Great,Turnip 24.3.0 9v2,Skyline,1.0,Runs about 5-7 fps faster on Skyline,Pocket 5
+Crash Bandicoot N. Sane Trilogy,Perfect,Turnip 24.1.0 R17,Sudachi,Latest,Vsync- immediate (off). Use asynchronous shaders – yes. CPU accuracy – unsafe.,Pocket 5
+Crash Team Racing: Nitro-Fueled,Poor,Turnip 24.3.0 9v2,Citron,1.0,Crash at the start of the race,Pocket 5
+Crash Team Racing: Nitro-Fueled,Perfect,Qualcomm 0.746.0,Skyline,1.0,"Docked mode, Force maximum clocks on and RP5 in High Performance gives smooth and stable 30fps",Pocket 5
+Crash Team Racing: Nitro-Fueled,Great,Qualcomm 0.746.0,Skyline,1.0,"Updates/DLC not supported, 30fps in docked mode",Pocket 5
+Crashlands,Perfect,Qualcomm 0.746.0,Sudachi,1.00.0.93.0,,Pocket 5
+Crawl,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Creepy Tale,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Cris Tales,Great,Qualcomm 0.746.0,Yuzu,1.03,Perfect 30fps docked mode but some minor isual and audio glitches,Pocket 5
+Crisis Core: Final Fantasy II Reunion,Great,Turnip 24.3.0 9v2,Citron,1.0.1,"Handheld Mode Accuracy Level : High Disk Shader Cache : On Force Maximum Clocks : On Use Async Shaders : On Audio : Cubeb Prologue is a little bit choppy at 18-30fps, but after the whole thing ran at 28-30 fps. Only thing that holds this back is intermittent blooming issues. I’ve been having trouble using cheats on Citron, but if anyone could help itd be greatly appreciated bc i have 30fps, no bloom, and no dof cheats that would definitely change htis from great to perfect",Pocket 5
+Crosscode,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,"Played 2h, super smooth",Pocket 5
+Crow Country,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Crow Country,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Crown Trick,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 60fps docked, looks great",Pocket 5
+Cruis’n Blast,Perfect,Turnip 24.3.0 9v2,Sudachi,1.07,"Did one race, stable 60fps docked, put the unit in sleep for 45 mins mid-race",Pocket 5
+Cruis’n Blast,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Crumble,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Crymachina,Perfect,Turnip 24.3.0 9v2,Sudachi,1.2.0,"Locked 30FPS in handheld mode, set graphics accuracy to high.",Pocket 5
+Crypt Custodian,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Crypt Custodian,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Crysis Remastered,Poor,Qualcomm 0.746.0,Yuzu,1.7.0,Neither driver work both boot to menu but crash when game starts,Pocket 5
+Crystal Breaker,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Ctr: Nitro Fueled,Perfect,Turnip 24.2.0 R19,Sudachi,1.0.15,game crashes before I can even start a race on a loading screen. If I go pass the loading (sometimes it happens) I just see a black screen,Pocket 5
+Cult Of The Lamb,Perfect,Qualcomm 0.746.0,Citron,1.4.5 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Cult Of The Lamb,Perfect,Qualcomm 0.746.0,Suyu,1.0,Sudachi with 9v2 didn’t work,Pocket 5
+Cult Of The Lamb,Perfect,Qualcomm 0.746.0,Yuzu,1.4.6,60fps! Docked mode @ mostly 60fps with dips when entering rooms.,Pocket 5
+Cuphead,Perfect,Qualcomm 0.746.0,Yuzu,1.2.5,Perfect 60fps docked,Pocket 5
+Cuphead In The Delicious Last Course,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.7,,Pocket 5
+Curse Of The Dead Gods,Playable,Turnip 24.3.0 9v2,Citron,1.0,"0.75x Resolution, Docked for almost constant 30 FPS. Occasionally crashes, some minor graphical issues",Pocket 5
+Cursed To Golf,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Cyberage,Perfect,GPU 0.746.0 Qualcomm,Citron,1.0,,Pocket 5
+Dadish,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Dadish 3D,Great,Qualcomm 0.746.0,Yuzu,1.0,"40-60fps n slowdown runs great, slightly better framerates in handheld",Pocket 5
+Danganronpa: Trigger Happy Havoc Anniversary Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 docked,Pocket 5
+Dark Devotion,Poor,Qualcomm 0.746.0,Yuzu,1.0,Boots to black screen on Yuzu and Sudachi with both drivers,Pocket 5
+Dark Souls 1,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,"Needs a graphics fix, run in handheld mode or you will get gfx glitches (can’t see items on the ground etc.)",Pocket 5
+Dark Souls Remastered,Great,Turnip 24.3.0 9v2,Sudachi,Updated and Patched to fix the low light issues,"Occasional crashing (maybe once an hour or so), but performance is otherwise good.",Pocket 5
+Darkest Dungeon II,Playable,Qualcomm 0.746.0,Sudachi,1.0,(playable docked if you start a game in handheld first),Pocket 5
+Darkest Dungeon II,Playable,Qualcomm 0.746.0,Yuzu,1.0,loading can be slow,Pocket 5
+Darksiders I,Playable,Turnip 24.3.0 9v2,Citron,1.0,Somehow almost worse than Darksiders II,Pocket 5
+Darksiders II,Playable,Turnip 24.3.0 9v2,Citron,1.0,"It’s amazing that it even runs, but it has tons of painful stuttering and FPS dips constantly throughout the gameplay. Playable, but Painful",Pocket 5
+Darksiders Warmastered Edition,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,.5x resolution handheld mode 30fps for opening scene then drops to 11 then to 5,Pocket 5
+Darkwood,Perfect,Qualcomm,Sudachi,1.0.5,,Pocket 5
+Date Everything!,Perfect,default,Yuzu,1.0,Prologue can crash if mashed through. Bit slow but fully functional.,Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Yuzu,v1.0.4.1040,"Stable gameplay at 30 FPS in Docked Mode. Resolution set to 1× (1080p) for better performance and native fidelity. FIFO sync mode enabled to prevent screen tearing. Window Adaptation Filter set to Bicubic for smoother visuals, with FSR Sharpness at 10% for subtle image enhancement. FXAA anti-aliasing and 2× anisotropic filtering ensure clean visuals. Disk shader cache, asynchronous shaders, and reactive flushing enabled for maximum stability. Force Max Clocks disabled. No significant FPS drops experienced.",Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Yuzu,v1.0.3.978 + DLC,"Great gameplay at 30 FPS with occasional frame drops to 22-25 FPS at certain mid-game locales. Docked mode ON, 1 x Resolution, Sync Mode ON, Asynchronous shaders ON, Disk Shader Cache ON. I tried this on Citron 0.6 and the latest Sudachi (March 2025), and latest Yuzu with stock drivers seems to perform the most stable with no 0.0 FPS bugs or erratic stutters",Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Sudachi,v1.0.3.972 w/ DLC,"Game is packed into an XCI with the newest update and DLC. I am using keys and firmware 19.0.0. Using docked mode because the switch ersion is capped at 30fps. undocked instills some blur to text, use AMD fidelity if you prefer undocked.",Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Yuzu,Latest update + DLC,30fps with occasional stutters but overall nothing that hinders gameplay. Docked mode ON; 1x Resolution; Sync Mode ON; Asynchronous shaders ON; Disk shader Chache ON; Force Max Clocks ON;,Pocket 5
+Dave The Diver,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Dave The Diver,Perfect,Turnip 23.2.0,Yuzu,v1.0.3.972 AND DLC,Using latest prod keys and firmware. Docked with asychronous shaders ON.,Pocket 5
+Dawn Of The Monsters,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked,Pocket 5
+Dead Cells,Perfect,Turnip 24.3.0 9v2,Citron,1.23.2 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Dead Cells,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Dead Cells,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dead Cells,Perfect,Turnip 24.3.0 9v2,Yuzu,1.25.0,Play amazing,Pocket 5
+Dead End Job,Perfect,Qualcomm 0.746.0,Yuzu,1.0.5,Perfect 60fps in docked mode,Pocket 5
+Death Elevator 2,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Wont start,Pocket 5
+Death Mark,Perfect,Turnip 24.3.0 9v2,Citron,1.02,It’s a isual novel so not intensive. Seems to be running perfectly.,Pocket 5
+Death Tales,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Death’s Door,Perfect,Turnip 24.3.0 9v2,Citron,1.1.6,Citron 0.4 Mainline (be191f740) (Havent tried the “optimized”) Locked 30fps 1x Res. Handheld mode (720p) Everything default so far Played to the first boss,Pocket 5
+Death’s Gambit: Afterlife,Perfect,Qualcomm 0.746.0,Yuzu,1.0.6,Perfect 60fps docked,Pocket 5
+Deemo -Reborn-,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,Freezes before getting in game on Yuzu and Sudachi,Pocket 5
+Deltarune,Perfect,Qualcomm 0.746.0,Sudachi,1.0,"If audio glitching, use cubeb audio output engine",Pocket 5
+Deltarune,Perfect,Turnip 24.3.0 9v2,Citron,1.00a,1X docked. Works great. Played around 5 hours so far.,Pocket 5
+Demon Turf,Playable,Qualcomm 0.746.0,Sudachi,1.1,FPS is between 15-30 but it actually feels ery good art style makes FPS not a problem imo,Pocket 5
+Demon’s Tilt,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3,Handheld mode Run at 90% CPU for stability,Pocket 5
+Destroy All Humans!,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Destroy All Humans!,Poor,Qualcomm 0.746.0,Yuzu,1.0.1,No luck in Yuzu or Sudachi with either driver,Pocket 5
+Destroy All Humans!,Playable,Turnip 24.3.4-Unified (@Mr_Purple_666),Yuzu,1.0,"Technically runs, around 20-30 fps. 1x Rez, mailbox, shaders on and max clock. Not a great experience for such a great game.",Pocket 5
+Detective Pikachu Returns,Poor,Qualcomm 0.746.0,Sudachi,1.0,Needs default driver to work. Works flawlessly until the Jewel mission where it crashes when you go to the second floor of the mansion.,Pocket 5
+Detective Pikachu Returns,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Needs default driver to work,Pocket 5
+Devil Engine Complete Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.03,,Pocket 5
+Devil May Cry 1,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Devil May Cry 3 Special Edition,Great,Qualcomm 0.746.0,Yuzu,1.0.1,Almost perfect in docked mode just has an audio delay during cutscenes that does not effect gameplay,Pocket 5
+Dex,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60dps docked,Pocket 5
+Diablo 2: Resurrected,Playable,Qualcomm 0.746.0,Citron,1.0.3.0,You need the specific “Offline file” for your update-file to update the game. Install the “Offline file” as a mod. Load the exefs folder and it should install.,Pocket 5
+Diablo 3: Eternal Collection,Perfect,Turnip 24.3.0 9v2,Eden,1.0,No issues first 10 mins of game. 60 fps default settings,Pocket 5
+Diablo 3: Eternal Collection,Perfect,Turnip 24.3.0 9v2,Yuzu,2.7.7.92380,,Pocket 5
+Diablo III,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Diablo III,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dicey Dungeons,Perfect,Turnip 24.3.0 9v2,Citron,1.10.1,,Pocket 5
+Die After Sunset,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Perfect 30dps handheld,Pocket 5
+Diesel Legacy: The Brazen Age,Poor,Turnip 24.3.0 9v2,Citron,1.0,Stuck on title screen,Pocket 5
+Digimon Cyber Sleuth,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Stable 60fps in docked mode,Pocket 5
+Digimon Story Cyber Sleuth: Complete Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfection in docked mode,Pocket 5
+Digimon Survive,Playable,Qualcomm 0.746.0,Yuzu,1.0,Runs about 15fps but its a turn based rpg so it doesnt matter much,Pocket 5
+Digimon World -Next Order-,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60 docked, one of the best looking games I have tried so far on rp5",Pocket 5
+Disco Elysium – The Final Cut,Great,Qualcomm 0.746.0,Sudachi,1.0.1,Newest Sudachi Might take a couple of resets for shaders to build You can tune settings this is what worked for me 30fps stable in-game Accuracy Level – High .5x Res Vsync – mailbox Disk shader on force clocks on synch shaders on Reactive flush on Cpu accuracy – Paranoid,Pocket 5
+Disco Elysium – The Final Cut,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.9,No luck in Yuzu or Sudachi with either driver,Pocket 5
+Disgaea 5 Complete,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Intro movie is choppy and is around 30-50 fps I recommend skipping it rest is smooth 60 unless loading new area,Pocket 5
+Disney Dreamlight Valley,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Disney Epic Mickey: Rebrushed,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,A good amount of framerate dips but definitely playable with a little patience,Pocket 5
+Disney Illusion Island,Perfect,Qualcomm 0.746.0,Yuzu,1.1.1,"Perfect 60 docked mode, looks amazing",Pocket 5
+Divinity Original Sin 2,Playable,Turnip 24.3.0 R5,Citron,1.0.9,Game runs between 15fps-30fps. Playable but not fun. -FPSGODSpeed,Pocket 5
+Doctor Who: Edge Of Reality,Poor,Qualcomm 0.746.0,Yuzu,1.0.7,Freezes way too much to play in Yuzu and Sudachi with Qualcomm and Turnip 9v2,Pocket 5
+Dodgeball Academia,Perfect,Qualcomm 0.746.0,Citron,1.0,Perfect 60fps,Pocket 5
+Dogman: Mission Impawssible,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Played 3 levels, plays great",Pocket 5
+Dogurai,Perfect,Qualcomm 0.746.0,Yuzu,1.0,plays perfectly,Pocket 5
+Don’t Starve Nintendo Switch Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0.10,"1x Docked, runs at locked 60 fps.",Pocket 5
+Don’t Starve Together,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Will not even boot into game on Yuzu or Sudachi with either driver,Pocket 5
+Donkey Kong Country Returns HD,Great,Qualcomm 0.746.0,Sudachi,1.0.13,VSync off. Accuracy high. Handheld mode. High performance. Near perfect 60fps gameplay.,Pocket 5
+Donkey Kong Country Returns HD,Perfect,Qualcomm 0.746.0,Citron,1.0,VSync off. Accuracy high. Handheld mode. High performance. Near perfect 60fps gameplay.,Pocket 5
+Donkey Kong Country: Tropical Freeze,Perfect,Turnip 24.3.0 9v2,Yuzu,1.02,Perfect 60fps,Pocket 5
+Donkey Kong Country: Tropical Freeze,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps docked,Pocket 5
+Donkey Kong Country: Tropical Freeze,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,60 fps perfect and no graphical glitches,Pocket 5
+Donut Dodo,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,plays perfectly,Pocket 5
+Donuts’n’justice,Great,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked with audio glitches,Pocket 5
+Doom (2016),Playable,Turnip 24.1.0 R18,Citron,1.0,"Citron 0.4 (be191f740) Do not activate updates Docked : No CPU debugging : Yes Resolution : 0.5x Force GPU max frequencies : Yes AMD Fidelity FX goes to crash Also works with Turnip 24.1.0 R17_v2 FPS : 15~25, so playable but not enjoyable",Pocket 5
+Doom + Doom 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Doom 64,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 25fps docked, that is the locked framerate since its a port of an n64 game",Pocket 5
+Doraemon Dorayaki Shop Story,Great,Qualcomm 0.746.0,Yuzu,1.04,Game hangs when attempting to access “Site” menu.,Pocket 5
+Dorfromantik,Perfect,Qualcomm 0.746.0,Citron,I’m not sure.,"Runs perfect, you should play this game.",Pocket 5
+Double Dragon Neon,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"720p, standard performance setting",Pocket 5
+Dragon Ball FighterZ,Perfect,Turnip 24.1.0 R18,Citron,1.0,Needs DBZ crash fix mod to stop crashing when using supers https://www.mediafire.com/file/llur8mo8d2zln93/DBFZ_540p_crash_fix.zip/file Default everything .75 res,Pocket 5
+Dragon Ball FighterZ,Poor,Turnip 24.3.0 9v2,Yuzu,0.1.38,"Game either crashes at beginning of game, or when a special move is used",Pocket 5
+Dragon Ball FighterZ,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Turnip 25 rev5 did not work, 24.3.0 R9v2 worked.",Pocket 5
+Dragon Ball Z: Kakarot,Perfect,Turnip 25.2.0 R1,Sudachi,1.0,,Pocket 5
+Dragon Ball Z: Kakarot,Great,Turnip 24.3.0 9v2,Yuzu,"1.50, 15DLC",Works great framerate wise but there is a weird red glow over the screen during some battles. Handheld mode mostly 30fps with occasional dropped frames.,Pocket 5
+Dragon Marked For Death: Advanced Attackers,Perfect,Turnip 24.3.0 9v2,Sudachi,3.1.5,,Pocket 5
+Dragon Quest Builders,Great,Turnip 23.3.0-devel,Sudachi,1.0,"This is the only driver I found, where it doesn’t have a weird green border issue with the item bar. The game has a bug found in all emulators where some items will show the wrong icon(even on PC) but otherwise the game works fine for the most part.",Pocket 5
+Dragon Quest Builders 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Plays Perfect at 35fps , no graphical glitches",Pocket 5
+Dragon Quest III HD-2D Remake,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Audio can be a little crackly, but overall ery playable.",Pocket 5
+Dragon Quest III HD-2D Remake,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,has some stuttering in the open world,Pocket 5
+Dragon Quest III HD-2D Remake,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Can crash sometimes, performance is pretty much locked 30fps tho.",Pocket 5
+Dragon Quest Monsters,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 30dps docked looks great, some minor audio stutter that probably will go away in handheld mode but worth it to play docked",Pocket 5
+Dragon Quest X,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.1,20-30fps handheld mode but its in japanese,Pocket 5
+Dragon Quest XI S: Echoes Of An Elusive Age,Great,Turnip 24.3.0 9v2,Yuzu,1.0,No textures in Qualcomm – need to use Turnips,Pocket 5
+Dragon’s Dogma: Dark Arisen,Great,Qualcomm 0.746.0,Yuzu,1.0,Shockingly works amazing! Couple minor dips but its pretty much locked to 30 in docked mode,Pocket 5
+Draw A Stickman: Epic,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Dreamscaper,Poor,Turnip 24.3.0 9v2,Yuzu,1.1.1.5,Crashes after a few mins of play on Yuzu and Sudachi,Pocket 5
+Dredge,Poor,Turnip 24.3.0 9v2,Eden,1.5.3,"It’s a coin toss on whether the game will load. Most of the time you will make it to the title screen, but when you try to progress to the actual game, it will: 1. Load fine 2. Black screen 3. Crash and shut down the entire device",Pocket 5
+Dredge,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Dredge,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dredge,Great,Turnip 24.3.0 9v2,Sudachi,1.5.3,"Graphics accuracy set to high. Handheld Mode. 30FPS, minor dips. Async shaders improve performance a bit.",Pocket 5
+Dredge,Perfect,Turnip 9v2,Citron,1.5.3,,Pocket 5
+Drone Pilot: Extreme Flight Simulator,Great,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Dros,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.1,No luck with either driver in Yuzu or Sudachi,Pocket 5
+Drova Forsaken Kin,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Duck Detective: The Secret Salami,Perfect,Qualcomm 0.746.0,Eden,1.1.2,Accuracy Level needs to be set to High or the game will freeze when Tutorial pop ups are shown,Pocket 5
+Duck Detective: The Secret Salami,Poor,Turnip 24.3.0 9v2,Yuzu,1.1.2,"Tested on Yuzu and Sudachi with Qualcomm and Turnips, game freezes ery quickly",Pocket 5
+Duck Game,Perfect,Turnip 24.1.0 R18,Yuzu,1.0,"11/10 party game, runs great. Small graphics issues in certain screens in the game but they dont affect gameplay.",Pocket 5
+Dungeonoid 2: Awakening,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Dungeons And Doomknights,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dungeons Of Dreadrock – The Dead King’s Secret,Great,Qualcomm 0.746.0,Citron,v1.0.1,Citron 6b9dd40 Default parameters,Pocket 5
+Dungeons Of Dreadrock – The Dead King’s Secret,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Dungreed,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 60fps docked,Pocket 5
+Dusk,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Perfect 60fps, you do have to swipe up to stop freezes every once and while.",Pocket 5
+Dusk Diver,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Handheld mode .75x resolution almost perfect 30fps occasional dips,Pocket 5
+Dust & Neon,Great,Qualcomm 0.746.0,Yuzu,Yuzu 278 (dc529a89a) All default parameters,,Pocket 5
+Dust & Neon,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked,Pocket 5
+Dust: An Elysian Tail,Perfect,Turnip 24.3.0 9v2,Sudachi,1.06.181214,,Pocket 5
+Dustoff Heli Rescue 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Dying Light Definitive Collection,Great,Turnip 24.3.0 9v2,Yuzu,1.0,sometimes fps drops,Pocket 5
+Dysmantle,Great,Qualcomm 0.746.0,Sudachi,1.4.0.0,The minimap doesn’t work but the pause map does. I played 3 areas before I got bored. 40-60 FPS.,Pocket 5
+Ea Sports Fc 25,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Playable,Pocket 5
+Ea Sports Fc 25,Poor,Turnip 24.3.0 9v2,Yuzu,1.73,Does not open,Pocket 5
+Ea Sports Fc 25,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Doesn’t even open,Pocket 5
+Eastward,Perfect,Qualcomm 0.746.0,Yuzu,1.2.1 + Octopia DLC,Perfect 60fps docked,Pocket 5
+Eastward,Perfect,Turnip 24.3.0 9v2,Yuzu,1.2.1,60 fps,Pocket 5
+Eastward: Octopia!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.2.1,"60 fps, Plays Great!",Pocket 5
+Echo Generation,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 30fps handheld mode, looks like a cool game",Pocket 5
+Echoes Of The Plum Grove,Playable,Turnip 25.0.0 R8,Yuzu,1.0,,Pocket 5
+Elderand,Perfect,Qualcomm 0.746.0,Yuzu,1.3.2.1,Perfect 60fps docked,Pocket 5
+Eldest Souls,Perfect,Qualcomm 0.746.0,Yuzu,1.1.23,Perfect 60fps docked,Pocket 5
+Elsie,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Elypse,Great,Qualcomm 0.746.0,Yuzu,1.0.9,50-55fps in handheld mode,Pocket 5
+Elypse,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Elypse,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Emio: The Smiling Man – Famicom Detective Club,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Runs well without additional tweaks. No noticeable issues after several hours of play.,Pocket 5
+Empty Shell,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Crashes launcher,Pocket 5
+Enclave HD,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Docked,Pocket 5
+Ender Lilies: Quietus Of The Knights,Perfect,Turnip 24.3.0 9v2,Citron,1.1.1,"Needs the 1.1.1 update to play 60fps Citron 0.3, Accuracy Normal or High – High is more stable Kept the rest on default",Pocket 5
+Ender Magnolia Bloom In The Mist,Perfect,Turnip 24.3.0 9v2,Citron,0.3,"Handled, Accurancy high",Pocket 5
+Enraged Red Ogre,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,Runs perfectly 1x resolution,Pocket 5
+Enter The Gungeon,Perfect,Qualcomm 0.746.0,Yuzu,2.1.91,Perfect 60fps docked,Pocket 5
+Enter The Gungeon,Great,Turnip 24.3.0 9v2,Yuzu,2.1.92,One of my favorite switch games and it runs really great. There are frame drops occasionally and it’s not a locked 60fps but it’s more than playable.,Pocket 5
+Eternal Edge,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Not quite perfect 30fps docked but ery close,Pocket 5
+Eternights,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 30fps docked,Pocket 5
+Etrian Odyssey HD,Great,Qualcomm 0.746.0,Yuzu,1.0.2a,Not quite perfect 60fps docked but super close it feels like its perfect without the frame counter I would say its perfect,Pocket 5
+Evasion From Hell,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld mode sudachi,Pocket 5
+Everafter Falls,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Working great with latest Citron update,Pocket 5
+Everafter Falls,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Often crashes if trying to change controller settings mid-game – set up controllers before launching the game,Pocket 5
+Everhood,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,"Perfect 60fps docked, looks amazing on OLED",Pocket 5
+Everspace,Great,Turnip 24.1.0 R18,Sudachi,1.0.5,"Works great a 30 fps but the game quits after you die, but no graphic glitches or slow downs",Pocket 5
+Exhausted Man,Perfect,Qualcomm 0.746.0,Yuzu,1.0.6,Runs Perfect… bizarre game,Pocket 5
+Exzeus Collection,Perfect,Qualcomm 0.746.0,Yuzu,1.03,Perfect 60fps docked,Pocket 5
+F.I.S.T. Forged In Shadow Torch,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Boots in 9v2 but crashes before game starts on Yuzu and Sudachi,Pocket 5
+Factorio,Poor,Turnip 24.3.0 9v2,Sudachi,1.1.110,crash at first loading,Pocket 5
+Fading Afternoon,Poor,Qualcomm 0.746.0,Citron,1.3.0,"Stuck on black screen, does not start.",Pocket 5
+Fairy Tail,Playable,Turnip 24.3.0 9v2,Yuzu,"1.0.6, 62 DLC","Very playable in handheld mode .75x resolution with graphics accuracy set to high. About 30-40fps in battles and 20-40fps in the world, feels like a ita port but definitely playable.",Pocket 5
+Fallen Legion: Rise To Glory,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Docked mode, almost 60fps for the first stage.",Pocket 5
+Fantasian Neo Dimension,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"crashes on latest driver, 9v2 is perfect",Pocket 5
+Fantasy Life – The Girl Who Steals Time,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Plays but crashes every once in a while Asynchronous shaders on Vsync Fifo Relaxed Adreno Max clock enabled Disk Shaders cache off 0.5-0.75x resolution FRS 0% Anti Alias off Performance mode is fine but high may be better Game will crash before start if Disk Shaders cache enabled . Limiting factor looks to be the driver. Getting 28-30 Fps sometimes but gameplay has a little stuttering and it drops. Game crashes when too many things or inputs and happening, hard to say but there’s supposedly issues with memory leak in the game so an update may patch that. Running v1.00 of the game",Pocket 5
+Fantasy Life – The Girl Who Steals Time,Perfect,Turnip 24.3.0 9v2,Eden,1.1.0,After EXTENSIVE testing…. Accuracy: High Vsync: FIFO Relaxed Anti-aliasing: Off Shader cache: Off Async shaders: On Reactive flushing: On,Pocket 5
+Fantasy Life – The Girl Who Steals Time,Great,Turnip 24.3.0 9v2,Sudachi,1.1.0,1.0.0 crashes early. After updating to 1.1.0 I’ve been playing for a while and it’s flawless. Solid 30fps in handheld mode,Pocket 5
+Far: Changing Tides,Perfect,Qualcomm 0.746.0,Yuzu,v131072,"Crashes with 9v5, use Qualcomm GPU driver. Smooth 30fps.",Pocket 5
+Fast Rmx,Playable,Turnip 24.3.0 9v2,Citron,1.0,"Runs @20-30FPS, as a game supposed to run @60FPS, it is slow and not really playable. Tested with Sudachi and Citron, with multiples drivers and configuration, and with or without updates",Pocket 5
+Fatal Frame: Maiden Of Black Water,Great,Qualcomm 0.746.0,Yuzu,"1.0.2, 4 DLC",Great in docked mode 30fps most of the time drops to 20 for certain parts almost perfect.,Pocket 5
+Fatal Frame: Mask Of The Lunar Eclipse,Playable,Qualcomm 0.746.0,Yuzu,1.0,Handheld mode .75x resolution is playable mostly 30fps but some slowdown and audio glitching,Pocket 5
+Fate/samurai Remnant,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.2,Perfect on Resolution 0.75X,Pocket 5
+Fate/Stay Night Remastered,Perfect,Turnip 24.3.0 9v2,Yuzu,1.3.0 b335,,Pocket 5
+Fez,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Fifa 18,Great,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Fifa 18,Great,Turnip 24.3.0 9v2,Citron,1.0,60 FPS with occasional dips. No player indicator. Playable but disappointing,Pocket 5
+Fifa 19,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"It’s running great 60 fps troughout the game, sometimes dipping to 30 – 50 on goal celebration or replays. The only problem it’s missing player indicator. making it really hard to play",Pocket 5
+Fifa 23,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.3,"Player jerseys colour is blue, player names not showing",Pocket 5
+Fighting Ex Layer Another Dash,Perfect,Turnip 24.3.0 9v2,Sudachi,2.2.2,,Pocket 5
+Final Fantasy,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Final Fantasy Crystal Chronicles Remastered,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 30fps docked,Pocket 5
+Final Fantasy II,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,"Perfect 30fps docked, perfect 60fps using built in fast forward",Pocket 5
+Final Fantasy III,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Final Fantasy IV,Great,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps but has audio glitching,Pocket 5
+Final Fantasy Vi,Perfect,Turnip 25.2.0 R9,Sudachi,1.0,"Might have audio glitching, if so try cubeb audio output engine",Pocket 5
+Final Fantasy X HD Remaster,Perfect,Turnip 24.3.0 9v2,Citron,1.0,30 fps in handheld mode. Docked may work but certain wide shots slow to 20-25 fps.,Pocket 5
+Final Fantasy X HD Remaster,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Perfect 30fps in handheld mode,Pocket 5
+Final Fantasy XII,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Final Fantasy XV Pocket Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1.0,"Perfect 60fps handheld, super smooth 45-60fps docked",Pocket 5
+Final Vendetta,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Finding Paradise,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Fire Emblem Engage,Great,Qualcomm 0.746.0,Yuzu,1.0,"30fps docked, some ery minor dips almost perfect",Pocket 5
+Fire Emblem Warriors: Three Hopes,Playable,Turnip 25.2.0 R2,Citron,1.0,Expect a bunch of slowdowns due to shaders. Afterwards runs at a solid 30-40 fps. Runs better than Three Houses ;_;,Pocket 5
+Fire Emblem: Engage,Great,Turnip 24.3.0 9v2,Citron,2.0.0,"Make sure to have GPU Accuracy at High, save often as it may randomly crash.",Pocket 5
+Fire Emblem: Three Houses,Great,Qualcomm 0.746.0,Suyu,1.1.1,"Handheld, 0.75x only",Pocket 5
+Firewatch,Great,Turnip 24.1.0 R18,Yuzu,1.0,"Handheld mode, High graphics accuracy, 1x resolution. 25fps on average.",Pocket 5
+Firewatch,Great,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Five Nights At Freddy’s: Help Wanted 2,Great,Turnip 23.2.0,Citron,1.0,"The game runs great, but some sections require playing with Joy Cons (which have to be connected through Bluetooth)",Pocket 5
+Five Nights At Freddy’s: Help Wanted 2,Poor,Turnip 25.2.0 R11,Sudachi,1.0,The game shows a black screen all the time.,Pocket 5
+Five Nights At Freddy’s: Into The Pit,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Five Nights At Freddy´s: Security Breach,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Plays Perfect at 30fps,Pocket 5
+Flat Kingdom Paper’s Cut Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Flynn Son Of Crimson,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Didn’t play to completion yet but it plays perfectly in the beginning,Pocket 5
+Fnaf Sb,Great,Turnip 24.3.0 9v2,Yuzu,1.0,".75x handheld. Mostly 30 fps, dips to ~20 when looking at big areas and freezes briefly when loading areas (happens on every device). Overall, runs about as well as the switch (with the decreased resolution, of course).",Pocket 5
+Fobia,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps handheld mode,Pocket 5
+Food Delivery Battle,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Handheld mode gets 60fps BUT sometimes freezes but can be fixed by swiping up as if you were going to close the app then clicking back into it.,Pocket 5
+For A Vast Future,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+For The King,Great,Qualcomm 0.746.0,Yuzu,1.0,Handheld mode 30fps some slight dips,Pocket 5
+Forager,Great,Qualcomm 0.746.0,Sudachi,4.1.3,Starts on a black screen but if you wait a bit the game will play perfectly.,Pocket 5
+Forager,Perfect,Turnip 24.3.0 9v2,Citron,4.1.3,Takes around 1 minute to load at the beginning but otherwise runs perfectly,Pocket 5
+Forager,Perfect,Turnip 24.3.0 9v2,Skyline,1.0,Skyline 0.0.3 (1868) Only emulator that booted (all others : black screen with sound on),Pocket 5
+Forgive Me Father,Great,Turnip 24.3.0 9v2,Yuzu,1.5.4.3,Almost perfect 30fps just some slight dips great experience docked mode,Pocket 5
+Forgotten Anne,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Fortress S,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Freddi Fish 4: The Case Of The Hogfish Rustlers Of Briny Gulch,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Freddy Spaghetti,Poor,Qualcomm 0.746.0,Yuzu,1.0,"First game to completely crash my entire RP5, had to hard reset",Pocket 5
+Freedom Planet,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Flawless,Pocket 5
+Freedom Wars Remastered,Perfect,Qualcomm 0.746.0,Yuzu,1.0,PERFECT 30fps docked mode!! Looks great!,Pocket 5
+Frog Detective: The Entire Mystery,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 Docked,Pocket 5
+Frogue,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Frogun Deluxe Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1,Perfect 30 docked,Pocket 5
+From Heaven To Earth,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld mode,Pocket 5
+Funko Fusion,Playable,Turnip 24.3.0 9v2,Citron,0.1,It loads and can be played but there is a large amount of blinking graphically glitches that makes the screen hard to look at and the frames jump around often.,Pocket 5
+Furi Definitive Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.5.137,Menus and cutscenes a little laggy but does not affect gameplay,Pocket 5
+G.I. Joe: Wrath Of Cobra,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Slow loading but works great,Pocket 5
+Garden Story,Perfect,Qualcomm 0.746.0,Yuzu,1.4.1,Perfect 30fps docked,Pocket 5
+Gear Club Unlimited 2,Perfect,Qualcomm 0.746.0,Citron,1.7.2,"Menus run at a perfect 60, in game a perfect 30 and that is with the RP5 in performance mode.",Pocket 5
+Genesis Noir,Great,Turnip 24.3.0 9v2,Yuzu,1.7,"Perfect 30 handheld, some dips",Pocket 5
+Ghost Of A Tale,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,No boot in sudachi or yuzu with either driver,Pocket 5
+Ghost Song,Great,Qualcomm 0.746.0,Yuzu,1.2.12b,45fps docked 50-55 handheld,Pocket 5
+Ghost Sync,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"3 DLC, perfect 60 docked",Pocket 5
+Ghost Trick: Phantom Detective,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"works perfect, didn’t played too much tho",Pocket 5
+Ghostbusters: The Video Game – Remastered,Great,Turnip 24.3.0 9v2,Yuzu,v1.2,Yuzu 278 (dc529a89a) Resolution : 0.75x Force max frequencies : Yes May give better FPS with Uzuy MMJR,Pocket 5
+Ghostrunner,Playable,Turnip 24.3.0 9v2,Yuzu,1.8,"Good framerate handheld mode, but severe audio glitching making it impossible to play with sound",Pocket 5
+Ghosts And Apples,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 docked,Pocket 5
+Ghosts And Goblins Resurrection,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Goblin Sword,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Godstrike,Perfect,Qualcomm 0.746.0,Yuzu,2021.04.08,Perfect 30 docked,Pocket 5
+Going Under,Great,Turnip 24.3.0 9v2,Yuzu,1.0.4,Perfect 30fps but some audio glitching,Pocket 5
+Golf Story,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,,Pocket 5
+Golf With Your Friends,Perfect,Qualcomm 0.746.0,Sudachi,1.0.14,Default settings. Perfect 30 fps on the forest 18 holes.,Pocket 5
+Good Job!,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30 docked,Pocket 5
+Gori: Cuddly Carnage,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Crashes in Yuzu and Sudachi with both drivers,Pocket 5
+Gothic 2 Complete Classic,Playable,Turnip 23.2.0,Citron,1.0,"1х, handheld. Turn on Asynchronous Shaders. Stable 30 fsp. Sometimes crashes",Pocket 5
+Grand Mountain Adventure,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Hangs during loading,Pocket 5
+Grand Mountain Adventure: Wonderlands,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Severe isual glitches in Yuzu and Sudachi with both drivers,Pocket 5
+Grandia HD Collection,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,Black screen at the start and stay stuck like that. Try on other emulators for the same result,Pocket 5
+Grapple Dog,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Graveyard Keeper,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Graveyard Keeper,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Graveyard Keeper,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.0.4633,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Gravity Duck,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Greak: Memories Of Azur,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 handheld mode,Pocket 5
+Grim Fandango Remastered,Great,Qualcomm 0.746.0,Yuzu,1.0,SMOOTH 45-60FPS HANDHELD,Pocket 5
+Grim Fandango Remastered,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Grime,Playable,Turnip 24.3.0 9v2,Suyu,1.3.9,some crackling audio but otherwise locked 30 FPS,Pocket 5
+Grime – Definitive Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.3.9,Yuzu 278 (dc529a89a) All default parameters Use cubeb for good audio,Pocket 5
+Gripper,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"30fps handheld mode, some dips.",Pocket 5
+Gris,Great,Qualcomm 0.746.0,Yuzu,1.0,40-45fps docked,Pocket 5
+Groove Coaster Wai Wai Party,Perfect,Qualcomm 0.746.0,Citron,1.0.20 +49 DLCs,"Trying to play online locks up the game, haven’t been able to try local multiplayer. Sometimes the audio will stutter upon launch, restarting citron fixes it.",Pocket 5
+Grounded,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.4,"GPU accuracy set to high, undocked, res x0.75 12-20 fps",Pocket 5
+Grow: Song Of The Evertree,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.1,Handheld mode mostly 30fps some dips and freezes,Pocket 5
+Gta: San Andreas – Definitive Edition,Great,Turnip 24.3.0 9v2,Citron,1.0.8,"System – 100% max Speed, Handheld mode, Rest your choice Graphic – Extreme, 1X, Sync off, nearest neighbors, 25% FSR, AA off, AF standart, 16:9, DSC on, Max freq on, ASync Shader on, Urf off Audio – Auto Debug – ulkan, NCE, accurate, CPU Debugging on, Fastmem on not Final, work in progress, Runs good with some random crashes here and there",Pocket 5
+Guacamelee! 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Guacamelee! Super Turbo Championship Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Guayota,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Guilty Gear Strive,Great,Turnip 24.3.0 9v2,Citron,1.01,"Used performance mode and enabled asynchronous shaders. runs at a smooth 58-60, slight input lag.",Pocket 5
+Gun Gore & Cannoli 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,,Pocket 5
+Gunman Clive HD,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 docked,Pocket 5
+Guns Of Fury,Perfect,Turnip 24.3.0 9v2,Eden,1.0,More than 60% of the game completed. Perfect so far.,Pocket 5
+Guns Of Fury,Poor,Turnip 24.3.0 9v2,Citron,1.0,won’t boot black screen,Pocket 5
+Guns Of Fury,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,won’t boot,Pocket 5
+Gunslugs,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30 docked,Pocket 5
+Hades,Playable,Qualcomm 0.746.0,Citron,1.0,still trying to set it up but i am having lighting issues,Pocket 5
+Hades,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hades,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.37136,"Perfect 60 handheld, also perfect 60 docked but crashes",Pocket 5
+Hades,Perfect,Turnip 24.3.0 9v2,Yuzu,1.38232,"1x resolution, accuracy high, fifo (on), amd fidelityfx, SMAA 45-50fps",Pocket 5
+Hades,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Hades,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hades,Great,Turnip 24.3.0 9v2,Yuzu,1.0.38233,Might have character glitches at some point but ery rare,Pocket 5
+Happy’s Humble Burger Farm,Perfect,Turnip 23.0.0,Sudachi,1.0,"Rare minor graphical glitches, but otherwise runs at a buttery smooth 30 fps!",Pocket 5
+Hatsune Miku: Project Diva Mega Mix,Great,Qualcomm 0.746.0,Citron,1.0,Slight frame drops in select songs. Otherwise runs well with low load times.,Pocket 5
+Have A Nice Death,Great,Qualcomm 0.746.0,Sudachi,1.0,60 FPS . no problem,Pocket 5
+Have A Nice Death,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Heavenly Bodies,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Heavenly Bodies,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hell Is Other Demons,Perfect,Turnip 24.3.0 9v2,Citron,6.6.12,Perfect 60 FPS Docked,Pocket 5
+Hell Pie,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.4,Crashes before getting to gameplay,Pocket 5
+Hellblade: Senua’s Sacrifice,Playable,Turnip 24.3.0 9v2,Yuzu,1.1.0,"Handheld mode .75x resolution. accuracy set to high, runs about 20fps",Pocket 5
+Hellboy Web Of Wyrd,Poor,Qualcomm 0.746.0,Yuzu,1.0.4,boots and gets into game with 40fps but unfortunately continually freezes,Pocket 5
+Hello Kitty Island Adventure,Perfect,Turnip 24.3.0 9v2,Sudachi,1.10.1,"Works amazingly! Docked mode, Forced maximum clocks, use asynchronus shaders. Only issue I have had is with taking pictures, some pictures have weird texture problems, and saving the pictures crash the game.",Pocket 5
+Hello Neighbor,Great,Turnip 24.3.0 9v2,Yuzu,1.0,30-50fps handheld,Pocket 5
+Hellpoint,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Won’t boot on yuzu or sudachi with either driver,Pocket 5
+Heretic’s Fork,Great,Turnip 24.3.0 9v2,Citron,1.2.2.15,Almost Perfect 30 FPS. Occasional dips,Pocket 5
+High On Life,Playable,Turnip 24.3.0 9v2,Eden,1.0.3,playable and gets better while playing with graphical error where everything is recolored blue or green its kinda funny,Pocket 5
+Hitman Blood Money Reprisal,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Hitman Blood Money Reprisal,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Hob: The Definitive Edition,Poor,Turnip 24.3.0 9v2,Yuzu,1.1.2,Black screen in yuzu and sudachi,Pocket 5
+Hogwarts Legacy: Deluxe Edition,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"only qualcomm driver managed to load and go into character creation but theres is graphical glitches with the character, soon crashes at name creation.",Pocket 5
+Hollow Knight,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hollow Knight,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Hollow Knight,Perfect,Turnip 24.3.0 9v2,Sudachi,1.4.3.2b,,Pocket 5
+Horizon Chase 2,Great,Turnip 24.3.0 9v2,Yuzu,1.6.6,Only reason not saying perfect is because of occasional crashes and some microstutter Asych shaders ON. Audio – Cubeb. Run 1.6.6 update and build some shaders @ 30fps Then add the 60fps mod by StevensND,Pocket 5
+Horizon Chase Turbo,Perfect,Turnip 24.3.0 9v2,Yuzu,2.6.1,,Pocket 5
+Hotline Miami 1 & 2,Perfect,Qualcomm 0.615.77,Sudachi,2.0.3,"it crashes at first then it will work if you launch it again, no crashes after.",Pocket 5
+Hotline Miami 1 & 2,Perfect,Turnip 24.3.0 9v2,Yuzu,2.0.3,"it crashes at first then it will work if you launch it again, no crashes after.",Pocket 5
+Hotline Miami 1 & 2,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Hotshot Racing,Great,Turnip 24.1.0 R18,Sudachi,1.0.5,"Works great in handheld, 60fps most most of the time. Minor graphical glitches in the menu and rare graphical glitch in races too, barely noticeable.",Pocket 5
+Hotshot Racing,Great,Turnip 24.3.0 9v2,Sudachi,1.0.5,Almost there with 55-60fps. Some minor glitches in menu. ery good playable. Some drops to 40fps at explosions.,Pocket 5
+Hotshot Racing,Great,Qualcomm 0.746.0,Yuzu,1.0.5,Average about 45fps docked,Pocket 5
+Hue,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Huntdown,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Hunter X,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Wouldn’t load in Sudachi or Yuzu but seems great with Citron,Pocket 5
+Hunterxhunter Nenximpact,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Hyper Light Drifter,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Hypnospace Outlaw,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.4,Appears to run flawlessly.,Pocket 5
+Hyrule Warriors: Age Of Calamity,Great,Turnip 25.2.0 R4,Citron,1.3.0,"1xResolution (20-24 FPS), Window adaptive filter: AMD FidelityFX, AA Method: FXAA, Force Max clocks, use async shaders",Pocket 5
+Hyrule Warriors: Definitive Edition,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Game will crash randomly. Mostly in the first level, but the crashes are more rare past the first level. Save frequently from the start menu.",Pocket 5
+Hyrule Warriors: Definitive Edition,Great,Turnip 24.3.0 9v2,Yuzu,1.0.1,Definitely has some dips but mostly 30-40fps handheld mode seems like a good experienvce,Pocket 5
+I Am The Hero,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,Tested in docked mode,Pocket 5
+Iconoclasts,Perfect,Qualcomm 0.746.0,Yuzu,1.15p,:erfect 60fps docked,Pocket 5
+Ikenfell,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3.2,Perfect 60fps docked,Pocket 5
+Immortals Fenyx Rising,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Would, not boot in Yuzu or sudachi with any driver I tried",Pocket 5
+In Other Waters,Great,Turnip 24.3.0 9v2,Citron,1.0.4,Works well although the fps ranges from 30-50,Pocket 5
+In Sound Mind,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Crashes in Yuzu and Sudachi and slows the whole device down,Pocket 5
+Inmost,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4.3,Perfect 30fps docked,Pocket 5
+Inscryption,Perfect,Turnip 24.3.0 9v2,Citron,1.34.0,Citron is back in development! 30 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Can’t Tell If The Audio Is Stuttering/Crackling Or If It’s Just The Game SFX Everything Else Default.,Pocket 5
+Inscryption,Perfect,Turnip 24.3.0 9v2,Sudachi,1.20.1,Graphics accuracy level needs sets to high,Pocket 5
+Inside,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,So far so good… LOVE this game!,Pocket 5
+Into The Breach,Perfect,Turnip 25.2.0 R9,Sudachi,1.2.88,,Pocket 5
+Into The Breach,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Inukari – Chase Of Deception,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Iris And The Giant,Perfect,Qualcomm 0.746.0,Yuzu,1.1.8,Perfect 60fps handheld,Pocket 5
+Iron Meat,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Ironfall Invasion,Perfect,Qualcomm 0.746.0,Citron,1.0,1x handheld smooth 60 in my testing so far,Pocket 5
+Islanders,Great,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+It Takes Two,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Freezes before gameplay in yuzu and sudachi with all 3 drivers,Pocket 5
+Ittle Dew,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Jack Move,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 60fps docked,Pocket 5
+Jamestown+,Perfect,Qualcomm 0.746.0,Citron,1.0.3,,Pocket 5
+Jet Lancer,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Perfect 60 FPS, Takes around a minute to load at first",Pocket 5
+Jet Lancer,Playable,Turnip 24.3.0 9v2,Suyu,1.0,Does not start on suyu but works perfect at 30fps on yuzu docked,Pocket 5
+John Wick Hex,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Perfect 30fps docked,Pocket 5
+Jojo’s Bizarre Adventure: All-Star Battle R Deluxe Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,2.3.3,,Pocket 5
+Jujutsu Kaisen Cursed Clash,Playable,Turnip 24.3.0 9v2,Yuzu,1.2.0,Please use handheld mode if not it will crash at certain point of the game,Pocket 5
+Jurassic World Evolution,Great,Turnip 23.3.0-devel,Sudachi,1.0.1,Idk,Pocket 5
+Just Shapes & Beats,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Kamen Rider Memory Of Heroez,Great,Qualcomm 0.746.0,Citron,1.0,"Achieves consistent 30 fps gameplay Use 0.75 resolution with upscaling for assurance High Performance mode Throughout my gameplay, there were no game breaking graphical glitches that occured compared to using Turnip 9v2 where half of the screen turned black during cutscenes. Will test it further",Pocket 5
+Kamen Rider Memory Of Heroez Premium Sound Edition,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.1,Major graphical glitches making it unplayable even though it runs quite smoothly,Pocket 5
+Kamen Rider Memory Of Heroez Sound Edition,Perfect,Qualcomm 0.746.0,Citron,1.0,Performance mode is sufficient runs pretty good with a steady 30fps at 0.75x Asynchronous Shaders on you must use the qualcomm driver to not have the black graphics glitch,Pocket 5
+Kamibako – Mythology Of Cube,Perfect,Qualcomm 0.746.0,Citron,1.0,Citron 0.4 Some settings not necessary but this worked. Set limit speed to 200% for 60fps .75 resolution vsync mailbox disk shader cache force clocks reactive flushing cpu accuracy – unsafe,Pocket 5
+Kamiko,Perfect,Qualcomm 0.746.0,Sudachi,1.0,60fps consistent,Pocket 5
+Kanjozoku 2,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Cant get passes loading screen docked,Pocket 5
+Katamari Damacy Reroll,Perfect,Qualcomm 0.746.0,Yuzu,1.0,perfect 30 docked,Pocket 5
+Katana Zero,Perfect,Turnip 24.3.0 9v2,Citron,1.0.5,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Katana Zero,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.5,,Pocket 5
+Katrielle And The Millionaires’ Conspiracy,Great,Turnip 24.3.0 9v2,Sudachi,1.1,"Works great, about 3 hours into the game so far",Pocket 5
+Kaze And The Wild Masks,Perfect,Qualcomm 0.746.0,Sudachi,🎮 Nome do Jogo: Kaze and the Wild Masks 🗓 Data de Lançamento: 26 de março de 2021 🆔️ ID do Programa: 010038B00F142000 📀 Formato de Arquivo: NSP + Update v2.5.3 + DLC,Smooth gameplay with default settings and driver! This is an awesome indie game and it feels a bunch like old DKC games!,Pocket 5
+Keeper’s Toll,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Keeper’s Toll,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Kero Blaster,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Plays perfectly,Pocket 5
+Kill Knight,Perfect,Qualcomm 0.746.0,Citron,1.1.0,,Pocket 5
+Kill The Crows,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Perfect 60 FPS Docked. Change accuracy level to either high or extreme. If you don’t it will constantly crash.,Pocket 5
+Kill The Crows,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+King Krieg Survivors,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Kingdom 2 Crowns,Perfect,Turnip 24.3.0 9v2,Sudachi,2.1.0,,Pocket 5
+Kirby And The Forgotten Land,Great,Turnip 24.3.0 9v2,Citron,1.0,"Game plays beautifully for the most part, even on 1x res. The only issue is that the game sometimes crashes at the very end of a level/world; still looking for a solution for this.",Pocket 5
+Kirby And The Forgotten Land,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"async on, use 1x still pretty stable",Pocket 5
+Kirby And The Forgotten Land,Poor,Turnip 24.3.0 9v2,Citron,1.0,"Could play only with fist 30 mins of game world 1, but world 2 and world 3 is crash city. Random crashes or when trying to change worlds or moving in through the 3 star doors",Pocket 5
+Kirby And The Forgotten Land,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"Runs between 23-30 fps, not perfect",Pocket 5
+Kirby Star Allies,Great,Turnip 24.3.0 9v2,Sudachi,3.0.0,The only issues (which might be bad for epileptics) is ery bad flickering sometimes. If you can get past that you can 100% beat oid Termia and beat the game,Pocket 5
+Kirby Star Allies,Great,Turnip 23.2.0,Sudachi,1.0,,Pocket 5
+Kirby’s Dream Buffet,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,"30fps in-game, 60fps in menus- same as on actual hardware.",Pocket 5
+Kirby’s Return To Dreamland Deluxe,Great,Turnip 24.3.0 9v2,Yuzu,1.0,40-60fps handheld mode some stutters but good experience,Pocket 5
+Klonoa Phantasy Reveire Series,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 handheld,Pocket 5
+Kudzu,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+La Noire,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Playable 30 fps but might have some fps drop during gun fight or driving,Pocket 5
+Lacuna,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Legacy Of Kain Soul Reaver 1&2 Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"(start in dock until you get through the opening animation, after that it runs great in docked",Pocket 5
+Legend Of Grimrock,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Works great, but I have just played 10 minutes. Might be problems down the line, but I doubt it. Default settings.",Pocket 5
+Legend Of Zelda – Links Awakening,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Legend Of Zelda – Links Awakening,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,60 fps mod v3 No DOF mod 1 x resolution High performance Dynamic CPU backend Runs near to 60fps even in overworld,Pocket 5
+Legend Of Zelda – Links Awakening,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Same Mods and settings as Sudachi with the same performance in Citron.,Pocket 5
+Legend Of Zelda: Breath Of The Wild,Perfect,turnip_mrpurple T19,Citron,1.6.0,The same settings as the other submissions for the game The most important setting is Force maximum clocks since it makes sure that the game doesn’t go down to 20fps and stays at 30 fps The next import thing is this driver (https://github.com/MrPurple666/purple-turnip/releases/tag/vturnip_mrpurple-T19-toasted.adpkg) by mrpurple that will fix the visual glitches in the dungeons The game runs at 1x with a few frame drops when rendering shaders,Pocket 5
+Lego Builder’s Journey,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Lego City Undercover,Great,Turnip 24.3.0 9v2,Yuzu,1.0.3,game does not work in sudachi due to ghraphical glitches with the screen,Pocket 5
+Lego Harry Potter Collection,Great,Turnip 24.1.0 R17,Yuzu,v1.2.0,Yuzu 278 (dc529a89a) Backend CPU : JIT Force max frequencies : Yes,Pocket 5
+Lego Jurassic World,Perfect,Turnip 25.2.0 R9,Yuzu,1.0,720/1080p Docked Mode,Pocket 5
+Lego Marvel Superheroes,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Won’t go over 15 even in 0.25,Pocket 5
+Lego Marvel Superheroes 2,Perfect,Qualcomm 0.746.0,Yuzu,Latest,"Crashed with Turnips, but the system drivers work great. Wouldn’t launch with Sudachi.",Pocket 5
+Lego Star Wars: The Skywalker Saga,Poor,Over 2 dozen drivers tested,Yuzu,1.0 or 1.10.0,"The intro crashes the game, but if you import a save which has played at least the 1st mission then you can skip it but once it reaches the menu it crashes your device or the app. I have managed to get into the game only 1 time but there were lots of visual bugs at 25 fps and it crashed 30 seconds later.",Pocket 5
+Leo’s Fortune,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Leo’s Fortune,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Life Is Strange Double Exposure,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,"Won’t boot at all in yuzu, boots in sudachi with Turnip 9v2 but crashes at the ery beginning of the game",Pocket 5
+Life Is Strange Remastered,Great,Turnip 24.1.0 R18,Citron,1.0.1,Use asynch shaders to help graphics stutter. CPU accuracy – Unsafe,Pocket 5
+Life Is Strange: Before The Storm Remastered,Great,Qualcomm 0.746.0,Citron,1.0,Citron 0.4v – Default settings,Pocket 5
+Link’s Awakening,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"No Blur Mod, 60 fps Mod, dock, sync off, 0.75, force max clocks, turn off NCE",Pocket 5
+"Little Kitty, Big City",Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked 😀,Pocket 5
+Little Nightmares,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.2,Seemed like it was gonna work well in handheld mode but crashes when you turn on the flashlight,Pocket 5
+Little Nightmares Ii,Great,Turnip 24.3.0 9v2,Citron,1.3,"Default settings, 30 FPS stable. working great so far. Citron 0.4",Pocket 5
+Littlewood,Perfect,Qualcomm 0.746.0,Sudachi,1.03,,Pocket 5
+Live A Live,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,NOTE: Imperial China level boss has a super that causes the game to crash no matter what I tried. Exported save and finished fight on PC ersion of emu. *some of the Debug settings may be pointless. GRAPHICS> Accuracy Level > High. GRAPHICS> Anti-aliasing method > SMAA. DEBUG > CPU Backend > Dynamic. DEBUG > CPU accuracy > Accurate.,Pocket 5
+Live A Live,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,I kind of changed all of these one at a time and with some anecdotal knowledge. So some of the Debug settings may be pointless. GRAPHICS> Accuracy Level > High. GRAPHICS> Anti-aliasing method > FXAA. DEBUG > CPU Backend > Dynamic. DEBUG > CPU accuracy > Accurate.,Pocket 5
+Live A Live,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Mostly perfect 30 handheld but has some drops in battles,Pocket 5
+Live A Live,Great,Turnip 24.3.0 9v2,Citron,1.0,It’s more than great I think but does have some frame drops.,Pocket 5
+Llamasoft: The Jeff Minter Collection,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"It’s an emulator in an emulator, and works perfectly!",Pocket 5
+Loco Motive,Perfect,Qualcomm 0.746.0,Citron,1.0,plays perfectly,Pocket 5
+Lollipop Chainsaw Repro,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Lone Fungus,Poor,Qualcomm 0.746.0,Citron,1.0,"Launches into black screen. The game itself works fine, but even with other drivers (turnip 9v2 and others) and with other emulators (eden and sudachi) the black screen remains. Installing the update didn’t help either. Someone with more knowledge might be able to get it to work, since the screen being black is really the only problem; you can hear the sounds and even move around, use the menu etc. but screen is always black.",Pocket 5
+Lone Ruin,Poor,Qualcomm 0.746.0,Citron,1.0,Major Graphical Issues,Pocket 5
+Lonely Mountains Downhill,Great,Turnip 24.3.0 9v2,Citron,1.6,"Updated game and installed all DLC. Most Emulators and Drivers work. Reduce resolution to 75%, Accuracy Level High (very important), Force Maximum Clocks. Game plays at 60 FPS (mostly), even looks like 1080 with FSR turned on. If the game freezes, pretend like you’re switching apps, and go right back to the game. It usually works.",Pocket 5
+Lonely Mountains Downhill,Poor,Turnip 25.2.0 R1,Sudachi,1.0.1,"Reduced the resolution to the lowest setting. I could select a course, the course loaded, but crashes when I start to move forward. New to this, don’t know what to try next.",Pocket 5
+Lonely Mountains Downhill,Poor,Turnip 24.3.0 9v2,Citron,1.0,Crashes when loading startup menu,Pocket 5
+Lost In Random,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 30fps handheld mode,Pocket 5
+Lovers In A Dangerous Spacetime,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4 (v262144),"4-player with bluetooth controllers, no issues.",Pocket 5
+Luigi’s Mansion 3,Playable,Qualcomm 805,Sudachi,1.4.0,"0.75x , async off , shaders cache on Graphical glitches are common. Mirror glitch present in Yoga Mat level ,needed to see a game walkthrough to get past that. Strobing glitch after few hours of gameplay ,sometimes gets so bad need to restart the game. Few compromises but still playable to beat the game.",Pocket 5
+Luigi’s Mansion 3,Great,BioSensor MK1,Citron,1.0,Perfectly playable with 0.75 resolution and can add mods like 60fps,Pocket 5
+Luigi’s Mansion 3,Playable,Qualcomm 0.746.0,Citron,1.4.0,Citron 0.3 Works with some graphics issue but seems promising Accuracy level High Resolution 0.75x Force Maximum clocks,Pocket 5
+Luna’s Fishing Garden,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Lunar Remastered Collection,Great,Qualcomm 0.746.0,Sudachi,1.0,"Set audio to Cubeb. Docked. Solid framerates in Lunar 1. Lunar 2 had ery minor studders where framerates dropped to 40fps here and there, which are present in handheld mode. Played through the first dungeon in both games, no issues. I hesitate to say “perfect” but they certainly seem 100% playable at 1-2 hours in. No issues with cutscenes and no graphic glitches that I noticed.",Pocket 5
+Lunar Remastered Collection,Playable,Turnip 24.3.0 R5,Sudachi,1.0.2 (v131072),"Lunar Silver Story Classic and Remastered both work perfectly; I ran around, watched FMVs, and did some battles with no issues. Lunar Eternal Blue Classic plays the FMVs without issues, but there are frame dips from 60 to 40 from the start when moving around. After the first boot it started exhibiting the issues that described next. Lunar Eternal Blue Remastered does not boot FMVs and gets stuck at the first in-game cutscene so I could not test in-game performance and is unplayable. I cannot recommend playing Lunar Eternal Blue on the RP5 at the current state with this configuration.",Pocket 5
+Lysfanga – The Time Shift Warrior,Great,Qualcomm 0.746.0,Yuzu,1.0,Yuzu 278 (dc529a89a) Undocked Video precision : high Force max frequencies : yes,Pocket 5
+Mahoyo: Witch On The Holy Night,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Maid Of The Dead,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Worked but crashed in Sudachi every time a “lucky dip” powerup was collected,Pocket 5
+Mario & Luigi: Brothership,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Mario & Luigi: Brothership,Perfect,Turnip 24.1.0 R17,Citron,1.0,This will fix any glitches on second island when you first meet Luigi,Pocket 5
+Mario & Luigi: Brothership,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"1x docked, Force maximum clocks and asynchronous shaders on, RP5 HP mode, 30fps. It crashed on me once, just at the beginning of the game, but didn’t happen again.",Pocket 5
+Mario & Luigi: Brothership,Playable,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Mario + Rabbids Kingdom Battle,Poor,Turnip 24.3.0 9v2,Sudachi,1.9.0 (+ 4 DLC),Glitch in shadows – Plays OK (variable fps) up to the second tutorial battle where game freezes. Tested multiple parameters adjustment without success,Pocket 5
+Mario + Rabbids Kingdom Battle,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld mode gameplay but there are graphical glitches and wrong colors during some cutscenes but gameplay is perfect. Does not work in YUZU,Pocket 5
+Mario + Rabbids Sparks Of Hope,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Gets through the intro prompts but freezes before getting to the menu,Pocket 5
+Mario Golf Super Rush,Great,Turnip 24.1.0 R18,Citron,4,Played an entire round of golf no crashes. Further testing needed to erify,Pocket 5
+Mario Kart 8 Deluxe,Great,Qualcomm 0.746.0,Citron,3.0.4,"NEAR perfect, I get lighting glitches with headlights and such but it’s not the worst thing ever and most courses don’t use them. I had system crashes and graphical issues with the turnip drivers i tried. I’ve gotten 3 stars on 150cc, mirror, and most of 200cc so it’s definitely stable and transitions between races well.",Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Turnip 25.0.0 R8,Yuzu,1.0,,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm adreno 819.1,Eden,3.0.4,Basically 60fps stable the whole time after caching shaders,Pocket 5
+Mario Kart 8 Deluxe,Playable,turnip 25.2.0 R13,Yuzu,3.0.4,System crash after first race,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm 0.746.0,Citron,3.0.4,Latest Mario Kart update gives solid 60 fps in docked mode using Qualcomm driver in Citron 0.6.1 I was able to load into a second and third race but I did not have time to complete a whole circuit.,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm 0.615.77,Sudachi,3.0.4,"3.0.4 makes the game run into 64bits NCE so the performance is highly affected positively! sOLID 60FPS FULL SPEED, only occasional and quick framedrops (very close to perfection)  Sudachi (driver 0615.77) – handheld mode – 1x resoution – accuracy normal – disk shader cache > on ( I usually never disable this optioon anyways) – force maximum clock – off (I set this as the default because it fixes a lot of audio stuttering in many games without negatively affecting others) – Asynchronous Shaders – on – Audio Cubeb (i make this default since it fix lots of audio stutter in many games and don’t affect negativally in others) OBS: Turnips still crashes the device so avoid them",Pocket 5
+Mario Kart 8 Deluxe,Perfect,Turnip 24.3.0 9v2,Citron,1.0,the game crashes and the console turns off,Pocket 5
+Mario Kart 8 Deluxe,Great,Qualcomm 0.746.0,Yuzu,2.3.0,"0.75x resolution, Firmware 18.1.0. Turnips crash the game and so do certain firmware ersions.",Pocket 5
+Mario Kart 8 Deluxe,Playable,Qualcomm 0.746.0,Yuzu,1.0,gets better over time,Pocket 5
+Mario Kart 8 Deluxe,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Seems to run ery similar on the top 3 emulators,Pocket 5
+Mario Odyssey,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Runs solid 60fps, but crashes sometimes during gameplay and at the ideo sequences, if you skip them immediately you can continue",Pocket 5
+Mario Odyssey,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Mario Party Superstars,Poor,Turnip 24.3.0 9v2,Sudachi,1.1.1,Crashes after choosing to start a campaign. Also crashes when going to Mt. Minigames and choosing Free Play.,Pocket 5
+Mario Party Superstars,Poor,Qualcomm 0.746.0,Sudachi,1.1.1,Crashes after choosing to start a campaign. Also crashes when going to Mt. Minigames and choosing Free Play.,Pocket 5
+Mario Strikers Battle League,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.2,"40FPS – 50FPS, Default settings, standard mode. Had no crashes.",Pocket 5
+Mario Tennis Aces,Perfect,"Turnip – Jan. 04, 2025",Sudachi,1.0,"Graphics: 0.75x, Sync Off, FSR Sharpness: 20%",Pocket 5
+Mario vs. Donkey Kong,Perfect,Turnip 24.3.0 9v2,Yuzu,Update 1.01,"Runs at 60fps, handheld",Pocket 5
+Marsupilami – Hoobadventure,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Console: High Performance. Asynch shaders – On. Audio – cubeb. Plays 55-60fps.,Pocket 5
+Marvel Ultimate Alliance 3: The Black Order,Poor,Turnip 24.3.0 9v2,Sudachi,1.4.1,Crashes,Pocket 5
+Marvel vs. Capcom Fighting Collection: Arcade Classics,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+Mary Skelter 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Master Detective Archive: Rain Code,Poor,Turnip 24.3.0 9v2,Citron,1.4.0,"It works great, almost perfect even, up until the quick time events at the end of the train, managed to muddle my way through 2 of them but it froze pretty much no matter what during those events. Tried every other emulator as well, along with system drivers and the most up to date Turnip on each emulator. No dice.",Pocket 5
+Mega Man Legacy Collection 2,Perfect,default,Yuzu,1.0,,Pocket 5
+Mega Man X Legacy Collection,Perfect,default,Yuzu,1.0,,Pocket 5
+Mega Man X Legacy Collection 2,Perfect,default,Yuzu,1.0,,Pocket 5
+Megam Man Legacy Collection,Perfect,default,Yuzu,1.0,,Pocket 5
+Megaton Musashi W: Wired,Great,Qualcomm 777,Sudachi,3.2.3,"Erratum for game update ersion, also playable with YUZU latest ersion , ALWAYS USE FIRMWARE 17.1.0 since it freezes on game launch on other fw ersions",Pocket 5
+Megaton Musashi W: Wired,Great,Qualcomm 777,Sudachi,1.0.1,"Sudachi ersion 6178075: Vsync FIFO ON, Reso. 0.75x, FORCE MAXIMUM CLOCKS always on to avoid crashes",Pocket 5
+Metal Gear Solid – Master Collection Version,Great,Turnip 24.3.0 9v2,Yuzu,1.5.0,"Some text is invisible, but apart from that a locked 60fps in the USA ersion",Pocket 5
+Metal Slug Tactics,Perfect,Qualcomm 819.1,Citron,v1.0.2,"Game DOES NOT run perfect with Turnips, locks up during assist attacks. Use Qualcomm drivers, I used 819.1 and game runs 50-60 FPS at almost all times. No crashes after 7 hours of gameplay, chipset temp running 60-65C. Runs fine on both standard and performance power modes. Settings: Undocked, Accuracy Normal, 1x Res, sync: FIFO (On), Disc Shader Cache: ON, Force max clocks: OFF (doesn’t help fps, makes chipset run hot), Use Async Shaders: ON",Pocket 5
+Metal Slug Tactics,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,,Pocket 5
+Metallic Child,Poor,Turnip 24.3.0 9v2,Suyu,1.0,"Doesn’t load at all, tried with several emulators",Pocket 5
+Metro 2033 Redux,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,It runs at a perfect 30fps in handheld mode but has a weird screen flickering issue. Plays ery well,Pocket 5
+Metroid Dread,Perfect,BioSensor MK2,Citron,2.1.0,"Docked 60fps, looks amazing on the OLED display! Couldn’t hit a solid 60fps using 9v2 unfortunately despite the other guides suggesting it Accuracy: Normal Force maximum clocks: On Asynchronous shaders: Off",Pocket 5
+Metroid Dread,Perfect,Turnip 24.3.0 9v2,Citron,2.1.0,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If The Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Metroid Dread,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Looks great on the RP5!,Pocket 5
+Metroid Prime Remastered,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Wow it runs AMAZING in docked mode! I can’t technically say perfect because there are slight dips but it is almost perfect 60dps it looks fantastic,Pocket 5
+Metroid Prime Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Metroid Prime Remastered,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Mighty Morphin Power Rangers: Rita’s Rewind,Perfect,Turnip 25.2.0 R4,Citron,1.0,Local multiplayer works perfect,Pocket 5
+Mighty Morphin Power Rangers: Rita’s Rewind,Perfect,Turnip 24.3.0 9v2,Sudachi,v1.0.3,,Pocket 5
+Miitopia,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,Make sure to have BOTH Firmware and Keys installed on Emulator. You need the firmware to use and create Miis. Also turn of Disk Shader Cache.,Pocket 5
+Minecraft Dungeons,Playable,Turnip 24.3.0 9v2,Yuzu,1.17.0.0 and 1.0,"Audio crackles, unplayable for me, tried Sudachi and Suyu",Pocket 5
+Minecraft Legends,Great,Turnip 24.3.0 9v2,Eden,Final Update1.18.19068.0,Handheld mode 20-40 fps depending on scene. Played a few hours without issue. force adreno overclock,Pocket 5
+Minecraft Story Mode – The Complete Adventure,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Framerate is perfect docked, but there is a weird thing where the textures on the character’s shirts look blurry. Does not effect gameplay.",Pocket 5
+Minecraft: Nintendo Switch Edition (legacy Console),Perfect,Turnip 24.1.0 R18,Citron,1.0,"Runs at solid 60fps, no drops. All performance settings enabled with cube audio.",Pocket 5
+Minecraft: Nintendo Switch Edition (Legacy Console),Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Lots of audio cracking for music but no other issues. Runs at around 40-50fps on 1x resolution and 50-60fps on 0.75x resolution. If you don’t mind turning off the music, it’s ery enjoyable!",Pocket 5
+Mining Mechs,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,,Pocket 5
+Minit,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Mistover,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.9,,Pocket 5
+Monster Boy And The Cursed Kingdom,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Monster Hunter Generations Ultimate,Perfect,Turnip 24.3.0 9v2,Citron,1.4.0 + 60 FPS Patch/Mod,Citron is back in development! 60 FPS Settings: Docked 1x Res. Turn on Force Maximum Clocks and Asynchronous Shaders Everything else default.,Pocket 5
+Monster Hunter Generations Ultimate,Perfect,Turnip 24.3.0 9v2,Yuzu,1.4.0,"Runs at a solid 30fps, and solid 60fps with patch",Pocket 5
+Monster Hunter Generations Ultimate,Perfect,Turnip 24.3.0 9v2,Citron,1.4.0,Solid 30fps. No crashes after 3 hours.,Pocket 5
+Monster Hunter Rise,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"No luck with qualcomm or Turnip 9v2 on Yuzu, Sudachi, Citron, or Suyu",Pocket 5
+Monster Hunter Stories,Perfect,Qualcomm 0.746.0,Yuzu,"1.0.1, 1 DLC","Perfect 60fps handheld about 45fps docked, slight audio stutter during some cutscenes but not during gameplay",Pocket 5
+Monster Train,Great,Turnip 24.3.0 9v2,Citron,2.0.0,"Accuracy: High , Resolution 1x, Adaptive Filter: AMD FidelityFX, AA: FXAA, Force Maximum clocks, Use Async Shaders",Pocket 5
+Monster Train 2,Perfect,Qualcomm 0.746.0,Sudachi,1.1,,Pocket 5
+Monster Train 2,Poor,Turnip 25.2.0 R9,Sudachi,1.1,"Instantly crashes, but works perfect with Qualcomm 0.746.0",Pocket 5
+Moonlighter,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.0.10,,Pocket 5
+Moonstone Island,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Running great at 60fps,Pocket 5
+Moonstone Island,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.9,Locked 60 fps. Plays great!,Pocket 5
+Mutazione,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,30-45fps docked but its a isual novel so it works perfectly,Pocket 5
+My Sims,Perfect,Qualcomm 0.746.0,Ryujinx,1.0,http://mikahintz.de/ryujinxAndroid.zip,Pocket 5
+My Sims,Poor,Turnip 24.3.0 9v2,Citron,1.1,I tried many setting sadly just met with a black screen. Would love to see if someone can get it running! Even tried the base driver. No dice.,Pocket 5
+My Time At Sandrock,Great,Qualcomm 0.746.0,Yuzu,1.4.0.0,Need the update to work. Resolution 0.75 Accuracy Level : High – CPU accuracy : Accurate 20 to 30 FPS and stable so far (only 2 hours),Pocket 5
+N++,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.5,,Pocket 5
+Naiad,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Kept freezing in first scene, when tabbing out it would temporarily run.",Pocket 5
+Naruto Shippuden Ultimate Ninja Storm 4 Road To Boruto,Perfect,Turnip 24.3.0 9v2,Sudachi,v1.0.15,"Not much setting is needed other then putting it in performance mode with a steady 30fps There will be a downloading data screen when it load, but for some reason Citron will not pass that screen so use Sudachi",Pocket 5
+Naruto Ultimate Ninja Storm Collection,Great,Turnip 24.3.0 9v2,Sudachi,1.0,only issue seen is crackling audio. otherwise runs great,Pocket 5
+Naruto X Boruto Ultimate Ninja Storm Connections,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Runs stable at 30fps. Did not play with settings since it there was no need.,Pocket 5
+Nascar Heat Ultimate Edition+,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect out of the box. No setting adjustments needed.,Pocket 5
+Neckbreak,Great,Turnip 24.3.0 9v2,Suyu,1.0,Runs great at 30fps docked,Pocket 5
+Need For Speed Hot Pursuit Remastered,Perfect,Qualcomm 0.746.0,Suyu,1.0,"both Suyu and Citron, thank you for this spreadsheet",Pocket 5
+Need For Speed Hot Pursuit Remastered,Great,Turnip 24.3.0 9v2,Sudachi,1.0.3,,Pocket 5
+Needy Girl Overdose,Perfect,Turnip 24.3.0 9v2,Citron,1.1.1,Consistent 45 – 60 fps,Pocket 5
+Neo: The World Ends With You,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,,Pocket 5
+Neon Abyss,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.6,,Pocket 5
+Neon Blood,Great,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Neon White,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Looks and runs amazing, perfect 60fps handheld and 35-40 docked",Pocket 5
+Nerd Survivors,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.20240625,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Neuro Voider,Perfect,Turnip 24.3.0 9v2,Citron,1.0.5,Perfect 60 FPS Docked,Pocket 5
+Neva,Perfect,Qualcomm 0.746.0,Citron,1.2.0,"60 FPS Docked during gameplay, some very minor dips in between some cutscenes",Pocket 5
+New Pokémon Snap,Great,Turnip 24.3.0 9v2,Citron,Latest,"disk shader cache = true, force maximum clocks = true Game works nearly perfect! Professor registers photos you take, little to no frame drops, overall really responsive. Only problem I’ve seen is that any pictures you take, beyond the initial run down with the professor, will just appear as blank black images.",Pocket 5
+New Pokémon Snap,Great,Qualcomm 0.746.0,Suyu,1.0,Handheld mode,Pocket 5
+New Super Lucky’s Tale,Perfect,Qualcomm 0.746.0,Yuzu,1.5.9,Perfect 30fps docked,Pocket 5
+New Super Mario Bros. U Deluxe,Perfect,Qualcomm 0.746.0,Suyu,1.0,"Firmware 17.0.1 runs perfect in yuzu, couldnt get it running in any other emu",Pocket 5
+Nexomon,Perfect,Qualcomm 0.746.0,Yuzu,1.02,"Perfect 60fps docked, looks great",Pocket 5
+Ni No Kuni Wrath Of The White Witch,Great,Turnip 24.3.0 R3,Sudachi,v1.0.11,You will need firmware 17.0.1 other firmwares will make the title screen bootloop but with firmware 17.0.1 you will go past that screen. Frames betwen 23-30 played until Ding Dong Dell so don’t know if completable,Pocket 5
+Nickelodeon All-Star Brawl 2,Great,Qualcomm 0.746.0,Yuzu,1.0,Works well handheld mode almost perfect 30fps just takes awhile to load in game,Pocket 5
+Nickelodeon Kart Racers,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Night In The Woods,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Played for around 30 minutes without any issues,Pocket 5
+Night Slashers Remake,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Turnips unplayable,Pocket 5
+Nights Of Azure 2,Playable,Turnip 24.3.0 9v2,Citron,1.0,Thought I’d give it a shot but when it came to combat the frame drops a bit too much. It’s for sure playable but I wouldn’t suggest it in this state.,Pocket 5
+Nine Sols,Perfect,Qualcomm 0.746.0,Sudachi,1.1,,Pocket 5
+Ninja Gaiden Sigma,Perfect,Turnip 24.1.0 R18,Citron,1.0.4,works perfect now with sound unlike older switch emulators. the game has washed out blacks go into grapics menu in game and turn gamma down to 0.5,Pocket 5
+Ninja Gaiden Sigma,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.2,Plays perfectly but no sound in game even after changing emulator audio settings,Pocket 5
+Ninja Slayer: Neo-Saitama In Flames,Playable,Turnip 24.3.0 9v2,Citron,1.0,Runs 60 FPS with no enemies on screen Killing or attacking enemies causes the fps to drop. Many FPS dips makes it annoying to play,Pocket 5
+Nintendo World Championship,Perfect,Qualcomm 0.746.0,Citron,1.0,Plays perfectly when I set graphics to 0.75,Pocket 5
+No More Heroes,Poor,Turnip 24.3.0 9v2,Sudachi,1.2.0,Graphical glitches making it unplayable,Pocket 5
+No More Heroes 2: Desperate Struggle,Poor,Turnip 24.3.0 9v2,Sudachi,1.2.0,Graphical glitches making text unreadable in game,Pocket 5
+No More Heroes 3,Playable,Turnip 24.3.0 9v2,Sudachi,1.1.1,Playable with low fps and some graphical glitches and lag,Pocket 5
+Nuclear Blaze,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Octodad: Dadliest Catch,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Black screen on yuzu and sudachi with both drivers,Pocket 5
+Octopath Traveler,Perfect,Mr. Purple T18,Citron,v1.0.1,"Docked, 1x Res, Disk Shader Cache:ON, Force Max Clocks:OFF, Async Shaders:ON All other settings default. Game is locked at 30FPS at all times, no stuttering, crashing, or glitches. Current save file time is at 13 hours.",Pocket 5
+Octopath Traveler,Great,Turnip 24.3.0 9v2,Citron,1.0.1,"Citron 0.4. Handheld Mode, Disabled Shader Cache, Disabled Asynchronous Shader Compilation. RP5 Performance and Smart Fan. Pretty smooth and stable",Pocket 5
+Octopath Traveler,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,(works surprisingly well when docked but dips down to ~15fps),Pocket 5
+Octopath Traveler,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Octopath Traveler,Perfect,Turnip 25.2.0 R4,Citron,1.0.4,x0.75,Pocket 5
+Octopath Traveler II,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Some graphical glitching in different lighting.,Pocket 5
+Octopath Traveler II,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"(same as OT1, both hold closer to 30fps docked)",Pocket 5
+Octopath Traveler II,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.1,"Graphics Accuracy Level: High; Use async shaders; Use reactive flushing; Handheld Mode// Performance Mode: Performance; Fan: Smart; No more lighting glitches!! Smooth 30FPS, Minor dips to high 20s.",Pocket 5
+Octopath Traveler II,Great,Turnip 24.3.0 9v2,Sudachi,1.1.1,"Graphics -> Accuracy Level: High; Performance: High; Fan: Smart. This solves the lighting glitches. Battles at 30FPS, Overworld mostly 30fps, Drops in some areas to mid 20s. ery playable.",Pocket 5
+Octopath Traveler II,Great,Turnip 24.3.0 9v2,Sudachi,1.02,Runs well at 30 fps with occasional dips. Only problem is the occasional random crash during combat which is quite annoying.,Pocket 5
+Oddworld: New ‘n’ Tasty!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Okami HD,Great,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 30fps handheld, some isual glitching",Pocket 5
+Okinawa Rush,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Old School Musical,Perfect,Qualcomm 0.746.0,Citron,1.3 + DLC,,Pocket 5
+Olliolli World,Perfect,Qualcomm 0.746.0,Yuzu,1.2.0,"Perfect 60dps docked, great game",Pocket 5
+Omega Labyrinth Life,Perfect,Turnip 25.2.0 R2,Eden,1.0,Drops frames in the overworld but nothing major,Pocket 5
+Omori,Perfect,Qualcomm 0.746.0,Eden,1.0,,Pocket 5
+One Piece Pirate Warriors 3,Great,Qualcomm 0.746.0,Yuzu,1.0,"About 45fps handheld mode, good experience",Pocket 5
+One Piece Unlimited World Red Deluxe Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps docked, looks great",Pocket 5
+One Step From Eden,Perfect,Turnip 24.3.0 9v2,Sudachi,1.5.6,,Pocket 5
+Onimusha: Warlords,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Plays flawlessly docked at 60fps,Pocket 5
+Ori And The Blind Forest,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Ori And The Blind Forest,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,"Perfect 60 docked, looks incredible on the OLED",Pocket 5
+Ori And The Blind Forest,Great,Qualcomm 0.746.0,Yuzu,Update 1.0.2,,Pocket 5
+Ori And The Blind Forest (Definitive Edition),Great,Turnip 24.1.0 R18,Citron,1.0.2,"This game does NOT run perfectly on RP5, despite what other entries in this sheet say. I tried a huge combination of emulators, drivers, settings etc. The best overall performance I got was docked mode 1x, Citron 0.4, Turnip 24.1.0 R18, force maximum clocks, asynchronous shaders, everything else default. The game would often hit 60fps, but it was not stable. It would often dip down to 30-50fps, and even when frame rate was 50+ there was frequent (albeit minor) stuttering. It’s absolutely playable and ery enjoyable but it is NOT 60fps locked.",Pocket 5
+Ori And The Will Of The Wisps,Playable,Turnip 24.3.0 9v2,Citron,1.2.0,Only successfully boots 1/4 of the time. FPS ranges from 10-35. Some minor graphical issues.,Pocket 5
+Otherwar,Perfect,Qualcomm 0.746.0,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Otxo,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Our Summer Festivals 2,Perfect,Qualcomm v615. 77,Sudachi,1.0.15,Set Accuracy Level to High. No need to change other settings. I played two times with these settings and it went perfectly well.,Pocket 5
+Our Summer Festivals 2,Perfect,Qualcomm v615. 77,Sudachi,1.0.15,"Uses both firmware and prodkeys 19.0.1. Set Accuracy Level High. Disable shader cache. Dont change anything else, this is the complete setting. Make sure play High Performance on your retroid pocket flip 2.",Pocket 5
+Outer Wilds,Perfect,Turnip 24.3.0 9v2,Citron,1.1.15.1027,.75 | Force maximum clocks | Use asynchronous shaders. Once shaders complie it runs at full speed,Pocket 5
+Overcooked 2 + All Dlc,Perfect,Turnip 25.0.0 R5,Yuzu,1.0,30 FPS LOCKED,Pocket 5
+Owlboy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.5,,Pocket 5
+Paint The Town Red,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,,Pocket 5
+Panzer Paladin,Perfect,Qualcomm 0.746.0,Yuzu,1.2.2,Play perfect,Pocket 5
+Paper Mario: The Origami King,Poor,Qualcomm 0.746.0,Sudachi,1.01,"Tried with yuzu, sudachi, and Skyline. All crash at the beginning sequence, if you use a save to skip that it crashes if you go into the loading zones. what a shame",Pocket 5
+Paper Mario: The Thousand-Year Door,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,froze after into battle,Pocket 5
+Paper Mario: The Thousand-Year Door,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Papwr Mario The Thousand Year Door,Great,Qualcomm adreno 819.1,Citron,1.0,Tried multiple drivers. Most crashed Citron. The qualcomm adreno 819.1 with high performance turned on and fan set to auto works. Undocked mode,Pocket 5
+Party Hard,Poor,Qualcomm 0.746.0,Kenji-nx,1.0,Crashes at boot.,Pocket 5
+Party Hard,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Passpartout,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Passpartout 2,Playable,Turnip 24.3.0 9v2,Yuzu,1.1.1,,Pocket 5
+Pato Box,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 60fps docked,Pocket 5
+Patrick’s Parabox,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Perfect 60 FPS Docked,Pocket 5
+Pentiment,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Pepper Grinder,Perfect,Turnip 24.3.0 9v2,Citron,1.0.4,,Pocket 5
+Persona 3 Portable,Perfect,Turnip 24.1.0 R18,Citron,1.0,Citron 0.4 Sounds set to Cubeb Res 1x native,Pocket 5
+Persona 4 Arena Ultimax,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked looks and plays great,Pocket 5
+Persona 4 Golden,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Great 60 fps. Occasionally crashes, but I find these settings most stable.",Pocket 5
+Persona 4 Golden,Perfect,Qualcomm 0.746.0,Sudachi,1.0,"Perfect 60fps docked, don’t play in yuzu it has audio issues there",Pocket 5
+Persona 4 Golden,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Runs flawlessly at 1x (710p) handled mode, 60FPS on performance mode. Audio set to cubeb",Pocket 5
+Persona 5 Royal,Perfect,Turnip Driver 24.1.0 r18 fix for a6xx,Yuzu,1.0,Docked Mode. Accuray level high.Resolution 0.75 Vsync mode FIFO (On) Use asynchronous shaders on disk shader cache on audiocubeb Api vulkan CPU backend dynarmic (slow) CPU accuracy auto high performance fan on sport 13:25 minutes beat castle 5/9 also clear shader cache if you have issues 30 fps,Pocket 5
+Persona 5 Royal,Great,Turnip 9v2,Sudachi,1.0.2,Accuracy: High,Pocket 5
+Persona 5 Royal,Perfect,Qualcomm 777,Yuzu,1.0,,Pocket 5
+Persona 5 Royal,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Crashes seem to be fixed by setting graphics accuracy to “high”. Runs at 30fps with minor slowdowns in some areas.,Pocket 5
+Persona 5 Royal,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,"Runs ery smooth, experienced one crash in first 40min of game play.",Pocket 5
+Persona 5 Royal,Perfect,Turnip 25.2.0 R2,Citron,1.0,,Pocket 5
+Persona 5 Royal,Great,Mr.Purple T19,Eden,1.0,"Works well with 60fps mod, however some crashes may happen. Change accuracy level to High if crashes happen",Pocket 5
+Persona 5 Strikers,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Boots and gets past menus but crashes as soon as gameplay starts,Pocket 5
+Persona 5 Tactica,Poor,Qualcomm 0.746.0,Yuzu,1.0,"Black screen in yuzu and sudachi with qualcomm, Turnip 9v2, and Turnip 25",Pocket 5
+Pga Tour 2k21,Poor,Qualcomm 0.746.0,Sudachi,1.9.0,"Tested at 0.75x resolution and in high performance mode. The game experiences a sudden drop in frame rate after the first screen, then closes.",Pocket 5
+Phoenix Wright: Ace Attorney Trilogy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Plays perfectly at 60fps,Pocket 5
+Phoenotopia Awakening,Perfect,Turnip 24.3.0 9v2,Citron,1.3.3,Runs at a perfect 60fps in docked mode,Pocket 5
+Pikmin 1,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,Game plays great with Turnips. Only reason it’s not rated higher is that the audio is bad,Pocket 5
+Pikmin 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Pikmin 2 runs perfect in it’s first hour of gameplay, no audio issues like the first game",Pocket 5
+Pikmin 3 Deluxe,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"runs smoothly with no graphical problems or crashes, highly reccomend!! :3",Pocket 5
+Pikmin 3 Deluxe,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Perfect up until the Armored Mawdad, I haven’t tested afterwards.",Pocket 5
+Pikmin 4,Great,Turnip 24.0.0,Citron,1.0,9v2 doesnt work after the intro part. use this driver.,Pocket 5
+Pikmin 4,Great,Turnip 24.3.0 9v2,Sudachi,1.0,30fps,Pocket 5
+Pikuniku,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Plays perfectly,Pocket 5
+Pixel Cup Soccer Ultimate Edition,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,Perfect 60fps docked,Pocket 5
+Pixel Retro Drift,Playable,Turnip 24.3.0 9v2,Suyu,1.0,"60fps, however crashes randomly",Pocket 5
+Pizza Tower,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,runs good at default settings,Pocket 5
+Pizza Tower,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Planescape Tournament And Icewind Dale,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Ensure update is disabled. Crashes unless played on 1.0,Pocket 5
+Plateup!,Perfect,Qualcomm 0.746.0,Yuzu,7.1.29,"Sometimes the game shows 0.0 fps and freezes on a black loading screen. If this happens, swipe up on the game screen as if you were going to close the process, but don’t close it. Then go back to the game.",Pocket 5
+Poison Control,Playable,Turnip 24.3.0 9v2,Suyu,1.0,I have it set to Nearest Neighbor for the adapting filter and that seems to work great. It goes between 50s and 40s for FPS but it ery playable.,Pocket 5
+Pokemon,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Pokemon Arceus,Perfect,Turnip 23.3.0-devel,Yuzu,1.0,"I’m running firmware 19.0.1 and prod.key 19.0.0 and getting consistent 30fps in handheld mode at 1x. No freezing, etc. like I was getting on other drivers.",Pocket 5
+Pokemon Brilliant Diamond,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,"With Luminiscent Platinum 2.1, use accuracy level high and handheld mode or it will freeze/crash",Pocket 5
+Pokemon Brilliant Diamond,Great,Turnip 24.3.0 9v2,Sudachi,1.3.0,Added the Luminescent Platinum mod as well. Runs at 30FPS. May hang but if you minimize the game and open again it fixes itself,Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 24.1.0 R18,Sudachi,1.0,Performance mode with fan set to auto to keep temps at 52-55 Celsius. Default settings in Sudachi,Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 24.3.0 9v2,Citron,1.0,"Max clocks on, async on,",Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 23.2.0,Sudachi,1.1.1,"Slow in some places, glitchy polygons in places, but plays pretty smoothly",Pocket 5
+Pokemon Legends: Arceus,Perfect,Turnip 24.3.0 9v2,Citron,1.1.1,TV Mode 1x resolution with texture pack,Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Pokemon Mystery Dungeon DX,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Using Uzuy emulator,Pocket 5
+Pokemon Scarlet,Playable,Turnip 24.3.0 9v2,Yuzu,3.0.1,"Intro is ery rough, maybe set resolution to 0.5x just until after you beat Nemona the first time, after that can raise to 0.75x. Runs pretty close to 26-30fps after the opening scene, but occasionally crashes/freezes. Possibly memory leaking is the cause? There are minor graphical glitches throughout. Some slow downs in battles and near pokemon centers. SETTINGS: DEVICE: high performance mode fan: smart GRAPHICS: accuracy: normal resolution: 0.75x vsync mode: FIFO (on) Window Adapting Filter: AMD FidelityFX Super Resolution FSR Sharpnes: 24% Anti-Aliasing Method: FXAA Anisotropic filtering: Default Aspect: 16:9 Disk Shader Cache: enabled Force Maximum Clocks: enabled Use asynchronous shaders: enabled Use reactive flushing: disabled AUDIO: Output engine: cubeb DEBUG: API: ulkan CPU backend: Native Code Execution (NCE) CPU Accuracy: unsafe",Pocket 5
+Pokemon Scarlet,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Pokemon Scarlet,Great,Turnip 25.2.0 R4,Yuzu,3.0.1,Is playable with 1x resolution. With 0.75x Resolution it works great.,Pocket 5
+Pokemon Shining Pearl,Perfect,Turnip 24.3.0 9v2,Yuzu,1.3.0,"Handheld mode; Graphics settings: accuracy: normal; 1x resolution; vsync: off; window adapting filter: AMD FidelityFX SuperResolution; FSR 25%; anisotropic filtering: default; disk shader cache: enabled; force maximum clocks: enabled; use asynchronous shaders: enabled; use reactive flushing: disabled; Audio output engine: cubeb; debug: api: ulkan; CPU backend: dynarmic; cpu accuracy: accurate; cpu debugging: disabled I believe crashes and freezes are caused by having apps running in the background. I had some crashing and freezing at first, but once I started paying attention and making triple sure nothing else was open at all, the game has been running flawlessly, 30fps.",Pocket 5
+Pokemon Shining Pearl,Great,Turnip 24.3.0 9v2,Yuzu,1.3.0,stable 30 fps,Pocket 5
+Pokemon Shining Pearl,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Pokemon Snap,Great,Turnip 24.3.0 9v2,Citron,2.0.1,"1x resolution, AMD FidelityFX filtering, FXAA AA Method, Force Maximum Clock, Use Asynch shaders, 50-60 FPS Stable",Pocket 5
+Pokemon Sword,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Haven’t done any post-game stuff, but you can play from A-Z. If you try to use Y-Comm it will crash",Pocket 5
+Pokemon Sword,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,"Crash when naming char – import a save with char created, available with help from google",Pocket 5
+Pokemon Violet,Great,Turnip 24.3.0 9v2,Eden,0.0.2 Pre Alpha,Runs stready at 0.75 res,Pocket 5
+Pokemon Violet,Great,Turnip 24.3.0 9v2,Sudachi,v1.0.15,"1x is playable 0.75x runs great (<30 fps on cutscenes, <25 fps on fights) Use High Performance mode(smart fan) Force Clock turned on graphics glitchs on some trees and some weird texture on pokemons, it gets the job done",Pocket 5
+Pokemon Violet,Playable,Turnip 25.0.0 R8,Sudachi,3.0.1,"Low FPS (around 15.0fps) makes game slow, experienced one crash redeeming DLC costumes (but they did get into inventory)",Pocket 5
+Pokemon: Let’s Go Eevee!,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,"Stable 30fps, force max clock enabled",Pocket 5
+Pokemon: Let’s Go Pikachu!,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,"30FPS stable, Force Maximum Clocks enabled",Pocket 5
+Pokemon: Shield,Perfect,Turnip 24.3.0 9v2,Citron,1.3.2 + 2DLC,"Adaptive filter: AMD FidelityFX, AA: FXAA, Force Maximum Clock, Use Asynch shaders",Pocket 5
+Pokemon: Sword,Great,Turnip 24.3.0 9v2,Citron,1.3.2,"Locked to 30FPS AMD FidelityFX Async shaders If it crashes after creating your character: Switch the CPU Backend to “JIT” in the Advanced Settings for character-creation until you can save the game, then switch back",Pocket 5
+Pokemon: Sword,Perfect,Turnip 24.3.0 9v2,Citron,1.3.2,"30 FPS 1x…Adaptive filter: AMD FidelityFX, AA: FXAA, Force Maximum Clock, Use Asynch shaders",Pocket 5
+Pokken Tournament Dx,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.3,,Pocket 5
+Portal,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,,Pocket 5
+Portal,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Portal,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Portal 2,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps docked, beautiful",Pocket 5
+Post Void,Perfect,Qualcomm 0.746.0,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Postal: Brain Damaged,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Perfect 60 FPS Docked. Change Accuracy level to High,Pocket 5
+Potion Craft,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Nice interactive use of touchscreent too!,Pocket 5
+Power Rangers: Battle For The Grid,Great,Qualcomm 0.746.0,Sudachi,2.9.2 + DLC,"45-60fps FPS Improves with time once all characters, colors and arenas have shaders – sometimes takes a few crashes and resets to get shaders built Occasional crashes, Yuzu has similar performance RP5 – High performance mode 1x Res. Handheld mode Graphics Accuracy Level: High (Can be moved to “Normal” once shaders downloaded – fps improves but not ery stable) Disk shader cache: On CPU Debug: Accurate Audio: cubeb Work in progress: Not much improvement with Force max clock and Asynch shaders on",Pocket 5
+Power Rangers: Battle For The Grid,Great,Turnip 24.3.0 9v2,Sudachi,2.8.0,Occasional crashes but plays great,Pocket 5
+Powerwash Simulator,Great,Qualcomm 805,Sudachi,1.10.0 + 7 DLC,"It locks up when saving. You can get around this by turning off auto save. You can then manual save the game. If it locks up during the save, tap the power button and it should continue (then you should save again)",Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Qualcomm 0.746.0,Citron,1.4.1 + DLC,"Works really good at basically a locked 60 fps. It has a few graphical issues here and there. Play with the qualcomm drivers, because the Turnip ones crashes the game when you open the map!",Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Qualcomm 0.746.0,Citron,1.4.1 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Qualcomm 0.746.0,Yuzu,1.4.2,"Turnip 9v2 crashes when openning the map, only qualcomm driver doesnt, gameplay performance wise is the same",Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Turnip 24.3.0 9v2,Yuzu,1.4.1,Update make the game run smoother,Pocket 5
+Princess Peach: Showtime!,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,"Crashes before first cutscene ends. My Settings: 1x Resolution, High Accuracy, VSync Off, Disk Shader Cache on, Force maximum clocks on, asynchronous shaders off.",Pocket 5
+Princess Peach: Showtime!,Great,Turnip 24.3.0 9v2,Citron,1.0,"Resolution scale 1x (This is important otherwise Peach and Toad’s face will be glitchy), Accuracy High (these seemed to determine whether game had sound or not), Sync Off, Disk shader cache on, For maximum clocks on, asynchronous shaders off, reactive flushing off.",Pocket 5
+Princess Peach: Showtime!,Great,Turnip 24.3.0 9v2,Citron,1.0,Citron 6b9dd40 Video precision : High Resolution : 0.75x Force max frequencies : Yes Still some minor glitches (ex : Peach’s face),Pocket 5
+Prodeus,Great,Qualcomm 805,Citron,1.0.1,Docked mode @ 0.75 resolution fluctuates 40 – 60 fps but doesn’t feel like it stutters. Really nice doom-like shooter,Pocket 5
+Pumpkin Jack,Playable,Turnip 24.3.0 9v2,Yuzu,1.4.4,Gameplay is smooth 30 in handheld mode but there is lots of audio stutter enough that I personally would not play it,Pocket 5
+Punch A Bunch,Playable,Turnip 25.2.0 R4,Yuzu,1.0,"Mostly 60fps, but some stages have major graphical glitches.",Pocket 5
+Quake 2,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Full 60fps – Does not run as well on Turnip/the other emulators,Pocket 5
+R-Type Final 2,Playable,Turnip 24.3.0 9v2,Sudachi,2.0.3,As a 60fps game it is running around 35-50fps. Major Graphical glitches on effects like explosions and lights all the time. Not enjoyable like this.,Pocket 5
+Racine,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Rain World,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Rainbow Moon,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Crashed on other emus I tried, playing 60 fps with undocked, high accuracy, 1x reso, mailbox sync, bilinear adapting filter, 25% fsr sharpness",Pocket 5
+Rayman Legends,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Rayman Legends: Definitive Edition,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Runs at a perfect 60fps in docked mode,Pocket 5
+Rebel Transmute,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Red Dead Redemption,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,Looks like its gonna be playable at first but crashes,Pocket 5
+Red Wings American Aces,Great,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Resident Evil 0,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Locked 30fps. Extremely beautiful on RP5.,Pocket 5
+Resident Evil 4,Poor,Turnip 24.3.0 9v2,Citron,1.0,Out of sync intro scene and game runs at 20-25 fps in handheld mode.,Pocket 5
+Resident Evil HD Remake,Great,Turnip 24.3.0 9v2,Citron,1.0,30 fps docked. Noticed some character flickering during certain lighting effects. Just about perfect but had to dock it a little for that.,Pocket 5
+Resident Evil Revelations,Great,Qualcomm 0.746.0,Suyu,1.0.1,Handheld mode firmware 17.0.1 runs great 60fps some minor slowdown here and there,Pocket 5
+Resident Evil Revelations,Playable,Qualcomm 0.746.0,Yuzu,1.0.1,It is playable and mostly plays 60fps handheld mode but there are enough dips and stutters to make it not ery enjoyable,Pocket 5
+Resident Evil Revelations 2,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,"1x Res. Async Shaders. Run full speed 30 fps. Slight hiccup or stutters when compiling shaders but if you put Async Shaders., The textures would load late but the stutters almost all gone. I have only played for like 15 minutes without any crash. So.. it is perfect so far",Pocket 5
+Retro City Rampage Dx,Perfect,Qualcomm 0.746.0,Yuzu,2.0.0,Perfect 60fps docked,Pocket 5
+Retrorealms,Perfect,Qualcomm 0.746.0,Citron,1.0.892068,"(Plus 4 DLCs) Freezes briefly on title, continues to play after a second or two.",Pocket 5
+Retrorealms,Perfect,Qualcomm 0.746.0,Yuzu,1.0.892068,(Including 4 DLCs) Runs smoothly if it doesn’t freeze on the title screen.,Pocket 5
+Return,Poor,Turnip 24.3.0 9v2,Suyu,1.0,wont launch,Pocket 5
+Return Of The Obra Dinn,Perfect,Qualcomm 0.746.0,Sudachi,1.0.1,"Docked mode, game gets to 60fps most of the time but then gets to 50 fps drops after a while because of the rain",Pocket 5
+Return Of The Obra Dinn,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,"60 fps, Plays Great!",Pocket 5
+Revita,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Riptide Gp Renegade,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Smooth as!,Pocket 5
+Rise Of The Third Power,Great,Turnip 24.3.0 9v2,Citron,1.0.5,"Generally runs perfectly, though I experienced crashes with any other driver",Pocket 5
+Risk Of Rain 2,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Risk Of Rain 2,Great,Turnip 24.3.0 9v2,Sudachi,1.2.2.1 + Survivors of The oid DLC,"This runs between 35-60 fps with the update. With no update it will run 30 fps and no more. The game is totally playable, got past the first boss and it didn’t struggle too much. The times where it drops below 40 fps don’t affect input latency so I didn’t really notice the frame rate affecting gameplay.",Pocket 5
+Risk Of Rain Returns,Perfect,Qualcomm 0.746.0,Citron,1.0.4,Citron is back in development! Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Risk Of Rain Returns,Great,Qualcomm 0.746.0,Yuzu,1.0.5,"Perfect 60fps, but has audio crackle",Pocket 5
+Rival Megagun,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Rival Megagun,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+River City Girls,Perfect,default,Citron,1.0,"When Booting it up on Yuzu, it gets stuck on Loading Shaders, But loading it up on Citron Boots it up immediately with no Problems",Pocket 5
+River City Girls 2,Perfect,default,Yuzu,1.0,Boots up and Runs No Problem,Pocket 5
+Road 96,Perfect,Qualcomm 0.746.0,Yuzu,1.04,Perfect 30fps handheld,Pocket 5
+Rocket League,Perfect,Turnip 24.3.0 9v2,Sudachi,2.0.1,,Pocket 5
+Rogue Heroes: Ruins Of Tasos,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.8,Sometimes crashes when I mess with controller setups mid-game,Pocket 5
+Rogue Legacy 2,Great,Qualcomm 615.50,Sudachi,v1.1.0,"No issues playing, sometimes crashes upon wake from sleep (pause emu before sleep helps most of the time).No data ever lost, though.",Pocket 5
+Rogue Legacy 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.0,,Pocket 5
+Roller Coaster Tycoon 3 Complete,Perfect,Turnip 24.3.0 9v2,Citron,Latest,,Pocket 5
+Rollercoaster Tycoon Classic,Perfect,Turnip 24.3.0 9v2,Sudachi,1.2.174,Runs really well,Pocket 5
+Romance Of The Three Kingdoms 8 : Remake,Poor,Turnip 24.3.0 9v2,Citron,1.0,Cannot boot to main menu. Tried Qualcom and also firmware 18.0 and 17.0,Pocket 5
+Romancing Saga 2: Revenge Of The Seven,Poor,Turnip 24.3.0 9v2,Citron,Latest,Would technically load the game but the graphics glitched out in a way that made everything shine with blinding light,Pocket 5
+Roots Of Pacha,Perfect,Turnip 24.3.0 9v2,Yuzu,1.2.0.5,"Apart from graphical glitches when creating player, game seems to be working fine on 1x docked with locked 60fps.",Pocket 5
+Ruiner,Great,Turnip 24.3.0 9v2,Citron,1.1S15773077ab,"Docked, 0.75x Resolution. Mostly Smooth 30 FPS, occasional dips.",Pocket 5
+Rune Factory 3,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Quick travel warp has massive graphical bugs that take over the entire screen. Everything else has been flawless.,Pocket 5
+Rune Factory 4s,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Text doesn’t appear. Tried with several other emulators and drivers and it’s the same,Pocket 5
+Rune Factory 5,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Some slight graphical glitches,Pocket 5
+Runnyk,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Runnyk,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Rusted Moss,Perfect,Turnip 24.3.0 9v2,Citron,1.29.2,,Pocket 5
+S.T.A.L.K.E.R.: Call Of Prypiat,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.2,Won’t start no matter what settings I play with,Pocket 5
+S.T.A.L.K.E.R.: Clear Sky,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.2,Won’t start no matter what settings I play with,Pocket 5
+S.T.A.L.K.E.R.: Shadow Of Chornobyl,Playable,Turnip 24.3.0 9v2,Citron,1.0,"Crashed the first time, after that it worked fine Citron 0.3 Enable USE_AUTO_STUB setting Force maximum clock speed 25-30FPS @ 1x resolution",Pocket 5
+Saga Frontier 2 Remastered,Perfect,Qualcomm 0.746.0,Citron,1.0.1,No noticeable issues. Docked 1X.,Pocket 5
+Saga Frontier Remastered,Great,Qualcomm 0.746.0,Yuzu,1.0.3,"Perfect 60fps docked, some micro stutters that effect audio",Pocket 5
+Saints Row IV,Playable,Qualcomm 0.746.0,Citron,1.1.0,"System – 110%, Handheld mode, Rest your choice Graphic – 1X, Sync off, Bilinear (important), 25% FSR, AA off, AF Auto, DSC on, Max freq on, ASync shader Off, Urf off Audio – Auto Debug – ulkan, NCE, unsafe, CPU Debugging on, Fastmem on not Final, Work in progress, a bit Dark but still playable",Pocket 5
+Saints Row: The Third – The Full Package,Poor,Qualcomm 0.746.0,Yuzu,1.6.1,"Gameplay is all black in yuzu and sudachi, no launch with 9v2",Pocket 5
+Sakuna: Of Rice And Ruin,Great,Qualcomm 777,Sudachi,1.0.9,"Grapihical glitches and crashes with Turnip 9v2. Plays smoothly with Qualcomm drivers instead, although minor graphical glitches and laggy cutscenes are still there",Pocket 5
+Salt And Sanctuary,Great,Turnip 24.3.0 9v2,Yuzu,1.0.3,"Almost perfect, ery slight dips in some places but super playable",Pocket 5
+Sam & Max: Save The World,Playable,Turnip 24.3.0 9v2,Sudachi,2.0.0,Handheld 0.75x res for 60fps,Pocket 5
+Samurai Jack: Battle Through Time,Perfect,Turnip 24.1.0 R18,Citron,1.0.3,"Citron 0.4 , 1x Native, all default. Runs amazing and looks Beautiful",Pocket 5
+Samurai Shodown,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Sanabi,Great,Qualcomm 0.746.0,Suyu,1.0,40fps docked,Pocket 5
+Savant – Ascent Remix,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Schim,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Put Accuracy Level on high or extreme. 1x Res – 30-35 FPS 0.75x Res – 50-60 FPS,Pocket 5
+Schim,Great,Qualcomm 0.746.0,Yuzu,1.0,Yuzu 278 (dc529a89a) Video precision : high Resolution : 0.75x Force max frequencies : Yes,Pocket 5
+Sclash,Playable,Turnip 24.3.0 9v2,Suyu,1.0,"30fps handheld, some stutters.",Pocket 5
+Scott Pilgrim vs. The World: The Game – Complete Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,,Pocket 5
+ScourgeBringer,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+ScourgeBringer,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Sd Gundam G Generation Genesis,Perfect,Qualcomm 0.746.0,Sudachi,1.0,60fps without problem,Pocket 5
+Sea Of Stars,Poor,Turnip 24.3.0 9v2,Citron,2.0.5,"Performance wise very playable, but there a lot of crashes in the progress of the story, even early on, so you cant really play the game, sadly",Pocket 5
+Sea Of Stars,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Game runs fine. But at some moments, like Elder mist or other places it crashed. All forks have the same problem. Qualcomm driver has missed textures.",Pocket 5
+Sea Of Stars,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.53846,,Pocket 5
+Seers Isle,Perfect,Qualcomm 0.746.0,Yuzu,2.0.1,Perfect 60fps docked,Pocket 5
+Sega Ages – Virtua Racing,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Senran Kagura Peach Ball,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Works perfectly,Pocket 5
+Senran Kagura Peach Ball,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Fullspeed (30FPS) throughout. Never encountered any bugs or slowdowns.,Pocket 5
+Serial Cleaner,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Shadow Labyrinth,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Shadowrun Returns,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,Used all default settings and it ran at a stable 60fps. Only issue is I had to use the overlay controls to advance one screen during character creation. Turned them off once I got into the game proper.,Pocket 5
+Shantae Half Genie Hero,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Default settings on Sudachi. Graphics at 1x. Device doesn’t even get hot. Temps stay around 42-45 Celsius.,Pocket 5
+Shantae: 1/2 Genie Hero – Ultimate Edition,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Run smoothly but has a long input lag. Makes it quite unplayable for a platformer… Same with Citron, with or without update.",Pocket 5
+Shantae: 1/2 Genie Hero – Ultimate Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Shashingo: Learn Japanese With Photography,Perfect,Turnip 25.2.0 R7,Yuzu,1.0,".75x , synch OFF. Graphics bugs far away but won’t ruin the game or stop from playing.",Pocket 5
+Shin Megami Tensei III Nocturne HD Remaster,Perfect,Turnip 24.1.0 R18,Citron,1.0.3,Citron 0.4 Limit speed 200% for 60fps .75 res Force Clocks Disk Shader Cache Use Reactive Flushing Ran into one crash after name creation (fixed by swiping up technique) played an hour no crashes.,Pocket 5
+Shin Megami Tensei III Nocturne HD Remaster,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.3,Its perfect 30fps in handheld mode but it goes to 0fps black screen every time you enter a new room which can be fixed by sliding up on the app as if you were going to close it then it will unfreeze. Playable but don’t think I would choose this over the ps2 ersion.,Pocket 5
+Shin Megami Tensei Vengeance,Great,Turnip 24.1.0 R18,Citron,1.0,Citron 0.4 30fps with minor dips Possible crashing in new scenes (save frequently) Played up to second battle with pixie Disk cache on Reactive flushing on (fixes graphics) Overdrive on (better fps) .5 res or .75 res .5 res felt like less crashing,Pocket 5
+Shin Megami Tensei Vengeance,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Shin-Chan: Shiro And The Coal Town,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Solid 30fps!,Pocket 5
+Shiren The Wanderer: The Mystery Dungeon Of Serpentcoil Island,Perfect,Qualcomm 0.746.0,Yuzu,2.1.2,Plays wonderfully!,Pocket 5
+Shogun Showdown,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Standard docked, default settings",Pocket 5
+Shovel Knight King Of Cards,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Shovel Knight Shovel Of Hope,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Shovel Knight: Treasure Trove,Perfect,Qualcomm 0.746.0,Yuzu,1.0,For me any Turnips on yuzu makes it crash when you enter the first level,Pocket 5
+Sifu,Playable,Turnip 24.3.0 9v2,Yuzu,1.11_790,"Handheld mode .5x resolution, barely playable gets 25-30fps most of the time but dips down to 15 or even a little lower. Playable if you don’t mind it looking and playing like a 3DS port",Pocket 5
+Signalis,Perfect,Qualcomm 0.746.0,Sudachi,1.4,Docked Mode 30 Fps locked Emulation Quality: High (fixes random crashes),Pocket 5
+Signalis,Perfect,Qualcomm 0.746.0,Yuzu,1.4,Perfect 30fps docked,Pocket 5
+Skater Xl,Perfect,Qualcomm 0.746.0,Yuzu,Updated 1.2.8.7,"1x Native, sync Off , Nearest Neigbor, Force maximum clocks, use Asynchronous Shaders, Use reactive Flushing. Note: The game will crash a couple times as the shaders will adjust and then run smoothly.",Pocket 5
+Skater Xl,Perfect,Qualcomm 0.746.0,Yuzu,Updated 1.2.8.7,"1x Native, sync Off , Nearest Neigbor, Force maximum clocks, use Asynchronous Shaders, Use reactive Flushing. Note: The game will crash a couple times as the shaders will adjust and then run smoothly.",Pocket 5
+Skul: The Hero Slayer,Perfect,Turnip 24.3.0 9v2,Sudachi,1.7.6,,Pocket 5
+Skullgirls: 2nd Encore,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.6,,Pocket 5
+Sky Oceans: Wings For Hire,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Would not boot in yuzu or sudachi with or without update on Turnip 9v2 or Qualcomm 0.746.0,Pocket 5
+Sky Rogue,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Skylanders Imaginators,Poor,Turnip 25.2.0 R11,Sudachi,1.1.1,"The game allows me to play the first level, but when I reach the HUB and I explore it for a bit, the game crashes. After restarting, the game crashes even earlier.",Pocket 5
+Skylanders Imaginators,Poor,Turnip 23.2.0,Citron,1.0,"The game, like how I tested it on Sudachi, allows me to play the first level, but when I reach the HUB and I explore it for a bit, the game crashes. After restarting, the game crashes even earlier.",Pocket 5
+Skylanders Imaginators,Poor,Turnip 25.2.0 R11,Citron,1.1.1,The game doesn’t get past the character selection screen because of a black screen covering everything,Pocket 5
+Skyrim,Playable,Turnip 24.3.0 9v2,Sudachi,1.1.392.3925134,"Plays fine, consistent 30fps at 0.75 res. Occasional crashes. Flickering lighting issue in dungeons. Worked around it somewhat by installing Enhanced Lights mod which makes flickering less intense, but also makes dungeons too dark in some areas. Mods can be installed by putting .esp/.esm files in sudachi/files/sdmc/atmosphere/contents/01000A10041EA000/romfs/Data. Edit Skyrim.ini folder in romfs folder. Add one if not there from Nexus mods Skyrim Switch Toolkit.",Pocket 5
+Slay The Spire,Perfect,Qualcomm 0.746.0,Yuzu,2.2.1,,Pocket 5
+Slay The Spire,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Slay The Spire,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Slay The Spire,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Slayers X: Terminal Aftermath: Vengance Of The Slayer,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Slime 3k – Rise Against Despot,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Sudachi 1.0.11 (99775b8) All default parameters,Pocket 5
+Slime Rancher,Poor,Turnip 24.3.0 9v2,Eden,1.0,Will crash before game file creation. Could not start new game.,Pocket 5
+Sludge Life,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Freezes a lot with yuzu and sudachi with both drivers,Pocket 5
+Snake Pass,Great,Turnip 24.3.0 9v2,Yuzu,1.4,"25fps docked, isuals are broken in handheld mode",Pocket 5
+Sniper Elite 3: Ultimate Edition,Poor,Turnip 25.2.0 R4,Yuzu,Both base and latest update crash after some time,Get perhaps 60 seconds of runtime then crashes,Pocket 5
+Sniper Elite 4,Great,Qualcomm 0.746.0,Yuzu,"1.0.3, 13 DLC",Seems to be mostly perfect 30 in handheld,Pocket 5
+Sniper Elite 4,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,game menu has some weird glitching but the game is playable,Pocket 5
+Snk Heroines Tag Team Frenzy,Poor,Turnip 24.3.0 9v2,Citron,1.0,Launches but characters are not visible. Tried Yuzu and Sudachi as well,Pocket 5
+SNK vs. Capcom: SVC Chaos,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Snowboarding The Next Phase,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Solar Ash,Great,Turnip 25.0.0 R5,Suyu,1.0,"20-25fps, runs good and looks good",Pocket 5
+Sonic Frontiers,Poor,Turnip 24.3.0 9v2,Citron,1.0,Crashes after completing the first level. People need to play a little further before listing a game as playable,Pocket 5
+Sonic Frontiers,Great,Turnip 24.3.0 9v2,Citron,1.0,"0.75x, force maximum clocks, use asynchronous shaders",Pocket 5
+Sonic Generations,Great,Turnip 24.3.0 9v2,Citron,1.01,"Works with 60fps mod, make sure to place it in the right folder, only Sonic generations part not shadow generations",Pocket 5
+Sonic Mania,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Sonic Origins,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Sonic Superstars,Perfect,Qualcomm 0.746.0,Sudachi,1.1.8,"Handheld mode, accuracy high, NCE/Qualcomm",Pocket 5
+Sonic Superstars,Great,Qualcomm 0.746.0,Suyu,1.0,,Pocket 5
+Sonic Wings Reunion,Poor,Qualcomm 0.746.0,Citron,1.0,crash and freeze,Pocket 5
+Sonic X Shadow Generations,Great,Turnip 24.1.0 R18,Citron,1.0,.75 resolution,Pocket 5
+Sonic X Shadow Generations,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Audio Output: cubeb to correct audio issues,Pocket 5
+Sonic X Shadow Generations,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+South Park: The Fractured Butt Whole,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,doesn´t render graphics. same for qualcom drivers,Pocket 5
+South Park: The Stick Of Truth,Perfect,Turnip 24.3.0 9v2,Yuzu,1.01,"Mode: Docked, Graphics Accuracy level: High",Pocket 5
+South Park: The Stick Of Truth,Perfect,Turnip 24.3.0 9v2,Citron,1.01,,Pocket 5
+Speed Overflow,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Speed Overflow,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Spelunky,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.5,"Played through the tutorial caves with 0 issues, 60fps.",Pocket 5
+Spelunky 2,Perfect,Turnip 24.3.0 9v2,Citron,1.27.0,"Debug > CPU Backend > Dynarmic …otherwise game doesn’t launch at all. Despite Dynarmic saying it is slow, it was running at 60fps.",Pocket 5
+Spelunky 2,Great,Turnip 24.3.0 9v2,Yuzu,1.28,"Before installing this driver, the game was unplayable, but it works great after the install.",Pocket 5
+Spintires: Mud Runner (Mudrunner – American Wilds),Great,Turnip 24.3.0 9v2,Yuzu,v3.6,Yuzu 278 (dc529a89a) CPU debugging : Yes Resolution : 0.75x Force max frequencies : Yes Cashes quite often,Pocket 5
+Spirit Hunter: Death Mark 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.04,"plays perfectly, default settings",Pocket 5
+Splatoon 3,Great,Turnip 24.3.0 9v2,Citron,DLC + 9.1.0,Occasional dips in fps but is surprisingly stable,Pocket 5
+Spongebob Squarepants: The Cosmic Shake,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.7,Handheld mode High performance Accuracy Level high 1x = 20-25fps 0.75x = 25-30fps Disk shader on Async shader on Audio cubeb Bloom glitch is easily fixable by having the accuracy level on high so its pretty much mandatory. Can crash during cutscene so I suggest to just skip all of it,Pocket 5
+Spyro Reignited Trilogy,Great,Turnip 25.2.0 R1,Yuzu,1.0,"Set Accuracy level to High, .75x Res, Asynchronous shaders on, Sharpness 25% or higher. Stable 30fps",Pocket 5
+Spyro Reignited Trilogy,Great,BioSensor MK1,Citron,1.0.1,Citron Optimized ersion (yes it runs better for this game) Docked // Accuracy to High for the color issue. Resolution 0.75 // -sync : immediate Disk shader cache: enabled Force maximum clocks (Aderno only): enabled Use asynchronous shaders: enabled Output engine: cubeb,Pocket 5
+Spyro Reignited Trilogy,Great,Turnip 25.0.0 R5,Citron,1.01,"Docked Mode, Graphics Accuracy: High, Resolution: 0.75X, Sync mode: Immediate (Off), Audio: cubeb Prerendered cutscenes have no audio. Minor slowdown in parts.",Pocket 5
+Stacklands,Great,Qualcomm 0.746.0,Citron,1.0,Could only get to 50-60% full speed,Pocket 5
+Stacklands,Perfect,Qualcomm 0.746.0,Sudachi,1.4.0.2,I beat the Demon Lord but have not played the expansion stuff yet. It plays perfectly but turn the fan on because the system starts getting hot the larger your board gets.,Pocket 5
+Star Ocean: First Departure R,Perfect,Qualcomm 0.746.0,Citron,1.0,Crashes during the first battle when using Turnips. Works flawlessly with standard. I have played about 20 minutes.,Pocket 5
+Star Ocean: The Second Story R,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,Crashes occasionally (after around an hour of straight gameplay) for seemingly no reason. Game autosaves enough that it’s not a real issue.,Pocket 5
+Star Ocean: The Second Story R,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1 + DLC,"Stable 30FPS in docked mode, cubeb audio engine, RP5 on standard performance mode",Pocket 5
+Star Of Providence,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Star Overdrive,Poor,Qualcomm 0.746.0,Citron,1.0.7,"Cutscenes load fine, but there is constant texture flickering during gameplay.",Pocket 5
+Star Wars – Knights Of The Old Republic,Great,Turnip 24.3.0 9v2,Yuzu,Base or Update 1.0.1,Seemed to work great. Only played into the main story a couple minutes,Pocket 5
+Star Wars – Knights Of The Old Republic II,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Seems to run great. Played through the first bit of the game.,Pocket 5
+Star Wars The Force Unleashed,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"The game launches and runs fine, but the pause menu options are transparent once you get into the game, making it quite difficult to navigate. Could play, if you’re determined or desperate.",Pocket 5
+Star Wars: Dark Forces,Perfect,Turnip 25.2.0 R4,Yuzu,1.0,,Pocket 5
+Stardew Valley,Perfect,Qualcomm 0.746.0,Citron,1.5.4.2,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Stardew Valley,Perfect,Qualcomm 0.746.0,Citron,1.6.9.37,Perfect 60 fps,Pocket 5
+Stardew Valley,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Stardew Valley,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Stardew Valley,Playable,Turnip 24.3.0 9v2,Yuzu,1.5.4.2,Controls are very painstakingly hard to go through,Pocket 5
+Steamworld Build,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Steamworld Dig,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.12.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Steamworld Heist II,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Steins Gate: My Darlings Embrace,Perfect,Turnip 24.3.0 9v2,Citron,1.0,60fps,Pocket 5
+Steins;Gate Elite,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2E,Perfect 60fps docked,Pocket 5
+Stella Of The End,Perfect,Qualcomm 0.746.0,Sudachi,1.0,It just works,Pocket 5
+Story Of Seasons: Friends Of Mineral Town,Perfect,Turnip 25.2.0 R11,Sudachi,1.1.7,Looks amazing too,Pocket 5
+Story Of Seasons: Pioneers Of Olive Town,Great,Turnip 24.3.0 9v2,Sudachi,Newest game update and newest update of Sudachi,"The newest sudachi update resolved issues with crashing. Using the 4gb of swap memory as well. It runs pretty consistently from 50-60fps. I normally run it on performance mode, but high performance gives it a couple extra frames per second.",Pocket 5
+Stranger Things,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,works great. would not load on standard driver. Only tried Yuzu.,Pocket 5
+Stray,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Handheld mode, resolution 0.75, CPU backend to dynamic slow. Some crashes and slowdown, but most of it runs at 29fps",Pocket 5
+Streets Of Rage 4,Perfect,Qualcomm 805,Citron,1.0.9,Tried default and Turnip but it glitches and you miss the “story ideos” found the latest Qualcomm fixes that.,Pocket 5
+Streets Of Rage 4,Perfect,Qualcomm 0.746.0,Sudachi,1.0.9,60 fps – Works perfectly with default settings,Pocket 5
+Streets Of Rogue,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect. I played 1 playthrough with soldier and got to the last floor without any problem.,Pocket 5
+Strike Suit Zero,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,Start in handheld then switch to docked,Pocket 5
+Subnautica,Perfect,Turnip 24.3.0 9v2,Yuzu,1.21.71113,Stable 30 fps in performance mode handheld 1x res,Pocket 5
+Subnautica,Perfect,Turnip 24.3.0 9v2,Yuzu,1.21.71113,Stable 30fps in docked mode,Pocket 5
+Suika Game,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Runs perfect 60FPS, even with default driver. Performance mode",Pocket 5
+Suika Game,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Suikoden I & Ii Hd Remaster: Gate Rune And Dunan Unification Wars,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Game hits a black screen once you enter Kyaro Town in Suikoden II.,Pocket 5
+Super Bomberman R,Perfect,Turnip 24.1.0 R18,Citron,1.0,,Pocket 5
+Super Bomberman R 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.1,,Pocket 5
+Super Lone Survivor,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Seems to run perfectly,Pocket 5
+Super Mario 3d All Stars,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Works flawlessly with a consistent 60 fps.,Pocket 5
+Super Mario 3D All Stars,Poor,Qualcomm 0.746.0,Yuzu,1.1.1,"Yuzu not playable with either Qualcomm 0.746.0 or Mesa Turnip 25.0.0 R5 (low fps and sound cracks). Not playable with Sudachi AT ALL, game crashes with Qualcomm 0.746.0 + ulkan 1.4.303",Pocket 5
+Super Mario 3D World + Bowser’s Fury,Perfect,Turnip 24.3.0 9v2,Citron,1.1.0,"Citron is back in development! Settings: Docked 45 – 50 FPS, Handheld 60 FPS 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.",Pocket 5
+Super Mario 3D World + Bowser’s Fury,Perfect,Turnip 24.3.0 9v2,Suyu,1.1.0,Handheld mode,Pocket 5
+Super Mario 3D World + Bowser’s Fury,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Super Mario Bros. Wonder,Playable,Turnip 24.3.0 9v2,Citron,1.01 + FPS mod,"Citron 0.5 + Turnip 9v2 or 24.1.0 R18 fix The game will freeze and restart the device at times, sometimes even corrupting the save games or configuration of the emulator. Much less issues now with Citron 0.5 but perhaps 7 levels are still problematic. Consider using Syncthing to save your game progress elsewhere and remove some of the frustration. If the issue with restart occurs, change CPU + Graphics accuracy to high, revert to default qualcomm driver and disable shader cache. Finish the level and revert config.",Pocket 5
+Super Mario Bros. Wonder,Great,BioSensor MK2,Yuzu,1.0,"Tested on standard performance (RP5), ery tiny slowdowns, Build d590cfb9d, firmware 18.1.0 (same for prod/keys), handheld mode, 1x resolution, disk cache on, basically all on default. It was the only emu and driver combination that didn’t crashed and rebooted the RP5/reset the emu after a second load, qualcomm drivers worked (didn’t reboot on second load) but was slow and gave graphic glitches. Same config on other ersions of yuzu, sudachi or citron, reboots the device. Decreasing the resolution, putting RP5 on high performance, or activating “force maximum clocks” might make it perfect. Update 1.0.1 doesn’t load the game, black screen.",Pocket 5
+Super Mario Bros. Wonder,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,"This setup stopped the issue where loading an existing save would hard crash the RP5 (two users confirmed.) Citron builds e2808ec and c718cc2 work (other ersions might work too.) Change audio engine to cubeb to stop stuttering. Undocked performance is 60fps, docked hovers around ~50fps. Optional fps stabilizing mod acquired here: https://github.com/theboy181/switch-ptchtxt-mods/blob/main/Super%20Mario%20Bros.%20Wonder/%5B010015100B514000%5D/v1.0.0/Stabilize%20FPS.rar",Pocket 5
+Super Mario Bros. Wonder,Perfect,Turnip 23.2.0,Yuzu,1.0,Use Turnip 23.2.0-devel to prevent crashes with shader cache enabled and Stabilize FPS mod from https://github.com/theboy181/switch-ptchtxt-mods/tree/main/Super%20Mario%20Bros.%20Wonder/%5B010015100B514000%5D/v1.0.0 to improve performance.,Pocket 5
+Super Mario Bros. Wonder,Great,Qualcomm 0.746.0,Yuzu,1.0,Emulator Uzuy Edge 0.0.5-13,Pocket 5
+Super Mario Bros. Wonder,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Super Mario Bros. Wonder,Great,Turnip 24.3.0 9v2,Yuzu,1.0,skip animations to avoid crashes,Pocket 5
+Super Mario Maker 2,Perfect,Turnip 24.3.0 9v2,Yuzu,3.0.3,"Consistent 60FPS! Had some rare audio crackling but this was fixed by switching audio engine to cubeb. Shame the app doesn’t support online, because Open Course World would have been good for this.",Pocket 5
+Super Mario Odyssey,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"You can beat the game, but here are some issues that I found: 1. Seaside Kingdoms boss will crash the game due to lag 2. Wooden Kingdom S Spewart fight has the same fate, but other Spewart fights (luncheon) seem to be A-OK 3. Cutscene music WILL GET CHOPPY 4. USE 0.75",Pocket 5
+Super Mario Odyssey,Great,Turnip 24.3.0 9v2,Citron,1.0.3,"Very Playable, use .75 resolution, plays at 60 fps to high 50s unless ery zoomed out at a large zone. Then fps drops to mid 40s. Overall a great play!",Pocket 5
+Super Mario Odyssey,Great,Turnip 24.3.0 9v2,Sudachi,1.3.0,"Almost perfect, above 50 FPS, ery few micro stutters",Pocket 5
+Super Mario Odyssey,Perfect,Turnip 25.2.0 R11,Eden,1.0,"Limitar porcentaje emulación: 85% Docked mode = On Resolution: 0,5x Vsync = Off Two hous playing without problems",Pocket 5
+Super Mario Party Jamboree,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Crashed during loading screen with both eden and sudachi,Pocket 5
+Super Mario RPG,Perfect,Qualcomm 0.746.0,Citron,1.0.1,Citron is back in development! 30-60 FPS Settings: Docked 1x Res.(Might Have More Stable Performance On Handheld) Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Super Mario RPG,Great,Qualcomm 0.746.0,Yuzu,1.0,"If your audio is crackling, change audio setting to ‘oboe’ instead of ‘Auto’. Only minor graphical issues happen when opening the item quick menu or saving progress (thumbnails), but nothing game-breaking. Smooth 60FPS on Performance mode.",Pocket 5
+Super Mario RPG,Great,Qualcomm 0.746.0,Yuzu,1.0,Crashes after the Main menu on the Turnips I tested (9v2 / 25.0.0 rev3). Might sometimes dip to 40/50fps,Pocket 5
+Super Mario Wonder,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Almost perfect, weird graphical glitches in overworld",Pocket 5
+Super Meat Boy,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Work perfectly with default settings,Pocket 5
+Super Monkey Ball Banana Rumble,Great,Qualcomm 0.746.0,Suyu,2,"Accuracy level = HIGH, or else menus will crash a lot. Undocked stays around 50-60fps and dropping to ~40 with certain menus on screen. Docked mode isn’t recommended; gameplay performance drops to about ~30fps.",Pocket 5
+Super Monkey Ball Banana Rumble,Playable,Qualcomm 0.746.0,Suyu,2,"Game has plenty of freezes when interacting with certain menus which can be strangely overcome by swiping up into the recent apps iew and then immediately returning to the game. Sometimes you have to do this consistently to make it through a menu. Once you’re in a stage there’s only rare freezes which can be fixed with the aforementioned trick. When not frozen, the game has solid 60fps in singleplayer. Must use stock driver as Turnip (9v2) crashes when trying to load any 3D content.",Pocket 5
+Super Robot Wars,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Super Smash Bros Ultimate,Perfect,Qualcomm 819.1,Yuzu,1.0,,Pocket 5
+Super Smash Bros Ultimate,Perfect,Turnip 25.2.0 R7,Yuzu,1.0,,Pocket 5
+Super Smash Bros Ultimate,Perfect,Qualcomm 682,Yuzu,1.0,Disk shader cache enabled Force maximum clocks enabled Use asynchronous shaders enabled (light stutters but gameplay is 60 fps),Pocket 5
+Super Woden GP 2,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.5,Does not boot,Pocket 5
+Superhot,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Emulator Uzuy Edge 0.0.5-13,Pocket 5
+Sword Of The Vagrant,Poor,Turnip 24.3.0 9v2,Citron,1.0,"Not playable on Sudachi, or Yuzu either",Pocket 5
+Symphonia,Perfect,Qualcomm 0.746.0,Citron,1.0,,Pocket 5
+Tactics Ogre Reborn,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Runs between 29 and 30 FPS perfectly.,Pocket 5
+Tales Of Vesperia,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.2,"Force Maximum Clocks. Resolution: .75x Audio Driver: Cubeb(required for audio to not glitch out. Game may crash once in a while, so save often.",Pocket 5
+Teenage Mutant Ninja Turtles: Mutants Unleashed,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Tried with sudachi and citron and combination of drivers. Maybe a preloaded shader cache patch will help.,Pocket 5
+Teenage Mutant Ninja Turtles: Shredders Revenge,Poor,Turnip 24.3.0 9v2,Eden,1.0,"No matter the driver, no matter the update, no matter the dlc, this game doesnt boot on Eden.",Pocket 5
+Teenage Mutant Ninja Turtles: Shredders Revenge,Great,Turnip 25.2.0 R4,Yuzu,1.0,Main gameplay is perfect but the intro cutscene and audio is stuttery,Pocket 5
+Teenage Mutant Ninja Turtles: Splintered Fate,Perfect,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.9.0,"It works perfectly, between 50-60 FPS",Pocket 5
+Teenage Mutant Ninja Turtles: Splintered Fate,Playable,Qualcomm 0.746.0,Yuzu,1.0,gets better as you play,Pocket 5
+Teenage Mutant Ninja Turtles: Splintered Fate,Playable,Qualcomm 0.746.0,Sudachi,1.0,(works with R9v2 but seems happier with System),Pocket 5
+Tennis In The Face,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Terminal Velocity,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.2.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Terraria,Perfect,Qualcomm 0.746.0,Citron,4.4.11,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Terraria,Perfect,Qualcomm 0.746.0,Yuzu,4.4.11,Perfect 60fps docked,Pocket 5
+Terraria,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Teslagrad,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Tetris 99,Poor,Turnip 24.3.0 9v2,Suyu,2.1.0,The tetris pieces are invisible.,Pocket 5
+Tetris Effect,Great,Turnip 24.3.0 9v2,Citron,1.0,Resolution set to 0.75x. 30-60FPS depending on the current background.,Pocket 5
+Thank Goodness You’re Here!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+The Binding Of Isaac: Afterbirth+,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,the game runs smoothly no change in drivers since its a ery lightweight game.,Pocket 5
+The Binding Of Isaac: Repentance,Perfect,Turnip 24.3.0 9v2,Sudachi,1.7.2,Change CPU backend to dynamic to eliminate graphical glitches.,Pocket 5
+The Binding Of Isaac: Repentance,Great,Turnip 24.3.0 9v2,Citron,1.7.9b,"Disable sync to fix a texture glitch. 55-60 fps on average, wouldn’t really notice it without the fps counter.",Pocket 5
+The Binding Of Isaac: Repentance,Great,Turnip 24.3.0 9v2,Sudachi,1.7.2,The frames do dip slightly at times however it is only ever so slightly slower than the original on switch which also has slowdown during busy moments (rerolling 100s of items etc.),Pocket 5
+The Case Of The Golden Idol,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Qualcomm 0.746.0,Yuzu,1.1.392.3925134,,Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Qualcomm 0.746.0,Yuzu,1.1.392.3925134,"Tried with Turnip but after some Gameplay it would exit, found the default gpu driver works fine and so far no exits.",Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Qualcomm 0.746.0,Yuzu,1.1.392.3925134,"Tried with Turnip but after some Gameplay it would exit, found the default gpu driver works fine and so far no exits.",Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Default settings, otherwise it crashes, handheld mode, 30fps at start",Pocket 5
+The Flame In The Flood,Great,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+The Hong Kong Massacre,Playable,Qualcomm 0.746.0,Suyu,1.0,25fps docked,Pocket 5
+The House In Fata Morgana: Dreams Of The Revenants Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+The House Of The Dead Remake,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.1,Game can be started but will crash once the first enemy attacks,Pocket 5
+The Hundred Line: Last Defense Academy,Great,Mr. Purple T18,Sudachi,1.0.3,"Definitely not perfect but runs at a pretty consistent 30fps. Crashes do occur, so save often! I tried other drivers, but it _feels_ like there may be better options, although this one is pretty stable overall.",Pocket 5
+The King of Fighters XIII: Global Match,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,Runs smooth at 60fps docked,Pocket 5
+The King of Fighters XIII: Global Match,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+The Last Campfire,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+The Legend Of Heroes: Trails From Zero,Poor,Qualcomm 0.746.0,Sudachi,1.0,"Freezes upon starting a New Game, also freezes occasionally in the options part of the title screen.",Pocket 5
+The Legend Of Heroes: Trails From Zero,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+The Legend Of Heroes: Trails To Azure,Poor,Turnip 24.3.0 9v2,Sudachi,1.1.17,It gets to menu but freezes soon after hitting new game. No idea if loading a save works. No change in setting or driver solved it.,Pocket 5
+The Legend Of Heroes: Trials Through Daybreak,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,"30FPS gameplay, runs smooth all the way through first battle, some dips to high 20s in cutscenes.",Pocket 5
+The Legend Of Zelda: Breath Of The Wild,Great,Turnip 24.3.4-Unified (@Mr_Purple_666),Citron,1.6.0,Very stable with the 1.6.0 BOTW update. Hovers around 26-30fps at 1x res and consistently 28-30fps at .75 res.,Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 24.1.0 R18,Citron,1.6.0,"At 1× resolution I’m getting about 28 FPS with minor drops; at 0.75× it’s around 30 FPS, falling to 28 FPS in heavily loaded scenes. In dungeons there are rendering issues – the image seems to split – but you can still get through.",Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 23.2.0,Yuzu,1.6.0,28 – 30 FPS Avg. Handheld Mode Graphics: Resolution – 0.75x (1.0x loses about 5-8 FPS and creates slowdown) Adapting Filter – Bilinear (AMD FidelityFX loses 2-3 FPS) Anti-aliasing – FXAA Disk Shader Cache – On Force Maximum Clocks – On Use Asynchronous Shaders – On,Pocket 5
+The Legend of Zelda: Breath of the Wild,Playable,Turnip 24.3.0 9v2,Yuzu,1.14,,Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 24.0.0-devel R12,Citron,1.6.0 + DLC 1+2,"System – 100% max Speed, Handheld mode Graphic – 1X, Sync FIFO on, Scaleforce, 25% FSR, AA off, AF 16x, DSC on, Max freq on, ASync Shader on Audio – cubeb Debug – ulkan, NCE, unsafe, CPU Debugging On, Fastmem on GPU-Driver – Mesa Turnip 24.0.0-devel – R12 + Aggressive mode not Final, Work in progress, still ghosting in shrines",Pocket 5
+The Legend of Zelda: Breath of the Wild,Perfect,Turnip 24.1.0 R17,Yuzu,1.6.0,“docked mode 0.75 x AMD fidelity FX FXAA disk shader cache force maximum clocks use asynchronous shaders on Shrine & water fixed works perfectly for me in the Shrine”,Pocket 5
+The Legend of Zelda: Breath of the Wild,Perfect,Turnip 24.1.0 R17,Yuzu,1.6.0,docked mode 1x AMD fidelity FX FXAA disk shader cache force maximum clocks use asynchronous shaders on Shrine & water fixed works perfectly for me in the Shrine,Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 24.3.0 9v2,Sudachi,1.6,"In shrines, I experienced some data moshing effects and some crashes but that all happened while fiddling with the settings so It needs more testing. Otherwise, the game is basically locked at 30 fps on the great plateau",Pocket 5
+The Legend of Zelda: Breath of the Wild,Playable,Turnip 24.3.0 9v2,Yuzu,1.6.0,Crashes after some playing time. Mostly when speak to NPC. I wish some one can help with that. Also some graphical issues inside sanctuarys,Pocket 5
+The Legend of Zelda: Breath of the Wild,Perfect,Turnip 24.3.0 9v2,Yuzu,1.5.0,BOTW SETTINGS (getting 25-30fps) SYSTEM Limit speed: enabled Limit speed percent: 100% Docked mode: disabled Emulated region: USA Custom etc: disabled GPU Turnips R9v2 GRAPHICS Accuracy level: normal Resolution: 2x 1440p/2160p) (slow) Vsync mode: FIFO (on) Window adapting filter: AMD FidelityFX super resolution FSR sharpness: 25% Anti-aliasing method: FXAA Anoscopic filtering: default Aspect ratio: Default (16:9) Disk shader cache: enabled Force maximum clocks (Aderno only): enabled Use asynchronous shaders: enabled Use reactive flushing: disabled DEBUG API: ulkan CPU: Native code execution (NCE) CPU accuracy: unsafe CPU Debugging: Disabled AUDIO: Output engine: cubeb DLC 3.0 UPDATE 1.5.0,Pocket 5
+The Legend Of Zelda: Echoes Of Wisdom,Playable,Qualcomm 0.746.0,Citron,1.0.1,"Very playable bordering great using handheld mode, RP5 in Performance, graphics accuracy High, sync Immediate, window adapting filter FSR, disk shader cache/max clocks/async shaders all turned on. The mod “Remove DOF/BLUR Proper” (https://gamebanana.com/mods/544570) is a must. 20 FPS in new scenes and when in combat game is semi slow motion. In open world/cutscenes/dungeons 30-45 FPS. Played as far as entering the first rift.",Pocket 5
+The Legend Of Zelda: Echoes Of Wisdom,Great,GPU 0.746.0 Qualcomm,Sudachi,1.0.2,Needs a mod for the blur and unlocking fps. Some graphical glitches. Run mailbox mandatory for now. Super fun!,Pocket 5
+The Legend Of Zelda: Skyward Sword HD,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+The Legend Of Zelda: Skyward Sword HD,Perfect,Turnip 23.3.0-devel,Yuzu,1.0,"If you have crashing issues, use this driver. Game hasn’t dropped below 60fps once yet, and I have completed the first 3 dungeons.",Pocket 5
+The Legend Of Zelda: Skyward Sword HD,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.1,"Sudachi didn’t work, have to use Suyu",Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Great,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Playable,Qualcomm 0.746.0,Citron,1.2.1,"System – 100% max Speed, Docked Mode(important), Rest your choice Graphic – Extreme, 1X, Sync Off, nearest neighbors, 25% FSR, AA Off, AF standart, 16:9, DSC On, Max freq On, ASync Shader On, URF Off Audio – cubeb Debug – ulkan, NCE, unsafe, CPU Debugging On, Fastmem On not Final, Work in progress",Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Playable,Qualcomm 0.746.0,Suyu,1.0,Some lighting glitches but 25-30 fps consistently,Pocket 5
+The Messenger,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+The Messenger,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+The Messenger,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+The Outer Worlds,Great,Turnip 24.3.0 9v2,Sudachi,1.0,runs at 25 to 30 fps. Crashes a few times in the beginning but able to restart and continue playing from saved state. so save frequently,Pocket 5
+The Outer Worlds,Poor,Turnip 24.3.0 9v2,Citron,Update +2DLC,"Framerate seems ok at .75x but big graphical glitching, someone could potentially tweak it to be playable",Pocket 5
+The Pathless,Poor,Turnip 24.3.0 9v2,Citron,1.0,Black screen and crash during first cinematic,Pocket 5
+The Pedestrian,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 30 FPS,Pocket 5
+The Plucky Squire,Playable,Turnip 24.3.0 9v2,Citron,1.0.4,"FAR from perfect – playable but not an enjoyable experience. Works around 30 FPS on the 2D sections, but an hour in the game jumps to 3D and the framerate tanks to 10-20 FPS.",Pocket 5
+The Plucky Squire,Great,Turnip 24.3.0 9v2,Yuzu,1.0.5,"DISCLAIMER: I did not get to the 3D part yet, the 2d part plays perfect in handheld mode and looks stunning",Pocket 5
+The Settlers: New Allies,Poor,Qualcomm 0.746.0,Yuzu,1.0.5,Game not launching,Pocket 5
+The Smurfs 2 : The Prisoner Of The Green Stone,Perfect,Turnip 24.3.0 9v2,Yuzu,1.03.03,Audio – cubeb. Asynch shaders on Plays well 30fps locked – Haven’t tried docked mode,Pocket 5
+The Smurfs Mission Villeaf,Perfect,Qualcomm 0.746.0,Yuzu,1.0.17.8,Perfect 30fps docked,Pocket 5
+The Stanley Parable: Ultra Deluxe,Great,Qualcomm 0.746.0,Yuzu,1.04,"50-60fps docked, feels great",Pocket 5
+The Tale Of Bistun,Poor,Turnip 24.3.0 9v2,Citron,1.0,"Crashes after the initial start ideo, tried with other emulators as well, same result",Pocket 5
+The Thing Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+The Wandering Village,Perfect,Qualcomm 0.746.0,Yuzu,1.0,60 fps,Pocket 5
+The Wardrobe: Even Better Edition,Perfect,Qualcomm 0.746.0,Citron,1.0,"Perfect 60fps with stock driver, won’t boot with Turnips.",Pocket 5
+The Wild At Heart,Perfect,Qualcomm 0.746.0,Yuzu,1.1.5,"Perfect 60fps docked, looks great",Pocket 5
+The Witcher 3: Wild Hunt,Playable,Turnip 24.3.0 9v2,Citron,Version 3.7,".5x on latest citron gets you 12-25fps, playable if you are extremely desperate. Seems promising for future citron builds.",Pocket 5
+The World Ends With You: Final Remix,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Choppy during animated cutscenes but plays great,Pocket 5
+There Is No Game,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Thief Simulator,Perfect,Qualcomm 0.746.0,Sudachi,1.4.0,minor texture error and occasional crash,Pocket 5
+This War Of Mine Complete Edition,Great,Turnip 24.3.0 9v2,Yuzu,1.0.4,50-60fps handheld,Pocket 5
+Thronefall,Perfect,Qualcomm 0.746.0,Citron,1.94,Almost Perfect 60 FPS Docked (FPS sits around 45-60 but you can’t really tell and it stays smooth with not FPS drops.),Pocket 5
+Thunder Ray,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Ran perfectly fine in dock/handheld modes at 30fps. One possible crash, unrepeatable.",Pocket 5
+Titan Quest,Perfect,Turnip 25.2.0 R9,Yuzu,1.0,720/1080p Docked Mode,Pocket 5
+To The Moon,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Toem,Perfect,Qualcomm 0.746.0,Yuzu,3,"Flawless 60fps docked, looks great on oled",Pocket 5
+Toki,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Little audio stutter on starting cinematics. But game maintains 60 fps,Pocket 5
+Toki,Perfect,Turnip 25.0.0 R5,Yuzu,1.0,"60fps flawless, played first 2 stages. Standard settings",Pocket 5
+Tokyo Mirage Sessions #Fe Encore,Great,Qualcomm 0.746.0,Yuzu,1.0,"Mostly 30fps handheld, some dips down to 20 and minor audio stutter",Pocket 5
+Tomb Raider I-III Remastered,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Tomb Raider I-III Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Runs fine, but the colors are oversaturated and ery dark in both PS1 and Remastered modes, to the point where some areas are almost impossible to see",Pocket 5
+Tonight We Riot,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Tony Hawk’s Pro Skater 1+2,Great,Turnip 23.3.0-devel,Sudachi,1.0,"Capped at 30fps, runs between 25-30fps most of the time except for more wide/open levels which occasionally drop to around 20fps at points. Graphical glitches are fairly common, but aren’t too distracting. No problems otherwise.",Pocket 5
+Tony Hawk’s Pro Skater 1+2,Perfect,Turnip 23.2.0,Sudachi,Latest,,Pocket 5
+Torchlight 2,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.5,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Torchlight 3,Perfect,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.9.1,Runs great. Shaders and clock enabled.,Pocket 5
+Torchlight II,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.98762,Plays ery well !,Pocket 5
+Torchlight II,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Torchlight II,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Totally Accurate Battle Simulator,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.34,Yuzu 278 (dc529a89a) Video precision : High,Pocket 5
+Transistor,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+Trek To Yomi,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"very playable but a bit stuttery, assuming its a shader issue",Pocket 5
+Trials Of Mana,Playable,Turnip 24.3.0 9v2,Citron,1.1.1,"Handheld Mode, Graphics Accuracy: High, Resolution: 0.75X, Sync mode: Immediate (Off), Audio: cubeb, CPU Accuracy: Accurate FPS can dip in towns, and in some cutscenes. Otherwise smooth most other places. Can be unstable initially.",Pocket 5
+Triangle Strategy,Poor,Turnip 24.3.0 9v2,Citron,1.1.1,Game crash at around 3hours mark. I tried different setting (CPU / GPU to high) and different drivers but the game is really unstable and crash mid fight,Pocket 5
+Triangle Strategy,Great,Turnip 23.2.0,Yuzu,1.1,"0.75x resolution, game speed capped, docked mode. FPS is a pretty stable 30 throughout. Only would see the occasional dip when entering a new map or the occasional in battle skill. Only played the first hour so far.",Pocket 5
+Trinity Trigger,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Plays perfectly at 60fps. 2 hours in with no dips so far.,Pocket 5
+Trombone Champ,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Runs great at 60fps,Pocket 5
+Trouser Critters Long Dagger,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Trouser Critters Long Dagger,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Trouser Critters Shiny Clam Rocks,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Tsukihime – A Piece Of Blue Glass Moon,Perfect,Turnip 24.3.0 R5,Sudachi,1.01,Set RP5 to Performance mode as effect heavy cutscenes will dip to 30 fps. Run 60fps at 1080p Docked mode with no issues. Tested all the way to chapter 8.,Pocket 5
+Tunic,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Tunic,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Tested first 30 minutes,Pocket 5
+Turbo Overkill,Great,Qualcomm 0.746.0,Citron,1.1.0,FPS stays around 20-30. Occasional dips but surprisingly good,Pocket 5
+Turbo Overkill,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Failed to boot, tried with Citron and had the same result",Pocket 5
+Twelve Minutes,Great,Turnip 24.3.0 9v2,Citron,1.0,Minor lightning glitch at the start. Good performance. Default Settings.,Pocket 5
+Two Point Hospital,Perfect,Turnip 24.3.0 9v2,Citron,Latest,,Pocket 5
+Ubermosh: Omega,Perfect,Qualcomm 0.746.0,Citron,1.0.1,Perfect 60 FPS Docked,Pocket 5
+Ugly,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,"I couldnt figure out how to complete the first puzzle so I cant say much, but it seems to be perfect 60fps docked",Pocket 5
+Ultimate Marvel vs. Capcom 3,Great,Turnip 25.2.0 R4,Yuzu,1.0,,Pocket 5
+Ultra Street Fighter II: The Final Challengers,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"720p, standard performance",Pocket 5
+Ultra Street Fighter II: The Final Challengers,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Umineko No Naku Koro Ni Catbox,Perfect,Turnip 24.1.0 R17,Sudachi,1.0.3,"It just works. It’s a visual novel, so I imagine it’s not taxing to the system.",Pocket 5
+Unavowed,Poor,Turnip 24.3.0 9v2,Citron,1.0,Does not work on any of the Drivers I have tested. Pixels are broken on screen. Tried many different settings.,Pocket 5
+Undead Horde,Great,Turnip 24.3.0 9v2,Yuzu,1.2.1,frame drops some times when summoning the large amt of undead,Pocket 5
+Undead Horde 2,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Under Defeat,Perfect,Turnip 25.0.0 R5,Citron,1.0,"Works great, also with dock mode. I recommend two joystick setting in game.",Pocket 5
+Undermine,Perfect,Turnip 24.3.0 9v2,Sudachi,1.2.0.0,,Pocket 5
+Undernauts: Labyrinth Of Yomi,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2bo,Runs great.,Pocket 5
+Undertale,Perfect,Qualcomm 0.746.0,Citron,1.11,Citron is back in development! 30 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Undertale,Perfect,Qualcomm 0.746.0,Sudachi,1.11,Locked to 30FPS,Pocket 5
+Unicorn Overlord,Great,Turnip 25.2.0 R2,Citron,v1.05,"Game is ery playable and enjoyable, but not perfect, like the other entry says. Tried several drivers, got the best framerate with 25.2.0_R2. Framerate is typically directly tied to the number of entities on-screen, with the world map usually being 50-60fps, battle maps being about 45, and 6v6 combat screens dipping down to 30fps. Being a tactical RPG, this really isn’t a problem, and feels great to play. Running in Handheld mode, with 0.75 resolution and FidelityFX. Cache, Max clocks, and Async Shaders turned on, CPU accuracy auto/graphics accuracy normal. May sometimes get the odd audio crackle, this can be fixed by switching audio to cubeb, but isn’t really necessary.",Pocket 5
+Unicorn Overlord,Perfect,Turnip 24.3.0 9v2,Sudachi,1.03,,Pocket 5
+Unmetal,Perfect,Turnip 25.2.0 R9,Yuzu,1.0,720/1080p Docked Mode,Pocket 5
+Unsighted,Perfect,Turnip 24.3.0 9v2,Citron,1.1.4,,Pocket 5
+Urban Myth Dissolution Center,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1,"60 fps docked, plays perfectly",Pocket 5
+Valiant Hearts: The Great War,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked mode,Pocket 5
+Valkyria Chronicles,Great,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked but some minor isual and audio glitches,Pocket 5
+Valkyria Chronicles 4,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Locked 30fps. Handheld or Docked.,Pocket 5
+Vampire Hunters,Great,Qualcomm 0.746.0,Citron,1.1.5.cl11438,Turn accuracy level to high. Stable 60 FPS when not in combat FPS ranges from 25-60 FPS while in combat Depends on amount of enemies and effects on screen,Pocket 5
+Vampire Survivors,Perfect,Qualcomm 0.746.0,Yuzu,"1.6.10, 2DLC",Perfect 60fps docked,Pocket 5
+Velocity 2x,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Victory Heat Rally,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Victory Heat Rally,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Seems to be running at full speed during races. There is a bit of slowdown during the intro to the races, but I am not sure if that happens on actual console. Played about 30 mins in.",Pocket 5
+Void Bastards,Great,Turnip 24.3.0 9v2,Sudachi,2.0.24,"Plays mostly 60fps in handheld, some drops in busy situations. Occasionally random crashes when loading new level. Game saves ery frequently so no biggie. Plays well overall.",Pocket 5
+Void Prison,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Void Prison,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Void Scrappers,Perfect,Qualcomm 0.746.0,Citron,1.3,Perfect 60 FPS Docked,Pocket 5
+Void Scrappers,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Void Scrappers,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Voidwrought,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Voltaire: The Vegan Vampire,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Wall World,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Wargroove,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Intro ideo did not play, but was skippable and game runs.",Pocket 5
+"Warhammer 40,000: Boltgun",Great,Turnip 24.3.0 9v2,Citron,1.0.0.7,"30 fps. Completed two levels. Settings: 1x, handheld, Disk shader Cache: On, force maximum clocks: On, Asynchronous Shader: On",Pocket 5
+Wavetale,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2.0,Update is required. Game is ery buggy without it.,Pocket 5
+We Love Katamari Reroll+ Royal Reverie,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Gameplay locked 30fps. Dipped only on loading screen.,Pocket 5
+What Lies In The Multiverse,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Plays perfectly, fun game!",Pocket 5
+What Remains Of Edith Finch,Playable,Turnip 24.3.0 9v2,Citron,1.0.1,game 1.0.0 (doesn’t work on Yuzu with the same settings) Docked Resolution 0.75 Accuracy High Vsync mode Immediate (off) Force maximum clocks Use asynchronous shaders,Pocket 5
+What The Golf,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Worked great right out of the box with firmware 19.0.1,Pocket 5
+Wild Bastards,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Wild Bastards,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Windjammers 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,,Pocket 5
+Wolffang Skullfang,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Crashes,Pocket 5
+World Of Goo,Perfect,Turnip 24.3.0 9v2,Yuzu,0.0.2,Only boots in handheld mode but runs at perfect 60,Pocket 5
+World Of Horror,Perfect,Qualcomm 0.746.0,Sudachi,1.0.3,,Pocket 5
+Worms Armageddon: Anniversary Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.1,"Docked mode locked 60fps, default settings",Pocket 5
+Wytchwood,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,"1x Docked – around 40-45 fps, 0.75x docked – almost solid 60, but there are some slight graphical glitches. Force max clocks and asynchronous shader set to on, rest of the settings are at default. High Performance RP5 setting. /Turnip 9v2 doesn’t improve performance or glitches, Turnip 25.0.0 rev2 crashes the game.",Pocket 5
+XCOM 2,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,"With or without the update, on yuzu, sudachi and citron, the game freezes when choosing either the game without DLCs or the game with dlcs.",Pocket 5
+Xenoblade Chronicles 2,Great,Turnip 23.3.0-devel,Sudachi,Version 1.4 and All DLC,"Courtesy of @Kewa from Discord: handheld mode, Resolution 1x accuracy high, FIFO(On) AMD FidelityFX 70-100% FXAA on Anisotropic Filtering default disk shader on, max clocks off async on reactive flushing off VULKAN NCE Debugging on and fastmem on",Pocket 5
+Xenoblade Chronicles X: Definitive Edition,Great,Turnip 24.3.0 9v2,Citron,1.0,Handheld mode 1x Resolution High performance Citron 0.6.1 Force Max Clocks On Async Shaders On,Pocket 5
+Xenoblade Chronicles X: Definitive Edition,Great,Turnip 24.3.0 9v2,Citron,1.0,Some slight frame drops but only rarely.,Pocket 5
+XIII,Great,Turnip 24.1.0 R18,Suyu,1.0,"105 % speedlimit, precision level high, high performance",Pocket 5
+Yakuza Kiwami,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Sudachi 1.0.11 (99775b8) Force max frequencies : Yes,Pocket 5
+Yakuza Kiwami,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld,Pocket 5
+Yo-Kai Watch 1 For Nintendo Switch,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Also installed fan made German language patch,Pocket 5
+Yokai Watch 1,Great,Qualcomm 0.746.0,Yuzu,1.3,"Globally, the game is running at 30 fps stable, some frame drops during the cinematics like when Nate is tracked by the Oni",Pocket 5
+Yokai Watch 4,Poor,Qualcomm 0.746.0,Eden,1.0,FPS average: between 2 and 7 fps with 0.75% res,Pocket 5
+Yoku’s Island Express,Great,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Yooka-Laylee And The Impossible Lair,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,Perfect 60fps docked,Pocket 5
+Yoshi’s Crafted World,Perfect,Turnip 24.3.0 9v2,Citron,8128d9b,Any Yuzu clones should work. Just need Graphics->Accuracy level->Extreme. It will get a bit hotter. Set the fan to Smart.,Pocket 5
+You Suck At Parking,Great,Qualcomm 0.746.0,Yuzu,v1.10.7,Yuzu 278 (dc529a89a),Pocket 5
+Youtubers Life,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Ys IX: Monstrum Nox,Great,Qualcomm 0.746.0,Sudachi,1.0.3,"Using Qualcomm driver made the performance great for this game. Running around in the city causes some stutter, but seems fine other than that.",Pocket 5
+Ys IX: Monstrum Nox,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"I’m tagging it as great and I don’t really notice any significant frame drops after over 3 hours of gameplay, but I need to play it a bit longer to tag it as perfect. However, I do believe we can tweak the emulator to get maximum performance out of it. Android Preset: Standard (), Performance() ,High Performance(x) System: Docked Mode – Off Graphics: 1x (720p/1080p) Vsync – On Disk Shader Cache – On Force Maximum Clocks – On Audio: Output Engine – Auto Debug: API: ulkan CPU: NCE CPU Accuracy: Auto",Pocket 5
+Ys Memoire: The Oath In Felghana,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 60fps docked, use audio engine cubeb to prevent audio glitching",Pocket 5
+Ys Memoire: The Oath In Felghana,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Played through the first dungeon,Pocket 5
+Ys Origin,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Runs flawlessly. Android Preset: Standard (), Performance(x) ,High Performance() System: Docked Mode – Off Graphics: 1x (720p/1080p) Vsync – On Disk Shader Cache – On Audio: Output Engine – Auto Debug: API: ulkan CPU: NCE CPU Accuracy: Auto",Pocket 5
+Ys Viii,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Runs very smoothly without issues thus far.,Pocket 5
+Planet Of Lana,Playable,Turnip 9v2,Sudachi,1.2.0.0,Plays really well but there is an black screen error in about 20 mins into the game. There is no mod yet to fix this as of 30/7/2025,Pocket 5
+Xenoblade Chronicles Definitive Edition,Poor,Turnip 25.2.0,Eden,0.0.3-rc1,"Runs at a decent framerate, but there are constant and severe graphical glitches",Pocket 5
+Castle Crashers,Poor,Turnip 24.3.0 9v2,Sudachi,Latest,"Sound works, but no picture.",Pocket 5
+The Legend Of Heroes: Trails From Zero,Poor,Turnip 25.2.0 R4,Eden,1.4,Runs and starts great but then Constant 0 fps crashes with audio still playing. Ive tried most of the recent drivers,Pocket 5
+Front Mission 3,Great,Qualcomm 0.746.0,Sudachi,1.0.1,,Pocket 5
+9th Dawn Remake,Perfect,Qualcomm 0.777,Sudachi,1.175,,Pocket 5
+A Short Hike,Perfect,Qualcomm 0.777,Sudachi,1.9.21,Completed Game. No issues,Pocket 5
+Ace Attorney Investigations Collection,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.0.1,,Pocket 5
+Advance Wars 1+2 Re-boot Camp,Perfect,Qualcomm 0.777,Sudachi,1.0.0,,Pocket 5
+Animal Crossing New Horizons,Perfect,24.3.0 9v2,Yuzu,2.0.8,,Pocket 5
+Animal Well,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.5,,Pocket 5
+Annalynn,Perfect,Turnip 24.3.0 9v2,Sudachi,1.6.1,,Pocket 5
+Another Code Recollection,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.0,,Pocket 5
+Ao Tennis 2,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.0,Runs at 20-30 FPS,Pocket 5
+Astral Ascent,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.14,,Pocket 5
+Astral Chain,Perfect,Turnip 25.3.0-R1,Sudachi,1.0.1,,Pocket 5
+Axiom Verge,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,If you install update it is not recognised in Sudachi,Pocket 5
+20 Minutes Till Dawn,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.1,,Pocket 5
+30xx,Perfect,Qualcomm 0.777,Sudachi,1.1.03,Screen is inverted (upside down) and crashes after a few minutes,Pocket 5
+Anomaly Agent,Perfect,Qualcomm 0.777,Sudachi,1.0.0.15,,Pocket 5
+Armored Lab Force Vulvehicles,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Ato,Perfect,Qualcomm 0.777,Sudachi,1.0.0,,Pocket 5
+"Warhammer 40,000: Boltgun",Perfect,Mesa Turnip 24.3.0 R9 v2,Eden,1.0.0.7,Need to use Prod Key v18.0.0 and use exact update and turnip driver listed or it will NOT work. This also runs perfect on Sudachi. Expect minor initial stutters as the emulator savesshader cache. Runs 30fps stable.,Pocket 5
+Balatro,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Just buy the game on Android and support the developer!,Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Great,Turnip 24.3.4-Unified (@Mr_Purple_666),Eden,1.0,,Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Great,Turnip 24.3.0 9v2,Eden,1.0,,Pocket 5
+Ender Magnolia Bloom In The Mist,Playable,Turnip 24.3.0 9v2,Citron,0.6,"v1.0 & v1.0.1 handheld mode, high accuracy game will stutter during combat and drop frames",Pocket 5
+Pinball Fx,Poor,Turnip 24.3.0 9v2,Citron,1.0,Games launches into menu and as soon as you press a button to advance it crashes. Tested multiple drivers and settings,Pocket 5
+Cookie Clicker,Perfect,Qualcomm 0.746.0,Eden,1.0.3,"Its Cookie Clicker, of course it runs well. Locked 60.",Pocket 5
+The Legend Of Zelda: Echoes Of Wisdom,Poor,Turnip 24.3.0 9v2,Yuzu,1.4.0.0,Freezes in the middle of loading the game,Pocket 5
+Raidou Remastered The Mystery Of The Soulless Army,Poor,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.0,"The game runs fine, but for some reason crashes as soon as you try to WALK?? Really weird. Tried a few more drivers and had no luck whatsoever",Pocket 5
+Outlast,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Prod Key 20.0.0 with last release of Yuzu. Played for 30 minutes and it kept a pretty stable 30 FPS at 1x resolution. No issues I could see during that time at all.,Pocket 5
+Ufo 50,Perfect,Turnip 23.3.0-devel,Eden,1.0,"Wouldn’t work on YUZU but works on Eden right out of the box, seemingly perfectly",Pocket 5
+Ufo 50,Poor,Qualcomm 0.746.0,Yuzu,1.0,"Wouldn’t work on YUZU no matter what I do. Back screen 0 FPS. I tried every driver I could, but no dice. Works perfectly in Eden though",Pocket 5
+Saints Row Iv,Poor,Turnip 24.3.0 9v2,Eden,1.0,doesnt even load,Pocket 5
+Warriors Abyss,Poor,Turnip 24.3.0 9v2,Eden,1.0,does load menu but lag at loading in game,Pocket 5
+Naruto Ultimate Ninja Storm 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Working perfectly pretty much out of the box, 30fps solid at 1x",Pocket 5
+Minecraft: Nintendo Switch Edition (legacy Console),Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.16,"There are 3 different configurations I found that have advantages and disadvantages. 1. Handheld mode, 1x resolution This is the most stable setting, but is only 720p and has a 7-chunk render distance. Perfect 60fps, extremely rarely freezes (but there is auto-save every minute or so, so don’t worry). 2. Docked mode, 0.75x resolution. Less stable, but gives a 810p resolution (not a typo, it is actually 810p) and has a 10-chunk render distance. Gameplay is almost always at 60fps, with rare dips to 55 or so. Freezes are infrequent, but not impossible. 3. Docked mode, 1x resolution. The least stable, but most impressive graphics. 1080p and 10-chunk render distance. Performance is also almost always at 60fps, but freezes are pretty common, maybe every 10-15 minutes or so. Also, make sure you use Turnip Driver 9v2 AND cubeb audio. Audio is totally messed up without cubeb.",Pocket 5
+Factorio,Poor,Turnip 24.3.0 9v2,Eden,1.0,Crash before loading in game,Pocket 5
+Pokken Tournament Dx,Great,Turnip 24.2.0 R4-fix,Citron,1.0,"1x res, cache shader on, async shader on. OPTION max clock 50-60fps",Pocket 5
+Hatsune Miku: Project Diva Mega Mix,Perfect,Qualcomm 0.746.0,Eden,1.0.6,"The game runs perfect without any extra setting, tested on latest eden build up to this date, used 19.0.1 firmware",Pocket 5
+Dragon Ball Xenoverse 2,Great,Turnip 24.3.0 9v2,Eden,v0.0.3,"Runs pretty well with the tweaks I made. Nearly stable 30fps in battle, which is really all that matters. Sometimes dips into low 20s when loading and in open world. I The game has to take a pretty big hit graphically and with resolution to make it work, but it still doesn’t look horrible. RP5 needs to be in High Performance Mode. .75 Resolution Handheld mode Played about an hour with no game breaking moments.",Pocket 5
+Dragon Ball Z: Kakarot,Poor,Turnip 24.3.0 9v2,Sudachi,Sudachi 1.0.15,"Game was running okay during opening fight and when you are flashing with Gohan, but then when you get home bright lights on screen make it unplayable. Could maybe work with some tweaking, but didn’t want to try. Used default settings.",Pocket 5
+Dragon Ball Z: Kakarot,Poor,Turnip 24.3.0 9v2,Eden,Eden v.0.0.3-rc2,"Game was running okay during opening fight and when you are flashing with Gohan, but then when you get home bright lights on screen make it unplayable. Could maybe work with some tweaking, but didn’t want to try. Used default settings.",Pocket 5
+Enclave Hd,Perfect,Qualcomm 0.746.0,Citron,1.0,Works Perfect in docked mode with default settings! No crashes or bugs so far.,Pocket 5
+Outward – Definitive Edition,Perfect,turnip_mrpurple T19,Eden,.0.03,Runs perfectly @ 30fps no dips so far,Pocket 5
+Sifu,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"Handheld mode .75x, asynchronous shaders & force maximum clocks on gets 25-30fps in combat but ~20 going from area to area. Playable but compromised.",Pocket 5
+Red Dead Redemption,Poor,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.0.4,Drops to 15 fps in populated areas on 0.5x,Pocket 5
+Red Dead Redemption,Playable,Turnip 24.3.4-Unified (@Mr_Purple_666),Eden,1.0,"30 fps locked at 0.5x, probably would drop in a more populated area than the first town. I tried the same configuration on Sudachi and was just 15 fps on the same town, another point for Eden emulator I guess!",Pocket 5
+Mega Man 11,Perfect,Turnip 24.3.0 9v2,Sudachi,1.01,,Pocket 5
+Dragon Ball Fighterz,Poor,Turnip 25.1.0,Eden,1.0,Game crashes even with crash fix mod and 540p resolution,Pocket 5
+Dragon Ball Fighterz,Perfect,Turnip 25.3.0-R4,Eden,1.33,Settings: 1) Crash fix enabled for 540p: https://www.mediafire.com/file/llur8mo8d2zln93/DBFZ_540p_crash_fix.zip/file ***THIS ONLY WORKS ON VERSION 1.33 2. Handheld mode .75 resolution 3. Disk shader cache/Async shaders on 4. FXAA/4x AA 5. ScaleForce on,Pocket 5
+Red Dead Redemption,Playable,Turnip 25.2.0-deveal-unified (@Mr_Purple_666),Eden,1.0,"Forced maximun clocks and used asynchronous shaders. 30 fps at native resolution with a few drops once in a while, runs almost as in original hardware, but that isn’t much saying",Pocket 5
+8-bit Adventures 2,Great,Qualcomm 805,Sudachi,1.0,,Pocket 5
+,Perfect Great Playable Poor,,Yuzu Sudachi Citron Eden Kenji-nx,,,Pocket 5
+.Hack//G.U. Last Recode,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30 docked,Pocket 5
+#DRIVE,Perfect,Turnip 24.3.0 9v2,Eden,1.0,,2025/07/23,Pocket 5
+8-Bit Adventures 2,Poor,Turnip 24.3.0 9v2,Citron,1.0,Can’t get this game to launch :/ rolls immediately in to black screen,Pocket 5
+12 Is Better Than 6,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Plays perfect docked mode looks amazing on oled.,Pocket 5
+13 Sentinels: Aegis Rim,Perfect,Turnip 24.3.0 9v2,Citron,1.1,Handheld 1x Lock to 30 fps (50% Limit speed percent) for a smoother experience.,Pocket 5
+13 Sentinels: Aegis Rim,Great,Turnip 24.1.0 R18,Citron,1.0,"Docked, 1x resolution, some dips in FPS but no crashes.",Pocket 5
+13 Sentinels: Aegis Rim,Great,Turnip 24.3.0 9v2,Sudachi,1.1,"Played mostly on 1x resolution. Mostly 60 fps, would drop to 40-30 fps in battles. Dropped to 20 in the final battle. Some crashes when there would be a lot of stuff in the background. Had to drop 0.75x resolution when deleting shader cache wouldn’t work. Settings: Accuracy Level: High (to get mostly 60 fps out of battle), Window Adapting Filter: AMD Fidelity FX Super Resolution (if 0.75x res), Audio: cubeb (if audio stutters)",Pocket 5
+13 Sentinels: Aegis Rim,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,"Excellent. Sometimes the audio stutters the slightest bit, but goes away on restart.",Pocket 5
+13 Sentinels: Aegis Rim,Perfect,Qualcomm 0.746.0,Yuzu,1.1,"Works perfect with update, docked mode 30fps solid",Pocket 5
+13 Sentinels: Aegis Rim,Great,Turnip 24.3.0 9v2,Citron,1.0,I would say this works pretty great and is ery much playable. On Suyu I had a crash but Citron seems to be working.,Pocket 5
+20 Minutes Till Dawn,Perfect,Qualcomm 0.746.0,Yuzu,v1.1.1,Yuzu 278 (dc529a89a) Default for all parameters,Pocket 5
+30xx,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,perfect,Pocket 5
+60 Seconds Reatomized,Great,Qualcomm 0.746.0,Yuzu,1.0.2,weird game but runs 50-55fps in docked mode,Pocket 5
+80’s Overdrive,Great,Qualcomm 0.746.0,Yuzu,1.1.0,Smooth 60 but minor audio stutters,Pocket 5
+198x,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+3000th Duel,Great,Turnip 24.3.0 9v2,Citron,"Update 1.1.2, DLC 1","Only had a few bugs where the game turned black when going into the next room, and also some random crashes. Noticed bugs only happened when resuming game from sleep.",Pocket 5
+A Boy And His Blob,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps,Pocket 5
+A Hat In Time,Great,Qualcomm 0.746.0,Yuzu,"1.0.4 + DLC 1, 2",Almost perfect in handheld mode but a few framerate dips,Pocket 5
+A Highland Song,Perfect,Qualcomm 0.746.0,Sudachi,1.2.3b,Stable between 30 and 60 FPS,Pocket 5
+A Juggler’s Tale,Poor,Turnip 25.2.0 R4,Yuzu,1.0,"Tested docked and handheld, in sudachi and yuzu, with qualcomm and Turnips this game will not get into the game on any",Pocket 5
+A Little To The Left,Perfect,Qualcomm 0.746.0,Yuzu,1.0,plays perfectly,Pocket 5
+A Memoir Blue,Poor,Qualcomm 0.746.0,Yuzu,1.0,Tried Sudachi and Yuzu with qualcomm and Turnip but cannot get past a couple mins in game without a crash,Pocket 5
+A Short Hike,Perfect,Turnip 24.3.0 9v2,Yuzu,1.9.21.1,"60 fps, Plays great!",Pocket 5
+A Sketchbook About Her Sun,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Abomi Nation,Great,Qualcomm 0.746.0,Yuzu,1.0,27fps works almost perfect in docked mode,Pocket 5
+Abzu,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Plays ery well,Pocket 5
+Ace Attorney Investigations Collection,Perfect,Qualcomm 0.746.0,Yuzu,1.0,100% speed,Pocket 5
+Ace Attorney Investigations Collection,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.0.1,play perfect,Pocket 5
+Ace Combat 7: Skies Unknown,Poor,Turnip 25.0.0 R8,Sudachi,1.0,Load well and you can play 60 fps but the colors are all glitched like in a psychedelic dream…,Pocket 5
+Advance Wars 1+2: Re-boot Camp,Perfect,Qualcomm 819.1,Yuzu,1.0,,Pocket 5
+Advance Wars 1+2: Re-Boot Camp,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Seems to run just like it does on secret console,Pocket 5
+Aeon Drive,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked mode,Pocket 5
+Aery Early Birds Bundle,Poor,Qualcomm 0.746.0,Yuzu,1.0,Yuzu and Sudachi with Turnip 25 and Qualcom all crash,Pocket 5
+Aew Fight Forever,Great,Turnip 24.3.0 9v2,Yuzu,Latest,Plays surprisingly great with latest update and DLC. Occasionally freezes for about a second during a match but nothing crazy,Pocket 5
+Afterimage,Great,Turnip 24.3.0 9v2,Sudachi,1.2.0,same settings works on Yuzu and Suyu,Pocket 5
+Agatha Christie – Murder On The Orient Express,Great,Qualcomm 819.1,Citron,1.1.11,"Freezes constantly and graphical glitches with System & Turnips. Runs @ 40-60fps with Qualcomm 819.1 driver, Accuracy Level : High, Resolution 1x, -Sync: Off, Disk Shader Cache: On, Force Maximum Clocks: On, Asynchronous Shaders: On",Pocket 5
+Ak-Xolotl,Perfect,Turnip 24.3.0 9v2,Citron,2.0.1,,Pocket 5
+Akane,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Alan Wake Remastered,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,After the Menü Crashes in Game. Also no luck on Citron,Pocket 5
+Alba,Playable,Qualcomm 0.746.0,Sudachi,1.0,"Works in handheld mode, Weird issue where sometimes it freezes and you have to swipe up from the bottom as if you are going to close the app to make it un freeze",Pocket 5
+Alex Kidd In Miracle World Dx,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Alien Hominid HD,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Flawless in docked mode, looks amazing on OLED",Pocket 5
+Alien: Isolation,Poor,Qualcomm 0.746.0,Yuzu,1.0/1.1.5,Did not work on Yuzu or Sudachi with either driver,Pocket 5
+Alphadia Genesis 2,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Alwa’s Awakening,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.5.3.21,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Angry Video Game Nerd I & II Deluxe,Perfect,Qualcomm 0.746.0,Yuzu,1.3.1,Perfect 60fps in docked mode,Pocket 5
+Animal Crossing: New Horizons,Perfect,Turnip 24.3.0 9v2,Citron,2.0.6 + DLC,Citron is back in development! Settings: Docked 1x Res. 30FPS Locked Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Animal Crossing: New Horizons,Perfect,Turnip 24.3.0 9v2,Citron,2.0.6 + DLC,Citron is back in development! Settings: Docked 1x Res. 30FPS Locked Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Animal Crossing: New Horizons,Perfect,Qualcomm 0.746.0,Yuzu,2.0.6,,Pocket 5
+Animal Crossing: New Horizons,Perfect,Turnip 24.3.0 9v2,Yuzu,2.0.6 + all DLC,Runs locked 30fps even in Docked mode.,Pocket 5
+Animal Well,Perfect,Turnip 24.3.0 9v2,Citron,"1.0,7",Citron is back in development! 60 FPS Settings: Docked 1x Res. Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Animal Well,Perfect,Turnip 24.3.0 9v2,Sudachi,1.02,Standard docked. Accuracy normal,Pocket 5
+Animal Well,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,Standard mode / Docked,Pocket 5
+Animus: Revenant,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.5,Yuzu 278 (dc529a89a) Video precision : High,Pocket 5
+Anno: Mutationem,Great,Turnip 24.3.0 9v2,Sudachi,1.05.08,"Worked great with Turnip driver and Accuracy level set to high. Opening cutscene is glitched, but after that, it runs at a stable 60fps.",Pocket 5
+Anno: Mutationem,Poor,Turnip 24.3.0 9v2,Citron,1.05.08,"Menu loads, but crashes when starting the story",Pocket 5
+Anodyne 2 : Return To Dust,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Anomaly Agent,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Anomaly Collapse,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Worked perfectly with Qualcomm 0.746.0 but not with any Turnip drivers. Shut down after hitting “start game”,Pocket 5
+Another Code: Recollection,Poor,Qualcomm 0.746.0,Citron,1.0,Crashes anytime you try to use Camera,Pocket 5
+Another Code: Recollection,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Runs at a smooth 30 in Docked mode without a hitch. Has the occasional weird graphical artifact, but they’re rather minor.",Pocket 5
+Another Crab’s Treasure,Playable,Turnip 24.1.0 R18,Citron,1.0.101.1,"*Crashes after main menu no matter what setting/driver I use at 1x, so you absolutely have to drop to .75x resolution (Both Docked or Undocked work). I had Disk Shader Cache, Force maximum clocks, and Use asynchronous shaders ticked on, as well as 16x Anisotopic filtering, AMD FidelityFX for Window adapting filter, and 100% FSR Sharpness. Everything else is default.",Pocket 5
+Ape Out,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Apico,Perfect,Turnip 24.3.4-Unified (@Mr_Purple_666),Citron,1.3.2d,"Perfect 60 FPS like on Secret Console/PC Docked Mode ON, Accuracy Level HIGH, Disk Shader Cache ON, Asynchronous Shaders ON RP5 on Standard mode",Pocket 5
+Apollo Justice: Ace Attorney Trilogy,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.1,Sudachi didn’t work,Pocket 5
+Aragami: Shadow Edition,Great,Qualcomm 0.746.0,Yuzu,1.0.1,Runs great handheld mode 30-60fps,Pocket 5
+Arcade Paradise,Perfect,Qualcomm 0.746.0,Yuzu,1.11,Perfect 60fps in handheld mode,Pocket 5
+Arcade Tanks World: Tank Battle Simulator,Great,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Archvale,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps in docked mode,Pocket 5
+Arietta Of Spirits,Perfect,Qualcomm 0.746.0,Yuzu,1.2.8.0,Perfect 60fps in docked mode,Pocket 5
+Arms,Great,Turnip 24.3.0 9v2,Citron,5.4.1,"Occasionally stuttering, FPS ranges 40-60 Docked. Some minor graphical issues (Disappears after loading)",Pocket 5
+Army Of Ruin,Great,Qualcomm 805,Sudachi,1.0,"Played in docked mode, with no OC results in some stuttering in later levels due to the amount of monsters. usually 30FPS below level 12/13 dips to ~24 for a few moments at the start of each level. Played with the OC boot.img results in perfect 30FPS in later levels in docked mode. Trying to play a 2x resolution in handheld results in crashing when picking up boss boxes.",Pocket 5
+Arrog,Great,Qualcomm 0.746.0,Yuzu,1.0.2,Don’t understand this game but it is smooth and runs well,Pocket 5
+Art Of Rally,Perfect,Turnip 24.3.0 9v2,Citron,1.1.8 + DLC,"Perfect, locked 30 FPS. Docked Mode ON, Accuracy Level HIGH, Disk Shader Cache ON, Asynchronous Shaders ON RP5 in Performance mode (not High Performance). Very occasional micro-stutters, only brief and temporarily.",Pocket 5
+Asdivine Hearts,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 30fps in docked mode,Pocket 5
+Aspire: Ina’s Tale,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked and looks amazing on OLED,Pocket 5
+Assassin’s Creed 2,Poor,Qualcomm 0.746.0,Yuzu,1.0,Has severe graphical glitching not playable on Sudachi or Yuzu,Pocket 5
+Assassin’s Creed 4,Playable,Turnip 24.3.0 9v2,Citron,1.0,"graphics accuracy on high docked mode off, fsr enabled.",Pocket 5
+Assassin’s Creed 4,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Actually runs at decent framerate in handheld mode but lots of isual glitches,Pocket 5
+Assassin’s Creed: The Ezio Collection,Playable,Turnip 24.3.0 9v2,Suyu,1.3,"Technically possible to get into the game and get 20-30fps fairly consistently. Frames hit 0 a lot and you need to swipe up the app into the recent apps screen and back down to make the frames start up again, but otherwise it’s 20-30fps. You will have to do this A LOT. Also isually it’s ERY glitchy. But I did manage to make it into AC2 up to the point where you meet the girl at night after jumping into the hay, didn’t crash. Can’t boot DLC.",Pocket 5
+Assassin’s Creed: The Rebel Collection,Great,Turnip 24.3.0 9v2,Citron,1.0,"working with constant 25-30FPS, resolution 1x, accuracy level to High, DS on, FMC ON, UAS ON",Pocket 5
+Assassin’s Creed: The Rebel Collection,Playable,Turnip 24.3.0 9v2,Suyu,1.0,".75x resolution, disk shader cache = true, force maximum clocks = true. Pretty finicky, seems to only crash sometimes when trying to boot, won’t boot at all if the settings aren’t right. Hits 20-30fps fairly consistantly, but does hit 0 FPS and hang there pretty often. Swipe the app up into recent apps and back down to jumpstart FPS again. Managed to boot into both games. Got onto land and killed the assassin after some parkour in black flag and ran around and did some parkour/cut scenes in rogue. Rogue seems to be less buggy, but both are isually ery buggy.",Pocket 5
+Astalon: Tears Of The Earth,Perfect,Qualcomm 0.746.0,Yuzu,1.0.12.1,Perfect 60fps in docked mode,Pocket 5
+Astalon: Tears Of The Earth,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Astebreed,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Black screen on Yuzu and Sudachi with either driver,Pocket 5
+Asterix & Obelix Xxl3: The Crystal Menhir,Perfect,Turnip 24.3.0 9v2,Eden,1.0,27-30 fps Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Asterix & Obelix Xxxl: The Ram From Hibernia,Perfect,Turnip 24.3.0 9v2,Eden,1.0,30 fps (The main menu runs at 18 fps) Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Astlibra Revision,Perfect,Turnip 24.3.0 9v2,Citron,1.0.5,Runs at full speed 60fps in docked mode,Pocket 5
+Astral Ascent,Poor,Qualcomm 0.746.0,Citron,1.0.13,Playable with graphical glitches for 30 minutes then crashes. Sudachi plays perfectly but crashes when accessing the merchant’s menu.,Pocket 5
+Astral Chain,Great,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Astral Chain,Great,Qualcomm 744.12,Citron,1.0,v744.12 gives me the best performance. less dips. Handheld. Async & max clocks on,Pocket 5
+Astral Chain,Great,Qualcomm 0.746.0,Yuzu,1.0,"Dips to 20fps in docked mode, but handheld mode is mostly 30 with an occasional dip to 25 but great experience.",Pocket 5
+Astral Chain,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"FPS can fluctuate (12-25 FPS) but is mostly playable, based on playing the intro.",Pocket 5
+Astral Flux,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Astral Flux,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Astroneer,Poor,Qualcomm 0.746.0,Yuzu,1.0,No boot in Yuzu or Sudachi with either driver,Pocket 5
+Atelier Ayesha: The Alchemist of Dusk DX,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Full speed at 30fps in handheld mode. Not a single frame drop.,Pocket 5
+Atelier Marie Remake: The Alchemist of Salburg,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Can get into town and run around. Frames gravitate around 20fps. bit sluggish but I would consider it playable.,Pocket 5
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"Frames at 22-25 , mostly 23 , playable at this state",Pocket 5
+Atelier Ryza 3: Alchemist Of The End & The Secret Key,Great,Turnip 24.3.0 9v2,Sudachi,1.0,0.75x resolution Disk shader cache ON Async Shaders ON Runs at constant 30fps,Pocket 5
+Atelier Ryza: Ever Darkness & The Secret Hideout,Great,Turnip 24.3.0 9v2,Eden,1.0.8,Minor Graphic Visual Glitch 0.75x resolution Disk shader cache ON Async Shaders ON,Pocket 5
+Atelier Shallie: Alchemists of the Dusk Sea DX,Great,Turnip 24.3.0 9v2,Suyu,1.0,From what I can tell it’s running almost perfect but does have some slight drops. Nothing that is super noticeable. I did have one moment where I was stuck on a loading loop but a reboot seemed to fix it.,Pocket 5
+Atone: Heart Of The Elder Tree,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps in docked mode,Pocket 5
+Avicci Invector,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Seems like its gonna work during calibration but then goes to 0fps black screen in Yuzu and Sudachi,Pocket 5
+Azura’s Crystals,Poor,Turnip 24.3.0 9v2,Citron,1.0,Game starts but crashes after the girl goes out of the house in all emulators,Pocket 5
+Azure Striker Gunvolt: Striker Pack,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Full 60 FPS Docked Mode looks gorgeous,Pocket 5
+Baba Is You,Perfect,Qualcomm 0.746.0,Eden,1.0,,Pocket 5
+Badland: Game Of The Year Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps in docked mode, looks great on OLED",Pocket 5
+Bakeru,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Video precision : High,Pocket 5
+Balatro,Perfect,Turnip 23.2.0,Sudachi,1.0,,Pocket 5
+Balatro,Perfect,Turnip 24.3.0 R5,Sudachi,Update 1.0.9,Other drivers should run fine but you will lose the background graphics in game,Pocket 5
+Balatro,Perfect,Turnip 24.3.0 9v2,Citron,1.1.0,Citron is back in development! *IT SOMETIMES GETS STUCK ON LOADING JUST EXIT AND LAUNCH THE GAME UNTIL IT STARTS* 60 FPS Settings: Docked 1x Res. Turn on Force Maximum Clocks and Asynchronous Shaders If audio is stuttering/crackling change output to cubeb Everything else default.,Pocket 5
+Baldo The Guardian Owls,Perfect,Qualcomm 0.746.0,Yuzu,1.0.15,Perfect 60fps docked,Pocket 5
+Baldur’s Gate And Baldur’s Gate II: Enhanced Editions,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,Runs wonderfully,Pocket 5
+Barbie Dreamhouse Adventures,Perfect,Turnip 24.3.0 9v2,Citron,2023.07.11,"Force Maximum clock, Use async shaders",Pocket 5
+Bastion,Perfect,Qualcomm 0.746.0,Citron,1.0,Standard setup file works perfect for me. Docked is the only additional change.,Pocket 5
+Bastion,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Bat Boy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a),Pocket 5
+Batman Arkham Asylum,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,It’s running really great @30fps on 1x resolution. But at some points or after a couple of minutes in the game it’ll freeze and the only way to progress is to delete the compiled shaders. So it’s kinda annoying that you have to close the emulator and delete the shaders for every 3-5 minutes.,Pocket 5
+Batman Arkham Asylum,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"30FPS @ Handheld, 0.75x Resolution",Pocket 5
+Batman Arkham Asylum,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.1,25-30 FPS Docked Mode Resolution x0.75,Pocket 5
+Batman Arkham City,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"very playable, some slowdown in combat, much fan noise",Pocket 5
+Batman Arkham City,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,30 Fps Handeld Mode Resolution x1,Pocket 5
+Batman: The Telltale Series,Playable,Qualcomm 0.746.0,Citron,1.0,Slight graphic artifacts and frame drops that have a chance to get you killed in the quick time events.,Pocket 5
+Battle Brothers,Perfect,Qualcomm 0.746.0,Sudachi,1.13.0,,Pocket 5
+Battle Chasers: Nightwar,Great,Turnip 24.3.0 9v2,Sudachi,1.0.2,"Some minor graphical glitches when entering combat, nothing gamebreaking",Pocket 5
+Battle Kid: Fortress Of Peril,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Bayonetta,Great,Turnip 24.3.0 9v2,Citron,1.1,Works really well. Handheld x1. Could change fps to cap at 45 to improve eperience via “Limit speed percent” to 70-75%. I run at 100% and do experience frame drops. The most intensive part of the game is the opening part where you will see drops to nearly 30 fps but the rest of the game is 55-45 fps.,Pocket 5
+Bayonetta,Great,Turnip 24.3.0 9v2,Sudachi,v1.1,minor fps drops when facing multiple enemies,Pocket 5
+Bayonetta 2,Great,Turnip 24.3.0 9v2,Sudachi,1.2,Lag during some cutscenes but plays great,Pocket 5
+Bayonetta 3,Poor,Turnip 24.3.0 9v2,Sudachi,1.2.0,Crashes when booting up game. Also crashes when changing drivers to Turnip 25.0.0 R4 or Qualcomm 777,Pocket 5
+Bayonetta Origins: Cereza And The Lost Demon,Great,Qualcomm 0.746.0,Yuzu,1.0,"Stable 30fps docked mode, some minor isual glitches occasionally but a great experience",Pocket 5
+Beasts Of Maravilla Island,Poor,Qualcomm 0.746.0,Yuzu,1.0.3,"It boots but every 20 seconds or so it completely freezes for several seconds I would consider unplayable, might be playable after shaders compile.",Pocket 5
+Beat Cop,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,60 fps Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Belle Boomerang,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Beyblade X Xone,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.6,crash after character selection,Pocket 5
+Beyblade X Xone,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.6,Crash after character selection,Pocket 5
+Beyond A Steel Sky,Perfect,Turnip 25.0.0 R5,Sudachi,1.0,"Handheld mode, perfect 30fps for first 25 min of game",Pocket 5
+Beyond Good And Evil – 20th Anniversary Edition,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"25fps docked mode some slowdown, better off playing on Gamecube",Pocket 5
+Big Helmet Heroes,Great,Turnip 24.3.0 9v2,Citron,1.0,Sometimes a crash may occur when the game loads a new location,Pocket 5
+"Big Kitty, Little City",Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Biomutant,Poor,Qualcomm 0.746.0,Yuzu,1.0,No launch in Sudachi or Yuzu with either driver,Pocket 5
+Bioshock Remastered,Poor,Qualcomm 0.746.0,Yuzu,1.0,"Tried Sudachi and Yuzu with both drivers with and without update, everything is 10fps with major isual glitching.",Pocket 5
+Bite The Bullet,Perfect,Qualcomm 0.746.0,Yuzu,1.2.1,Perfect 60fps in docked mode,Pocket 5
+Black Skylands,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 30fps, weird game",Pocket 5
+Black Witchcraft,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Plays Perfectly no audio glitches or lag,Pocket 5
+Black Witchcraft,Great,Turnip 24.3.0 9v2,Yuzu,1.0,mine wont play audio? gameplay is smooth though,Pocket 5
+Blade Assault,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 30fps docked mode,Pocket 5
+Blade Chimera,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.35,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Blade Chimera,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Slow loading at first or in between scenes sometimes but works perfect,Pocket 5
+Blade Runner Enhanced Edition,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Bladed Fury,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Plays great completed 2 levels: Some frame drops here and there but honestly faced this on switch as well,Pocket 5
+Blair Witch,Poor,Qualcomm 0.746.0,Yuzu,1.0,No luck in Yuzu or Sudachi with either driver,Pocket 5
+Blanc,Poor,Qualcomm 0.746.0,Yuzu,1.0,tried multiple settings but never got a stable frame rate and it has constant glitching in all drivers,Pocket 5
+Blasphemous,Perfect,Qualcomm 0.746.0,Citron,1.0.8 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On,Pocket 5
+Blasphemous,Perfect,Qualcomm 0.746.0,Yuzu,1.0.8,"1dlc installed, perfect 60fps docked",Pocket 5
+Blasphemous 2,Perfect,Turnip 24.3.0 9v2,Citron,1.0.3,Citron is back in development! Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Blasphemous 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Play amazingggg,Pocket 5
+Blast Brigade vs. The Evil Legion Of Dr. Cread,Great,Qualcomm 0.746.0,Citron,1.0.4,"Experienced framerate drops using any Turnip, but it seems to work perfectly with the system driver.",Pocket 5
+Blazing Strike,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,amazing game like tekken runs perfect,Pocket 5
+Bloodstained – Curse Of The Moon,Perfect,Qualcomm 0.746.0,Citron,ver 1.1,,Pocket 5
+Bloodstained: Ritual Of The Night,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"If you Update the Game, it becomes unplayable with many graphical glitches. er.1.0 runs almost at 60fps in Handheld with no glitches.",Pocket 5
+Bloomtown: A Different Story,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a),Pocket 5
+Bluey: The Videogame,Perfect,Turnip 24.3.0 9v2,Citron,1.0.6,"60FPS 1x resolution, Adapting Filter: AMD FidelityFX, AA Method: FXAA, Force Max Clock, Use Asynch shaders",Pocket 5
+Bomb Rush Cyberfunk,Perfect,Turnip 24.1.0 R18,Citron,v1.0.19975 (v262144),"Docked mode, 1080p almost locked 60fps (rare drops to high 50s) Enable the in-game “Unleash the beast” setting for 60fps – default is 30fps. Citron latest ersion. Stock drivers and 9v2 had shadow graphical issues which are resolved using this driver. All other settings are default. Here is the download link for the 24.1.0 – Rev. 18 driver: https://github.com/K11MCH1/AdrenoToolsDrivers/releases/ download/v24.1.0_R18/Turnip-24.1.0.adpkg_R18.a6xx.zip",Pocket 5
+Bomb Rush Cyberfunk,Perfect,Qualcomm 0.746.0,Citron,1.0.19975 + DLC,Citron is back in development! 30 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Bomb Rush Cyberfunk,Great,Qualcomm 0.746.0,Yuzu,1.0.19175,,Pocket 5
+Bomb Rush Cyberfunk,Perfect,Qualcomm 0.746.0,Yuzu,1.0.19975,Perfect 30fps in docked mode,Pocket 5
+Bonds Of The Skies,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Boomerang Fu,Great,Turnip 24.3.0 9v2,Yuzu,1.3.4,"Sometimes “soft” freezes, and I have to swipe up to task manager and it kicks back in. Also controllers have to swipe to open controller menu at player select screen every time to get them to kick back on.",Pocket 5
+Boot Hill Heroes,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60 in docked mode,Pocket 5
+Borderlands,Great,Qualcomm 0.746.0,Yuzu,1.0.2,Runs great in docked mode almost constant 30fps occasional dips,Pocket 5
+Borderlands 2,Perfect,Turnip 24.3.0 9v2,Yuzu,2921a2426,Yuzu with this particular ersion only. Other ersions will be stuck on intro. Run perfect 30fps.,Pocket 5
+Borderlands: The Pre-Sequel Ultimate Edition,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.1,"Runs 20-30fps and has frequent pauses, playable if you have a lot of patience",Pocket 5
+Boreal Tenebrae,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Perfect in handheld mode,Pocket 5
+Born Of Bread,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"colors look like their blown out on first load, exit & restart fixed",Pocket 5
+Born Of Bread,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Boti: Byteland Overclocked,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Handheld mode gets mostly 30fps but there is def some glitching and dips,Pocket 5
+Braid Anniversary Edition,Perfect,Qualcomm 0.746.0,Sudachi,1.5.0,Docked runs at 40-60 FPS,Pocket 5
+Bramble The Mountain King,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Black screen on Yuzu and Sudachi with both drivers,Pocket 5
+Bravely Default II,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,some fps dips and sound crackling,Pocket 5
+Breathedge,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.2,Crashes after intro in Yuzu and Sudachi with both drivers,Pocket 5
+Brewmaster Beer Brewing Simulator,Poor,Qualcomm 0.746.0,Sudachi,1.0,Game won’t load at all,Pocket 5
+Broforce,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1.3132,Runs perfect. Solid fps the entire first mission and in menus.,Pocket 5
+Brotato,Perfect,Qualcomm 0.746.0,Yuzu,1.0.0.3h,Perfect 60fps in docked mode,Pocket 5
+Brothers,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Perfect 60fps but some audio glitching that will bother you if you are sensitive to that, also the dual trigger dual stick controls of this game are ery uncomfortable on RP5",Pocket 5
+Bud Spencer & Terence Hill – Slaps And Beans 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,60 fps Docked Mode 1080p DC: On Force Max: On Asyncrone: On,Pocket 5
+Bug Fables,Perfect,Turnip 24.3.0 9v2,Citron,1.2.0.1,Runs perfectly at full speed,Pocket 5
+Bugsnax,Great,Qualcomm 0.746.0,Yuzu,1.0.2,Almost perfect I am getting one weird black box isual glitch in the background but it plays great,Pocket 5
+Bulletstorm Duke Of Switch Edition,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Bulletstorm Duke Of Switch Edition,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Burnout Legends,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Some minor slowdowns but almost always above 50fps,Pocket 5
+Burnout Paradise Remastered,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,Audio engine – cubeb,Pocket 5
+Burnout Paradise Remastered,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Not quite locked on 60FPS but plays smooth.,Pocket 5
+Butcher,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Bzzzt,Perfect,Qualcomm 0.746.0,Citron,1.0,Plays perfectly,Pocket 5
+Bzzzt,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps fun game!,Pocket 5
+Cadence Of Hyrule: Crypt Of The Necrodancer,Perfect,Qualcomm 0.746.0,Yuzu,1.4.0,Perfect 60fps in docked mode,Pocket 5
+Call Of Juarez: Gunslinger,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.3,"Mode: Handheld, 30FPS locked",Pocket 5
+Capcom Fighting Collection 2,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,Docked 1x No issues Prod.Key 20+,Pocket 5
+Captai,Great,Turnip 25.2.0 R9,Eden,1.3.0,Great. Playable up to 35 FPS,Pocket 5
+Captain Toad: Treasure Tracker,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Captain Toad: Treasure Tracker,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,"locked 60 fps, Plays great!",Pocket 5
+Caravan Sandwich,Poor,Turnip 24.3.0 9v2,Citron,1.0,crashes on load,Pocket 5
+Carrion,Perfect,Qualcomm 805,Sudachi,1.0,,Pocket 5
+Carto,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,Perfect 60fps in docked mode,Pocket 5
+Cassette Beasts,Great,Qualcomm 0.746.0,Yuzu,1.3.0,"1 DLC installed, almost perfect 30fps in handheld mode but threre are some dips, still a ery good experience.",Pocket 5
+Castlestorm,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Default settings.,Pocket 5
+Castlestorm 2,Poor,Turnip 24.3.0 9v2,Yuzu,1.2.0.0,"50 fps in main game at 0.75x handheld, 60 in arcade mode. Crashes after a minute.",Pocket 5
+Castlevania Anniversary Collection,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Castlevania Dominus Collection,Perfect,Turnip 24.3.0 9v2,Citron,1.1,,Pocket 5
+Cat Quest,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked mode,Pocket 5
+Cat Quest III,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Cat Quest III,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Catan Console Edition,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Catan Console Edition,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Catastronauts!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Catherine: Full Body,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.1,,Pocket 5
+Cave Story+,Perfect,Qualcomm 0.746.0,Yuzu,1.3,Perfect 60fps docked,Pocket 5
+Cel Damage Hd,Poor,Qualcomm 0.746.0,Yuzu,1.0,Boots to a black screen on Yuzu and Sudachi with both drivers,Pocket 5
+Celeste,Poor,Turnip 25.2.0 R9,Sudachi,1.4.0.0,Crashes when meeting the old man and first dialog starts,Pocket 5
+Celeste,Perfect,Qualcomm 0.746.0,Sudachi,1.4.0.0,,Pocket 5
+Celeste,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Perfect performance with no additional changes in the settings needed. 60 FPS.,Pocket 5
+Celeste,Perfect,Turnip 24.3.0 9v2,Citron,1.4.1.1,,Pocket 5
+Chained Echoes,Perfect,Qualcomm 0.746.0,Yuzu,1.31,Does not boot with Turnip 9v2,Pocket 5
+Chicken Police,Playable,Qualcomm 0.746.0,Yuzu,1.0.3,A little choppy but its playable in docked mode,Pocket 5
+Child Of Light Ultimate Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps docked, looks amazing on OLED",Pocket 5
+Chocobo Gp,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.4.1 + DLC,Yuzu 278 (dc529a89a) Runs at ~60fps docked Mays crash in the intro loop (just press A button to bypass) Works with other Turnips but not default / Qualcomm,Pocket 5
+Choo-Choo Charles,Playable,Turnip 25.0.0 R5,Yuzu,1.0,Actually plays well in handheld mode but there is no audio and some isual glitches,Pocket 5
+Chrono Cross – The Radical Dreamers Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Circuit Superstars,Perfect,Qualcomm 0.746.0,Sudachi,1.0,"The game works perfectly after several championships. It has only frozen when I tried to close the emulator, and it got stuck. But the game was saved.”",Pocket 5
+Citizen Sleeper,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Citizen Sleeper,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Civilization II,Great,Turnip 24.1.0 R18,Sudachi,1.0,"Needs the last Sudachi ersion, game loads and works great, but the map appears cloudy, but texts can be read",Pocket 5
+Clubhouse Games,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Runs well in Standard performance mode,Pocket 5
+Cluster Truck,Perfect,Qualcomm 0.746.0,Citron,1.0,Almost Perfect 60 FPS Docked in levels Some minor FPS dips occasionally Only low FPS in menu,Pocket 5
+Cobalt Core,Poor,Qualcomm 0.746.0,Sudachi,1.0,Tried multiple drivers and settings. Hangs at the start up loading screen.,Pocket 5
+Code Of Princess Ex,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Code Realize Wintertide Miracles,Perfect,Turnip 24.1.0 R18,Yuzu,1.0,"docked mode. 60fps most of the time except when recalling the log, but this is an issue i faced on official hardware as well. save often, game was prone to ery occasional crashes but switching to handheld mode might help. i never used skip text function, but i saw online people saying it would crash the game on official hardware so skip with caution.",Pocket 5
+Coffee Talk,Perfect,Qualcomm 0.746.0,Yuzu,1.47,Perfect 60fps in docked mode,Pocket 5
+Collection Of Mana,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect docked,Pocket 5
+Commandos 2 – HD Remaster,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Undocked Video precision : High Force max frequencies : Yes,Pocket 5
+Commandos 3 – HD Remaster,Great,Turnip 24.3.0 9v2,Yuzu,v1.00.053,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Company Of Heroes,Great,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Contra Operation Galuga,Great,Turnip 24.3.0 9v2,Sudachi,1.0.882291,"Default settings. Locked 30 fps at 1x in arcade mode, crashes after defeating the first boss. In campaign mode, it crashes before the boss.",Pocket 5
+Contra Operation Galuga,Great,Turnip 23.2.0,Citron,1.0,Some drops in FPS during startup and initial animation screen. But once the game is loaded I get a solid 30FPS for all game play as well as animation and dialog scenes. Borderline perfect.,Pocket 5
+Core Keeper,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Update breaks the game and doesn’t run. Stay on base ersion. Turnip doesn’t work. Yuzu doesn’t work. Sudachi and Suyu offer same performance. Perfect 50-60 FPS (Game’s target is 30).,Pocket 5
+Corpse Party,Perfect,Qualcomm 0.746.0,Yuzu,1.03,Perfect 60fps in docked mode,Pocket 5
+Crash Bandicoot 4,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"2DLC, handheld mode, .75x resolution, gets 25-30fps ery fun on rp5",Pocket 5
+Crash Bandicoot N. Sane Trilogy,Great,Turnip 24.1.0 R17,Citron,be191f740,"Most of the game runs perfect, but there are some small parts where it runs at ~10fps, so far I’ve seen this at the end of the bonus stages and whenever a specific enemy is on screen 1x (handheld) sync- immediate (off). Use asynchronous shaders – yes. CPU accuracy – unsafe.",Pocket 5
+Crash Bandicoot N. Sane Trilogy,Great,Turnip 24.1.0 R18,Yuzu,1.0,it runs around 30 fps for most of it but did freeze in the second level of crash warped but that might be a one time thing,Pocket 5
+Crash Bandicoot N. Sane Trilogy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"0.75x Docked rendering (810p), Force maximum clocks and asynchronous shader set to on, rest default. RP5 in High Performance mode. Above gives solid and smooth 30fps (at least in 1st and 3rd part of the trilogy, I haven’t tested 2nd part yet).",Pocket 5
+Crash Bandicoot N. Sane Trilogy,Great,Turnip 24.3.0 9v2,Skyline,1.0,Runs about 5-7 fps faster on Skyline,Pocket 5
+Crash Bandicoot N. Sane Trilogy,Perfect,Turnip 24.1.0 R17,Sudachi,Latest,Vsync- immediate (off). Use asynchronous shaders – yes. CPU accuracy – unsafe.,Pocket 5
+Crash Team Racing: Nitro-Fueled,Poor,Turnip 24.3.0 9v2,Citron,1.0,Crash at the start of the race,Pocket 5
+Crash Team Racing: Nitro-Fueled,Perfect,Qualcomm 0.746.0,Skyline,1.0,"Docked mode, Force maximum clocks on and RP5 in High Performance gives smooth and stable 30fps",Pocket 5
+Crash Team Racing: Nitro-Fueled,Great,Qualcomm 0.746.0,Skyline,1.0,"Updates/DLC not supported, 30fps in docked mode",Pocket 5
+Crashlands,Perfect,Qualcomm 0.746.0,Sudachi,1.00.0.93.0,,Pocket 5
+Crawl,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Creepy Tale,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Cris Tales,Great,Qualcomm 0.746.0,Yuzu,1.03,Perfect 30fps docked mode but some minor isual and audio glitches,Pocket 5
+Crisis Core: Final Fantasy II Reunion,Great,Turnip 24.3.0 9v2,Citron,1.0.1,"Handheld Mode Accuracy Level : High Disk Shader Cache : On Force Maximum Clocks : On Use Async Shaders : On Audio : Cubeb Prologue is a little bit choppy at 18-30fps, but after the whole thing ran at 28-30 fps. Only thing that holds this back is intermittent blooming issues. I’ve been having trouble using cheats on Citron, but if anyone could help itd be greatly appreciated bc i have 30fps, no bloom, and no dof cheats that would definitely change htis from great to perfect",Pocket 5
+Crosscode,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,"Played 2h, super smooth",Pocket 5
+Crow Country,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Crow Country,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Crown Trick,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 60fps docked, looks great",Pocket 5
+Cruis’n Blast,Perfect,Turnip 24.3.0 9v2,Sudachi,1.07,"Did one race, stable 60fps docked, put the unit in sleep for 45 mins mid-race",Pocket 5
+Cruis’n Blast,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Crumble,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Crymachina,Perfect,Turnip 24.3.0 9v2,Sudachi,1.2.0,"Locked 30FPS in handheld mode, set graphics accuracy to high.",Pocket 5
+Crypt Custodian,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Crypt Custodian,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Crysis Remastered,Poor,Qualcomm 0.746.0,Yuzu,1.7.0,Neither driver work both boot to menu but crash when game starts,Pocket 5
+Crystal Breaker,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Ctr: Nitro Fueled,Perfect,Turnip 24.2.0 R19,Sudachi,1.0.15,game crashes before I can even start a race on a loading screen. If I go pass the loading (sometimes it happens) I just see a black screen,Pocket 5
+Cult Of The Lamb,Perfect,Qualcomm 0.746.0,Citron,1.4.5 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Cult Of The Lamb,Perfect,Qualcomm 0.746.0,Suyu,1.0,Sudachi with 9v2 didn’t work,Pocket 5
+Cult Of The Lamb,Perfect,Qualcomm 0.746.0,Yuzu,1.4.6,60fps! Docked mode @ mostly 60fps with dips when entering rooms.,Pocket 5
+Cuphead,Perfect,Qualcomm 0.746.0,Yuzu,1.2.5,Perfect 60fps docked,Pocket 5
+Cuphead In The Delicious Last Course,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.7,,Pocket 5
+Curse Of The Dead Gods,Playable,Turnip 24.3.0 9v2,Citron,1.0,"0.75x Resolution, Docked for almost constant 30 FPS. Occasionally crashes, some minor graphical issues",Pocket 5
+Cursed To Golf,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Cyberage,Perfect,GPU 0.746.0 Qualcomm,Citron,1.0,,Pocket 5
+Dadish,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps in docked mode,Pocket 5
+Dadish 3D,Great,Qualcomm 0.746.0,Yuzu,1.0,"40-60fps n slowdown runs great, slightly better framerates in handheld",Pocket 5
+Danganronpa: Trigger Happy Havoc Anniversary Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 docked,Pocket 5
+Dark Devotion,Poor,Qualcomm 0.746.0,Yuzu,1.0,Boots to black screen on Yuzu and Sudachi with both drivers,Pocket 5
+Dark Souls 1,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,"Needs a graphics fix, run in handheld mode or you will get gfx glitches (can’t see items on the ground etc.)",Pocket 5
+Dark Souls Remastered,Great,Turnip 24.3.0 9v2,Sudachi,Updated and Patched to fix the low light issues,"Occasional crashing (maybe once an hour or so), but performance is otherwise good.",Pocket 5
+Darkest Dungeon II,Playable,Qualcomm 0.746.0,Sudachi,1.0,(playable docked if you start a game in handheld first),Pocket 5
+Darkest Dungeon II,Playable,Qualcomm 0.746.0,Yuzu,1.0,loading can be slow,Pocket 5
+Darksiders I,Playable,Turnip 24.3.0 9v2,Citron,1.0,Somehow almost worse than Darksiders II,Pocket 5
+Darksiders II,Playable,Turnip 24.3.0 9v2,Citron,1.0,"It’s amazing that it even runs, but it has tons of painful stuttering and FPS dips constantly throughout the gameplay. Playable, but Painful",Pocket 5
+Darksiders Warmastered Edition,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,.5x resolution handheld mode 30fps for opening scene then drops to 11 then to 5,Pocket 5
+Darkwood,Perfect,Qualcomm,Sudachi,1.0.5,,Pocket 5
+Date Everything!,Perfect,default,Yuzu,1.0,Prologue can crash if mashed through. Bit slow but fully functional.,Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Yuzu,v1.0.4.1040,"Stable gameplay at 30 FPS in Docked Mode. Resolution set to 1× (1080p) for better performance and native fidelity. FIFO sync mode enabled to prevent screen tearing. Window Adaptation Filter set to Bicubic for smoother visuals, with FSR Sharpness at 10% for subtle image enhancement. FXAA anti-aliasing and 2× anisotropic filtering ensure clean visuals. Disk shader cache, asynchronous shaders, and reactive flushing enabled for maximum stability. Force Max Clocks disabled. No significant FPS drops experienced.",Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Yuzu,v1.0.3.978 + DLC,"Great gameplay at 30 FPS with occasional frame drops to 22-25 FPS at certain mid-game locales. Docked mode ON, 1 x Resolution, Sync Mode ON, Asynchronous shaders ON, Disk Shader Cache ON. I tried this on Citron 0.6 and the latest Sudachi (March 2025), and latest Yuzu with stock drivers seems to perform the most stable with no 0.0 FPS bugs or erratic stutters",Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Sudachi,v1.0.3.972 w/ DLC,"Game is packed into an XCI with the newest update and DLC. I am using keys and firmware 19.0.0. Using docked mode because the switch ersion is capped at 30fps. undocked instills some blur to text, use AMD fidelity if you prefer undocked.",Pocket 5
+Dave The Diver,Perfect,Qualcomm 0.746.0,Yuzu,Latest update + DLC,30fps with occasional stutters but overall nothing that hinders gameplay. Docked mode ON; 1x Resolution; Sync Mode ON; Asynchronous shaders ON; Disk shader Chache ON; Force Max Clocks ON;,Pocket 5
+Dave The Diver,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Dave The Diver,Perfect,Turnip 23.2.0,Yuzu,v1.0.3.972 AND DLC,Using latest prod keys and firmware. Docked with asychronous shaders ON.,Pocket 5
+Dawn Of The Monsters,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked,Pocket 5
+Dead Cells,Perfect,Turnip 24.3.0 9v2,Citron,1.23.2 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Dead Cells,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Dead Cells,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dead Cells,Perfect,Turnip 24.3.0 9v2,Yuzu,1.25.0,Play amazing,Pocket 5
+Dead End Job,Perfect,Qualcomm 0.746.0,Yuzu,1.0.5,Perfect 60fps in docked mode,Pocket 5
+Death Elevator 2,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Wont start,Pocket 5
+Death Mark,Perfect,Turnip 24.3.0 9v2,Citron,1.02,It’s a isual novel so not intensive. Seems to be running perfectly.,Pocket 5
+Death Tales,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps in docked mode,Pocket 5
+Death’s Door,Perfect,Turnip 24.3.0 9v2,Citron,1.1.6,Citron 0.4 Mainline (be191f740) (Havent tried the “optimized”) Locked 30fps 1x Res. Handheld mode (720p) Everything default so far Played to the first boss,Pocket 5
+Death’s Gambit: Afterlife,Perfect,Qualcomm 0.746.0,Yuzu,1.0.6,Perfect 60fps docked,Pocket 5
+Deemo -Reborn-,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,Freezes before getting in game on Yuzu and Sudachi,Pocket 5
+Deltarune,Perfect,Qualcomm 0.746.0,Sudachi,1.0,"If audio glitching, use cubeb audio output engine",Pocket 5
+Deltarune,Perfect,Turnip 24.3.0 9v2,Citron,1.00a,1X docked. Works great. Played around 5 hours so far.,Pocket 5
+Demon Turf,Playable,Qualcomm 0.746.0,Sudachi,1.1,FPS is between 15-30 but it actually feels ery good art style makes FPS not a problem imo,Pocket 5
+Demon’s Tilt,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3,Handheld mode Run at 90% CPU for stability,Pocket 5
+Destroy All Humans!,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Destroy All Humans!,Poor,Qualcomm 0.746.0,Yuzu,1.0.1,No luck in Yuzu or Sudachi with either driver,Pocket 5
+Destroy All Humans!,Playable,Turnip 24.3.4-Unified (@Mr_Purple_666),Yuzu,1.0,"Technically runs, around 20-30 fps. 1x Rez, mailbox, shaders on and max clock. Not a great experience for such a great game.",Pocket 5
+Detective Pikachu Returns,Poor,Qualcomm 0.746.0,Sudachi,1.0,Needs default driver to work. Works flawlessly until the Jewel mission where it crashes when you go to the second floor of the mansion.,Pocket 5
+Detective Pikachu Returns,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Needs default driver to work,Pocket 5
+Devil Engine Complete Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.03,,Pocket 5
+Devil May Cry 1,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Devil May Cry 3 Special Edition,Great,Qualcomm 0.746.0,Yuzu,1.0.1,Almost perfect in docked mode just has an audio delay during cutscenes that does not effect gameplay,Pocket 5
+Dex,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60dps docked,Pocket 5
+Diablo 2: Resurrected,Playable,Qualcomm 0.746.0,Citron,1.0.3.0,You need the specific “Offline file” for your update-file to update the game. Install the “Offline file” as a mod. Load the exefs folder and it should install.,Pocket 5
+Diablo 3: Eternal Collection,Perfect,Turnip 24.3.0 9v2,Eden,1.0,No issues first 10 mins of game. 60 fps default settings,Pocket 5
+Diablo 3: Eternal Collection,Perfect,Turnip 24.3.0 9v2,Yuzu,2.7.7.92380,,Pocket 5
+Diablo III,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Diablo III,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dicey Dungeons,Perfect,Turnip 24.3.0 9v2,Citron,1.10.1,,Pocket 5
+Die After Sunset,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Perfect 30dps handheld,Pocket 5
+Diesel Legacy: The Brazen Age,Poor,Turnip 24.3.0 9v2,Citron,1.0,Stuck on title screen,Pocket 5
+Digimon Cyber Sleuth,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Stable 60fps in docked mode,Pocket 5
+Digimon Story Cyber Sleuth: Complete Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfection in docked mode,Pocket 5
+Digimon Survive,Playable,Qualcomm 0.746.0,Yuzu,1.0,Runs about 15fps but its a turn based rpg so it doesnt matter much,Pocket 5
+Digimon World -Next Order-,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60 docked, one of the best looking games I have tried so far on rp5",Pocket 5
+Disco Elysium – The Final Cut,Great,Qualcomm 0.746.0,Sudachi,1.0.1,Newest Sudachi Might take a couple of resets for shaders to build You can tune settings this is what worked for me 30fps stable in-game Accuracy Level – High .5x Res Vsync – mailbox Disk shader on force clocks on synch shaders on Reactive flush on Cpu accuracy – Paranoid,Pocket 5
+Disco Elysium – The Final Cut,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.9,No luck in Yuzu or Sudachi with either driver,Pocket 5
+Disgaea 5 Complete,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Intro movie is choppy and is around 30-50 fps I recommend skipping it rest is smooth 60 unless loading new area,Pocket 5
+Disney Dreamlight Valley,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Disney Epic Mickey: Rebrushed,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,A good amount of framerate dips but definitely playable with a little patience,Pocket 5
+Disney Illusion Island,Perfect,Qualcomm 0.746.0,Yuzu,1.1.1,"Perfect 60 docked mode, looks amazing",Pocket 5
+Divinity Original Sin 2,Playable,Turnip 24.3.0 R5,Citron,1.0.9,Game runs between 15fps-30fps. Playable but not fun. -FPSGODSpeed,Pocket 5
+Doctor Who: Edge Of Reality,Poor,Qualcomm 0.746.0,Yuzu,1.0.7,Freezes way too much to play in Yuzu and Sudachi with Qualcomm and Turnip 9v2,Pocket 5
+Dodgeball Academia,Perfect,Qualcomm 0.746.0,Citron,1.0,Perfect 60fps,Pocket 5
+Dogman: Mission Impawssible,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Played 3 levels, plays great",Pocket 5
+Dogurai,Perfect,Qualcomm 0.746.0,Yuzu,1.0,plays perfectly,Pocket 5
+Don’t Starve Nintendo Switch Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0.10,"1x Docked, runs at locked 60 fps.",Pocket 5
+Don’t Starve Together,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Will not even boot into game on Yuzu or Sudachi with either driver,Pocket 5
+Donkey Kong Country Returns HD,Great,Qualcomm 0.746.0,Sudachi,1.0.13,VSync off. Accuracy high. Handheld mode. High performance. Near perfect 60fps gameplay.,Pocket 5
+Donkey Kong Country Returns HD,Perfect,Qualcomm 0.746.0,Citron,1.0,VSync off. Accuracy high. Handheld mode. High performance. Near perfect 60fps gameplay.,Pocket 5
+Donkey Kong Country: Tropical Freeze,Perfect,Turnip 24.3.0 9v2,Yuzu,1.02,Perfect 60fps,Pocket 5
+Donkey Kong Country: Tropical Freeze,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 60fps docked,Pocket 5
+Donkey Kong Country: Tropical Freeze,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,60 fps perfect and no graphical glitches,Pocket 5
+Donut Dodo,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,plays perfectly,Pocket 5
+Donuts’n’justice,Great,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked with audio glitches,Pocket 5
+Doom (2016),Playable,Turnip 24.1.0 R18,Citron,1.0,"Citron 0.4 (be191f740) Do not activate updates Docked : No CPU debugging : Yes Resolution : 0.5x Force GPU max frequencies : Yes AMD Fidelity FX goes to crash Also works with Turnip 24.1.0 R17_v2 FPS : 15~25, so playable but not enjoyable",Pocket 5
+Doom + Doom 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Doom 64,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 25fps docked, that is the locked framerate since its a port of an n64 game",Pocket 5
+Doraemon Dorayaki Shop Story,Great,Qualcomm 0.746.0,Yuzu,1.04,Game hangs when attempting to access “Site” menu.,Pocket 5
+Dorfromantik,Perfect,Qualcomm 0.746.0,Citron,I’m not sure.,"Runs perfect, you should play this game.",Pocket 5
+Double Dragon Neon,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"720p, standard performance setting",Pocket 5
+Dragon Ball FighterZ,Perfect,Turnip 24.1.0 R18,Citron,1.0,Needs DBZ crash fix mod to stop crashing when using supers https://www.mediafire.com/file/llur8mo8d2zln93/DBFZ_540p_crash_fix.zip/file Default everything .75 res,Pocket 5
+Dragon Ball FighterZ,Poor,Turnip 24.3.0 9v2,Yuzu,0.1.38,"Game either crashes at beginning of game, or when a special move is used",Pocket 5
+Dragon Ball FighterZ,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Turnip 25 rev5 did not work, 24.3.0 R9v2 worked.",Pocket 5
+Dragon Ball Z: Kakarot,Perfect,Turnip 25.2.0 R1,Sudachi,1.0,,Pocket 5
+Dragon Ball Z: Kakarot,Great,Turnip 24.3.0 9v2,Yuzu,"1.50, 15DLC",Works great framerate wise but there is a weird red glow over the screen during some battles. Handheld mode mostly 30fps with occasional dropped frames.,Pocket 5
+Dragon Marked For Death: Advanced Attackers,Perfect,Turnip 24.3.0 9v2,Sudachi,3.1.5,,Pocket 5
+Dragon Quest Builders,Great,Turnip 23.3.0-devel,Sudachi,1.0,"This is the only driver I found, where it doesn’t have a weird green border issue with the item bar. The game has a bug found in all emulators where some items will show the wrong icon(even on PC) but otherwise the game works fine for the most part.",Pocket 5
+Dragon Quest Builders 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Plays Perfect at 35fps , no graphical glitches",Pocket 5
+Dragon Quest III HD-2D Remake,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Audio can be a little crackly, but overall ery playable.",Pocket 5
+Dragon Quest III HD-2D Remake,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,has some stuttering in the open world,Pocket 5
+Dragon Quest III HD-2D Remake,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Can crash sometimes, performance is pretty much locked 30fps tho.",Pocket 5
+Dragon Quest Monsters,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 30dps docked looks great, some minor audio stutter that probably will go away in handheld mode but worth it to play docked",Pocket 5
+Dragon Quest X,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.1,20-30fps handheld mode but its in japanese,Pocket 5
+Dragon Quest XI S: Echoes Of An Elusive Age,Great,Turnip 24.3.0 9v2,Yuzu,1.0,No textures in Qualcomm – need to use Turnips,Pocket 5
+Dragon’s Dogma: Dark Arisen,Great,Qualcomm 0.746.0,Yuzu,1.0,Shockingly works amazing! Couple minor dips but its pretty much locked to 30 in docked mode,Pocket 5
+Draw A Stickman: Epic,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Dreamscaper,Poor,Turnip 24.3.0 9v2,Yuzu,1.1.1.5,Crashes after a few mins of play on Yuzu and Sudachi,Pocket 5
+Dredge,Poor,Turnip 24.3.0 9v2,Eden,1.5.3,"It’s a coin toss on whether the game will load. Most of the time you will make it to the title screen, but when you try to progress to the actual game, it will: 1. Load fine 2. Black screen 3. Crash and shut down the entire device",Pocket 5
+Dredge,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Dredge,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dredge,Great,Turnip 24.3.0 9v2,Sudachi,1.5.3,"Graphics accuracy set to high. Handheld Mode. 30FPS, minor dips. Async shaders improve performance a bit.",Pocket 5
+Dredge,Perfect,Turnip 9v2,Citron,1.5.3,,Pocket 5
+Drone Pilot: Extreme Flight Simulator,Great,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Dros,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.1,No luck with either driver in Yuzu or Sudachi,Pocket 5
+Drova Forsaken Kin,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Duck Detective: The Secret Salami,Perfect,Qualcomm 0.746.0,Eden,1.1.2,Accuracy Level needs to be set to High or the game will freeze when Tutorial pop ups are shown,Pocket 5
+Duck Detective: The Secret Salami,Poor,Turnip 24.3.0 9v2,Yuzu,1.1.2,"Tested on Yuzu and Sudachi with Qualcomm and Turnips, game freezes ery quickly",Pocket 5
+Duck Game,Perfect,Turnip 24.1.0 R18,Yuzu,1.0,"11/10 party game, runs great. Small graphics issues in certain screens in the game but they dont affect gameplay.",Pocket 5
+Dungeonoid 2: Awakening,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Dungeons And Doomknights,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Dungeons Of Dreadrock – The Dead King’s Secret,Great,Qualcomm 0.746.0,Citron,v1.0.1,Citron 6b9dd40 Default parameters,Pocket 5
+Dungeons Of Dreadrock – The Dead King’s Secret,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Dungreed,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 60fps docked,Pocket 5
+Dusk,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Perfect 60fps, you do have to swipe up to stop freezes every once and while.",Pocket 5
+Dusk Diver,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Handheld mode .75x resolution almost perfect 30fps occasional dips,Pocket 5
+Dust & Neon,Great,Qualcomm 0.746.0,Yuzu,Yuzu 278 (dc529a89a) All default parameters,,Pocket 5
+Dust & Neon,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked,Pocket 5
+Dust: An Elysian Tail,Perfect,Turnip 24.3.0 9v2,Sudachi,1.06.181214,,Pocket 5
+Dustoff Heli Rescue 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Dying Light Definitive Collection,Great,Turnip 24.3.0 9v2,Yuzu,1.0,sometimes fps drops,Pocket 5
+Dysmantle,Great,Qualcomm 0.746.0,Sudachi,1.4.0.0,The minimap doesn’t work but the pause map does. I played 3 areas before I got bored. 40-60 FPS.,Pocket 5
+Ea Sports Fc 25,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Playable,Pocket 5
+Ea Sports Fc 25,Poor,Turnip 24.3.0 9v2,Yuzu,1.73,Does not open,Pocket 5
+Ea Sports Fc 25,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Doesn’t even open,Pocket 5
+Eastward,Perfect,Qualcomm 0.746.0,Yuzu,1.2.1 + Octopia DLC,Perfect 60fps docked,Pocket 5
+Eastward,Perfect,Turnip 24.3.0 9v2,Yuzu,1.2.1,60 fps,Pocket 5
+Eastward: Octopia!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.2.1,"60 fps, Plays Great!",Pocket 5
+Echo Generation,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 30fps handheld mode, looks like a cool game",Pocket 5
+Echoes Of The Plum Grove,Playable,Turnip 25.0.0 R8,Yuzu,1.0,,Pocket 5
+Elderand,Perfect,Qualcomm 0.746.0,Yuzu,1.3.2.1,Perfect 60fps docked,Pocket 5
+Eldest Souls,Perfect,Qualcomm 0.746.0,Yuzu,1.1.23,Perfect 60fps docked,Pocket 5
+Elsie,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Elypse,Great,Qualcomm 0.746.0,Yuzu,1.0.9,50-55fps in handheld mode,Pocket 5
+Elypse,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Elypse,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Emio: The Smiling Man – Famicom Detective Club,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Runs well without additional tweaks. No noticeable issues after several hours of play.,Pocket 5
+Empty Shell,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Crashes launcher,Pocket 5
+Enclave HD,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Docked,Pocket 5
+Ender Lilies: Quietus Of The Knights,Perfect,Turnip 24.3.0 9v2,Citron,1.1.1,"Needs the 1.1.1 update to play 60fps Citron 0.3, Accuracy Normal or High – High is more stable Kept the rest on default",Pocket 5
+Ender Magnolia Bloom In The Mist,Perfect,Turnip 24.3.0 9v2,Citron,0.3,"Handled, Accurancy high",Pocket 5
+Enraged Red Ogre,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,Runs perfectly 1x resolution,Pocket 5
+Enter The Gungeon,Perfect,Qualcomm 0.746.0,Yuzu,2.1.91,Perfect 60fps docked,Pocket 5
+Enter The Gungeon,Great,Turnip 24.3.0 9v2,Yuzu,2.1.92,One of my favorite switch games and it runs really great. There are frame drops occasionally and it’s not a locked 60fps but it’s more than playable.,Pocket 5
+Eternal Edge,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Not quite perfect 30fps docked but ery close,Pocket 5
+Eternights,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Perfect 30fps docked,Pocket 5
+Etrian Odyssey HD,Great,Qualcomm 0.746.0,Yuzu,1.0.2a,Not quite perfect 60fps docked but super close it feels like its perfect without the frame counter I would say its perfect,Pocket 5
+Evasion From Hell,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld mode sudachi,Pocket 5
+Everafter Falls,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Working great with latest Citron update,Pocket 5
+Everafter Falls,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Often crashes if trying to change controller settings mid-game – set up controllers before launching the game,Pocket 5
+Everhood,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,"Perfect 60fps docked, looks amazing on OLED",Pocket 5
+Everspace,Great,Turnip 24.1.0 R18,Sudachi,1.0.5,"Works great a 30 fps but the game quits after you die, but no graphic glitches or slow downs",Pocket 5
+Exhausted Man,Perfect,Qualcomm 0.746.0,Yuzu,1.0.6,Runs Perfect… bizarre game,Pocket 5
+Exzeus Collection,Perfect,Qualcomm 0.746.0,Yuzu,1.03,Perfect 60fps docked,Pocket 5
+F.I.S.T. Forged In Shadow Torch,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Boots in 9v2 but crashes before game starts on Yuzu and Sudachi,Pocket 5
+Factorio,Poor,Turnip 24.3.0 9v2,Sudachi,1.1.110,crash at first loading,Pocket 5
+Fading Afternoon,Poor,Qualcomm 0.746.0,Citron,1.3.0,"Stuck on black screen, does not start.",Pocket 5
+Fairy Tail,Playable,Turnip 24.3.0 9v2,Yuzu,"1.0.6, 62 DLC","Very playable in handheld mode .75x resolution with graphics accuracy set to high. About 30-40fps in battles and 20-40fps in the world, feels like a ita port but definitely playable.",Pocket 5
+Fallen Legion: Rise To Glory,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Docked mode, almost 60fps for the first stage.",Pocket 5
+Fantasian Neo Dimension,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"crashes on latest driver, 9v2 is perfect",Pocket 5
+Fantasy Life – The Girl Who Steals Time,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Plays but crashes every once in a while Asynchronous shaders on Vsync Fifo Relaxed Adreno Max clock enabled Disk Shaders cache off 0.5-0.75x resolution FRS 0% Anti Alias off Performance mode is fine but high may be better Game will crash before start if Disk Shaders cache enabled . Limiting factor looks to be the driver. Getting 28-30 Fps sometimes but gameplay has a little stuttering and it drops. Game crashes when too many things or inputs and happening, hard to say but there’s supposedly issues with memory leak in the game so an update may patch that. Running v1.00 of the game",Pocket 5
+Fantasy Life – The Girl Who Steals Time,Perfect,Turnip 24.3.0 9v2,Eden,1.1.0,After EXTENSIVE testing…. Accuracy: High Vsync: FIFO Relaxed Anti-aliasing: Off Shader cache: Off Async shaders: On Reactive flushing: On,Pocket 5
+Fantasy Life – The Girl Who Steals Time,Great,Turnip 24.3.0 9v2,Sudachi,1.1.0,1.0.0 crashes early. After updating to 1.1.0 I’ve been playing for a while and it’s flawless. Solid 30fps in handheld mode,Pocket 5
+Far: Changing Tides,Perfect,Qualcomm 0.746.0,Yuzu,v131072,"Crashes with 9v5, use Qualcomm GPU driver. Smooth 30fps.",Pocket 5
+Fast Rmx,Playable,Turnip 24.3.0 9v2,Citron,1.0,"Runs @20-30FPS, as a game supposed to run @60FPS, it is slow and not really playable. Tested with Sudachi and Citron, with multiples drivers and configuration, and with or without updates",Pocket 5
+Fatal Frame: Maiden Of Black Water,Great,Qualcomm 0.746.0,Yuzu,"1.0.2, 4 DLC",Great in docked mode 30fps most of the time drops to 20 for certain parts almost perfect.,Pocket 5
+Fatal Frame: Mask Of The Lunar Eclipse,Playable,Qualcomm 0.746.0,Yuzu,1.0,Handheld mode .75x resolution is playable mostly 30fps but some slowdown and audio glitching,Pocket 5
+Fate/samurai Remnant,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.2,Perfect on Resolution 0.75X,Pocket 5
+Fate/Stay Night Remastered,Perfect,Turnip 24.3.0 9v2,Yuzu,1.3.0 b335,,Pocket 5
+Fez,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Fifa 18,Great,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Fifa 18,Great,Turnip 24.3.0 9v2,Citron,1.0,60 FPS with occasional dips. No player indicator. Playable but disappointing,Pocket 5
+Fifa 19,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"It’s running great 60 fps troughout the game, sometimes dipping to 30 – 50 on goal celebration or replays. The only problem it’s missing player indicator. making it really hard to play",Pocket 5
+Fifa 23,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.3,"Player jerseys colour is blue, player names not showing",Pocket 5
+Fighting Ex Layer Another Dash,Perfect,Turnip 24.3.0 9v2,Sudachi,2.2.2,,Pocket 5
+Final Fantasy,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Final Fantasy Crystal Chronicles Remastered,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 30fps docked,Pocket 5
+Final Fantasy II,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,"Perfect 30fps docked, perfect 60fps using built in fast forward",Pocket 5
+Final Fantasy III,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Final Fantasy IV,Great,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps but has audio glitching,Pocket 5
+Final Fantasy Vi,Perfect,Turnip 25.2.0 R9,Sudachi,1.0,"Might have audio glitching, if so try cubeb audio output engine",Pocket 5
+Final Fantasy X HD Remaster,Perfect,Turnip 24.3.0 9v2,Citron,1.0,30 fps in handheld mode. Docked may work but certain wide shots slow to 20-25 fps.,Pocket 5
+Final Fantasy X HD Remaster,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Perfect 30fps in handheld mode,Pocket 5
+Final Fantasy XII,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Final Fantasy XV Pocket Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1.0,"Perfect 60fps handheld, super smooth 45-60fps docked",Pocket 5
+Final Vendetta,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Finding Paradise,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Fire Emblem Engage,Great,Qualcomm 0.746.0,Yuzu,1.0,"30fps docked, some ery minor dips almost perfect",Pocket 5
+Fire Emblem Warriors: Three Hopes,Playable,Turnip 25.2.0 R2,Citron,1.0,Expect a bunch of slowdowns due to shaders. Afterwards runs at a solid 30-40 fps. Runs better than Three Houses ;_;,Pocket 5
+Fire Emblem: Engage,Great,Turnip 24.3.0 9v2,Citron,2.0.0,"Make sure to have GPU Accuracy at High, save often as it may randomly crash.",Pocket 5
+Fire Emblem: Three Houses,Great,Qualcomm 0.746.0,Suyu,1.1.1,"Handheld, 0.75x only",Pocket 5
+Firewatch,Great,Turnip 24.1.0 R18,Yuzu,1.0,"Handheld mode, High graphics accuracy, 1x resolution. 25fps on average.",Pocket 5
+Firewatch,Great,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Five Nights At Freddy’s: Help Wanted 2,Great,Turnip 23.2.0,Citron,1.0,"The game runs great, but some sections require playing with Joy Cons (which have to be connected through Bluetooth)",Pocket 5
+Five Nights At Freddy’s: Help Wanted 2,Poor,Turnip 25.2.0 R11,Sudachi,1.0,The game shows a black screen all the time.,Pocket 5
+Five Nights At Freddy’s: Into The Pit,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Five Nights At Freddy´s: Security Breach,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Plays Perfect at 30fps,Pocket 5
+Flat Kingdom Paper’s Cut Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Flynn Son Of Crimson,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Didn’t play to completion yet but it plays perfectly in the beginning,Pocket 5
+Fnaf Sb,Great,Turnip 24.3.0 9v2,Yuzu,1.0,".75x handheld. Mostly 30 fps, dips to ~20 when looking at big areas and freezes briefly when loading areas (happens on every device). Overall, runs about as well as the switch (with the decreased resolution, of course).",Pocket 5
+Fobia,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps handheld mode,Pocket 5
+Food Delivery Battle,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Handheld mode gets 60fps BUT sometimes freezes but can be fixed by swiping up as if you were going to close the app then clicking back into it.,Pocket 5
+For A Vast Future,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+For The King,Great,Qualcomm 0.746.0,Yuzu,1.0,Handheld mode 30fps some slight dips,Pocket 5
+Forager,Great,Qualcomm 0.746.0,Sudachi,4.1.3,Starts on a black screen but if you wait a bit the game will play perfectly.,Pocket 5
+Forager,Perfect,Turnip 24.3.0 9v2,Citron,4.1.3,Takes around 1 minute to load at the beginning but otherwise runs perfectly,Pocket 5
+Forager,Perfect,Turnip 24.3.0 9v2,Skyline,1.0,Skyline 0.0.3 (1868) Only emulator that booted (all others : black screen with sound on),Pocket 5
+Forgive Me Father,Great,Turnip 24.3.0 9v2,Yuzu,1.5.4.3,Almost perfect 30fps just some slight dips great experience docked mode,Pocket 5
+Forgotten Anne,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Fortress S,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Freddi Fish 4: The Case Of The Hogfish Rustlers Of Briny Gulch,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Freddy Spaghetti,Poor,Qualcomm 0.746.0,Yuzu,1.0,"First game to completely crash my entire RP5, had to hard reset",Pocket 5
+Freedom Planet,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Flawless,Pocket 5
+Freedom Wars Remastered,Perfect,Qualcomm 0.746.0,Yuzu,1.0,PERFECT 30fps docked mode!! Looks great!,Pocket 5
+Frog Detective: The Entire Mystery,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 Docked,Pocket 5
+Frogue,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Frogun Deluxe Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1,Perfect 30 docked,Pocket 5
+From Heaven To Earth,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld mode,Pocket 5
+Funko Fusion,Playable,Turnip 24.3.0 9v2,Citron,0.1,It loads and can be played but there is a large amount of blinking graphically glitches that makes the screen hard to look at and the frames jump around often.,Pocket 5
+Furi Definitive Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.5.137,Menus and cutscenes a little laggy but does not affect gameplay,Pocket 5
+G.I. Joe: Wrath Of Cobra,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Slow loading but works great,Pocket 5
+Garden Story,Perfect,Qualcomm 0.746.0,Yuzu,1.4.1,Perfect 30fps docked,Pocket 5
+Gear Club Unlimited 2,Perfect,Qualcomm 0.746.0,Citron,1.7.2,"Menus run at a perfect 60, in game a perfect 30 and that is with the RP5 in performance mode.",Pocket 5
+Genesis Noir,Great,Turnip 24.3.0 9v2,Yuzu,1.7,"Perfect 30 handheld, some dips",Pocket 5
+Ghost Of A Tale,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,No boot in sudachi or yuzu with either driver,Pocket 5
+Ghost Song,Great,Qualcomm 0.746.0,Yuzu,1.2.12b,45fps docked 50-55 handheld,Pocket 5
+Ghost Sync,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"3 DLC, perfect 60 docked",Pocket 5
+Ghost Trick: Phantom Detective,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"works perfect, didn’t played too much tho",Pocket 5
+Ghostbusters: The Video Game – Remastered,Great,Turnip 24.3.0 9v2,Yuzu,v1.2,Yuzu 278 (dc529a89a) Resolution : 0.75x Force max frequencies : Yes May give better FPS with Uzuy MMJR,Pocket 5
+Ghostrunner,Playable,Turnip 24.3.0 9v2,Yuzu,1.8,"Good framerate handheld mode, but severe audio glitching making it impossible to play with sound",Pocket 5
+Ghosts And Apples,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 docked,Pocket 5
+Ghosts And Goblins Resurrection,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Goblin Sword,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.2,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Godstrike,Perfect,Qualcomm 0.746.0,Yuzu,2021.04.08,Perfect 30 docked,Pocket 5
+Going Under,Great,Turnip 24.3.0 9v2,Yuzu,1.0.4,Perfect 30fps but some audio glitching,Pocket 5
+Golf Story,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,,Pocket 5
+Golf With Your Friends,Perfect,Qualcomm 0.746.0,Sudachi,1.0.14,Default settings. Perfect 30 fps on the forest 18 holes.,Pocket 5
+Good Job!,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30 docked,Pocket 5
+Gori: Cuddly Carnage,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Crashes in Yuzu and Sudachi with both drivers,Pocket 5
+Gothic 2 Complete Classic,Playable,Turnip 23.2.0,Citron,1.0,"1х, handheld. Turn on Asynchronous Shaders. Stable 30 fsp. Sometimes crashes",Pocket 5
+Grand Mountain Adventure,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Hangs during loading,Pocket 5
+Grand Mountain Adventure: Wonderlands,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Severe isual glitches in Yuzu and Sudachi with both drivers,Pocket 5
+Grandia HD Collection,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,Black screen at the start and stay stuck like that. Try on other emulators for the same result,Pocket 5
+Grapple Dog,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Graveyard Keeper,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Graveyard Keeper,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Graveyard Keeper,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.0.4633,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Gravity Duck,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Greak: Memories Of Azur,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 handheld mode,Pocket 5
+Grim Fandango Remastered,Great,Qualcomm 0.746.0,Yuzu,1.0,SMOOTH 45-60FPS HANDHELD,Pocket 5
+Grim Fandango Remastered,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Grime,Playable,Turnip 24.3.0 9v2,Suyu,1.3.9,some crackling audio but otherwise locked 30 FPS,Pocket 5
+Grime – Definitive Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.3.9,Yuzu 278 (dc529a89a) All default parameters Use cubeb for good audio,Pocket 5
+Gripper,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"30fps handheld mode, some dips.",Pocket 5
+Gris,Great,Qualcomm 0.746.0,Yuzu,1.0,40-45fps docked,Pocket 5
+Groove Coaster Wai Wai Party,Perfect,Qualcomm 0.746.0,Citron,1.0.20 +49 DLCs,"Trying to play online locks up the game, haven’t been able to try local multiplayer. Sometimes the audio will stutter upon launch, restarting citron fixes it.",Pocket 5
+Grounded,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.4,"GPU accuracy set to high, undocked, res x0.75 12-20 fps",Pocket 5
+Grow: Song Of The Evertree,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.1,Handheld mode mostly 30fps some dips and freezes,Pocket 5
+Gta: San Andreas – Definitive Edition,Great,Turnip 24.3.0 9v2,Citron,1.0.8,"System – 100% max Speed, Handheld mode, Rest your choice Graphic – Extreme, 1X, Sync off, nearest neighbors, 25% FSR, AA off, AF standart, 16:9, DSC on, Max freq on, ASync Shader on, Urf off Audio – Auto Debug – ulkan, NCE, accurate, CPU Debugging on, Fastmem on not Final, work in progress, Runs good with some random crashes here and there",Pocket 5
+Guacamelee! 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Guacamelee! Super Turbo Championship Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Guayota,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Guilty Gear Strive,Great,Turnip 24.3.0 9v2,Citron,1.01,"Used performance mode and enabled asynchronous shaders. runs at a smooth 58-60, slight input lag.",Pocket 5
+Gun Gore & Cannoli 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,,Pocket 5
+Gunman Clive HD,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 docked,Pocket 5
+Guns Of Fury,Perfect,Turnip 24.3.0 9v2,Eden,1.0,More than 60% of the game completed. Perfect so far.,Pocket 5
+Guns Of Fury,Poor,Turnip 24.3.0 9v2,Citron,1.0,won’t boot black screen,Pocket 5
+Guns Of Fury,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,won’t boot,Pocket 5
+Gunslugs,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30 docked,Pocket 5
+Hades,Playable,Qualcomm 0.746.0,Citron,1.0,still trying to set it up but i am having lighting issues,Pocket 5
+Hades,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hades,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.37136,"Perfect 60 handheld, also perfect 60 docked but crashes",Pocket 5
+Hades,Perfect,Turnip 24.3.0 9v2,Yuzu,1.38232,"1x resolution, accuracy high, fifo (on), amd fidelityfx, SMAA 45-50fps",Pocket 5
+Hades,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Hades,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hades,Great,Turnip 24.3.0 9v2,Yuzu,1.0.38233,Might have character glitches at some point but ery rare,Pocket 5
+Happy’s Humble Burger Farm,Perfect,Turnip 23.0.0,Sudachi,1.0,"Rare minor graphical glitches, but otherwise runs at a buttery smooth 30 fps!",Pocket 5
+Hatsune Miku: Project Diva Mega Mix,Great,Qualcomm 0.746.0,Citron,1.0,Slight frame drops in select songs. Otherwise runs well with low load times.,Pocket 5
+Have A Nice Death,Great,Qualcomm 0.746.0,Sudachi,1.0,60 FPS . no problem,Pocket 5
+Have A Nice Death,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Heavenly Bodies,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Heavenly Bodies,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hell Is Other Demons,Perfect,Turnip 24.3.0 9v2,Citron,6.6.12,Perfect 60 FPS Docked,Pocket 5
+Hell Pie,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.4,Crashes before getting to gameplay,Pocket 5
+Hellblade: Senua’s Sacrifice,Playable,Turnip 24.3.0 9v2,Yuzu,1.1.0,"Handheld mode .75x resolution. accuracy set to high, runs about 20fps",Pocket 5
+Hellboy Web Of Wyrd,Poor,Qualcomm 0.746.0,Yuzu,1.0.4,boots and gets into game with 40fps but unfortunately continually freezes,Pocket 5
+Hello Kitty Island Adventure,Perfect,Turnip 24.3.0 9v2,Sudachi,1.10.1,"Works amazingly! Docked mode, Forced maximum clocks, use asynchronus shaders. Only issue I have had is with taking pictures, some pictures have weird texture problems, and saving the pictures crash the game.",Pocket 5
+Hello Neighbor,Great,Turnip 24.3.0 9v2,Yuzu,1.0,30-50fps handheld,Pocket 5
+Hellpoint,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Won’t boot on yuzu or sudachi with either driver,Pocket 5
+Heretic’s Fork,Great,Turnip 24.3.0 9v2,Citron,1.2.2.15,Almost Perfect 30 FPS. Occasional dips,Pocket 5
+High On Life,Playable,Turnip 24.3.0 9v2,Eden,1.0.3,playable and gets better while playing with graphical error where everything is recolored blue or green its kinda funny,Pocket 5
+Hitman Blood Money Reprisal,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Hitman Blood Money Reprisal,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Hob: The Definitive Edition,Poor,Turnip 24.3.0 9v2,Yuzu,1.1.2,Black screen in yuzu and sudachi,Pocket 5
+Hogwarts Legacy: Deluxe Edition,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"only qualcomm driver managed to load and go into character creation but theres is graphical glitches with the character, soon crashes at name creation.",Pocket 5
+Hollow Knight,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Hollow Knight,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Hollow Knight,Perfect,Turnip 24.3.0 9v2,Sudachi,1.4.3.2b,,Pocket 5
+Horizon Chase 2,Great,Turnip 24.3.0 9v2,Yuzu,1.6.6,Only reason not saying perfect is because of occasional crashes and some microstutter Asych shaders ON. Audio – Cubeb. Run 1.6.6 update and build some shaders @ 30fps Then add the 60fps mod by StevensND,Pocket 5
+Horizon Chase Turbo,Perfect,Turnip 24.3.0 9v2,Yuzu,2.6.1,,Pocket 5
+Hotline Miami 1 & 2,Perfect,Qualcomm 0.615.77,Sudachi,2.0.3,"it crashes at first then it will work if you launch it again, no crashes after.",Pocket 5
+Hotline Miami 1 & 2,Perfect,Turnip 24.3.0 9v2,Yuzu,2.0.3,"it crashes at first then it will work if you launch it again, no crashes after.",Pocket 5
+Hotline Miami 1 & 2,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Hotshot Racing,Great,Turnip 24.1.0 R18,Sudachi,1.0.5,"Works great in handheld, 60fps most most of the time. Minor graphical glitches in the menu and rare graphical glitch in races too, barely noticeable.",Pocket 5
+Hotshot Racing,Great,Turnip 24.3.0 9v2,Sudachi,1.0.5,Almost there with 55-60fps. Some minor glitches in menu. ery good playable. Some drops to 40fps at explosions.,Pocket 5
+Hotshot Racing,Great,Qualcomm 0.746.0,Yuzu,1.0.5,Average about 45fps docked,Pocket 5
+Hue,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Huntdown,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps,Pocket 5
+Hunter X,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Wouldn’t load in Sudachi or Yuzu but seems great with Citron,Pocket 5
+Hunterxhunter Nenximpact,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Hyper Light Drifter,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Hypnospace Outlaw,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.4,Appears to run flawlessly.,Pocket 5
+Hyrule Warriors: Age Of Calamity,Great,Turnip 25.2.0 R4,Citron,1.3.0,"1xResolution (20-24 FPS), Window adaptive filter: AMD FidelityFX, AA Method: FXAA, Force Max clocks, use async shaders",Pocket 5
+Hyrule Warriors: Definitive Edition,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Game will crash randomly. Mostly in the first level, but the crashes are more rare past the first level. Save frequently from the start menu.",Pocket 5
+Hyrule Warriors: Definitive Edition,Great,Turnip 24.3.0 9v2,Yuzu,1.0.1,Definitely has some dips but mostly 30-40fps handheld mode seems like a good experienvce,Pocket 5
+I Am The Hero,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,Tested in docked mode,Pocket 5
+Iconoclasts,Perfect,Qualcomm 0.746.0,Yuzu,1.15p,:erfect 60fps docked,Pocket 5
+Ikenfell,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3.2,Perfect 60fps docked,Pocket 5
+Immortals Fenyx Rising,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Would, not boot in Yuzu or sudachi with any driver I tried",Pocket 5
+In Other Waters,Great,Turnip 24.3.0 9v2,Citron,1.0.4,Works well although the fps ranges from 30-50,Pocket 5
+In Sound Mind,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Crashes in Yuzu and Sudachi and slows the whole device down,Pocket 5
+Inmost,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4.3,Perfect 30fps docked,Pocket 5
+Inscryption,Perfect,Turnip 24.3.0 9v2,Citron,1.34.0,Citron is back in development! 30 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Can’t Tell If The Audio Is Stuttering/Crackling Or If It’s Just The Game SFX Everything Else Default.,Pocket 5
+Inscryption,Perfect,Turnip 24.3.0 9v2,Sudachi,1.20.1,Graphics accuracy level needs sets to high,Pocket 5
+Inside,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,So far so good… LOVE this game!,Pocket 5
+Into The Breach,Perfect,Turnip 25.2.0 R9,Sudachi,1.2.88,,Pocket 5
+Into The Breach,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Inukari – Chase Of Deception,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Iris And The Giant,Perfect,Qualcomm 0.746.0,Yuzu,1.1.8,Perfect 60fps handheld,Pocket 5
+Iron Meat,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Ironfall Invasion,Perfect,Qualcomm 0.746.0,Citron,1.0,1x handheld smooth 60 in my testing so far,Pocket 5
+Islanders,Great,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+It Takes Two,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Freezes before gameplay in yuzu and sudachi with all 3 drivers,Pocket 5
+Ittle Dew,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Jack Move,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 60fps docked,Pocket 5
+Jamestown+,Perfect,Qualcomm 0.746.0,Citron,1.0.3,,Pocket 5
+Jet Lancer,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Perfect 60 FPS, Takes around a minute to load at first",Pocket 5
+Jet Lancer,Playable,Turnip 24.3.0 9v2,Suyu,1.0,Does not start on suyu but works perfect at 30fps on yuzu docked,Pocket 5
+John Wick Hex,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Perfect 30fps docked,Pocket 5
+Jojo’s Bizarre Adventure: All-Star Battle R Deluxe Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,2.3.3,,Pocket 5
+Jujutsu Kaisen Cursed Clash,Playable,Turnip 24.3.0 9v2,Yuzu,1.2.0,Please use handheld mode if not it will crash at certain point of the game,Pocket 5
+Jurassic World Evolution,Great,Turnip 23.3.0-devel,Sudachi,1.0.1,Idk,Pocket 5
+Just Shapes & Beats,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Kamen Rider Memory Of Heroez,Great,Qualcomm 0.746.0,Citron,1.0,"Achieves consistent 30 fps gameplay Use 0.75 resolution with upscaling for assurance High Performance mode Throughout my gameplay, there were no game breaking graphical glitches that occured compared to using Turnip 9v2 where half of the screen turned black during cutscenes. Will test it further",Pocket 5
+Kamen Rider Memory Of Heroez Premium Sound Edition,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.1,Major graphical glitches making it unplayable even though it runs quite smoothly,Pocket 5
+Kamen Rider Memory Of Heroez Sound Edition,Perfect,Qualcomm 0.746.0,Citron,1.0,Performance mode is sufficient runs pretty good with a steady 30fps at 0.75x Asynchronous Shaders on you must use the qualcomm driver to not have the black graphics glitch,Pocket 5
+Kamibako – Mythology Of Cube,Perfect,Qualcomm 0.746.0,Citron,1.0,Citron 0.4 Some settings not necessary but this worked. Set limit speed to 200% for 60fps .75 resolution vsync mailbox disk shader cache force clocks reactive flushing cpu accuracy – unsafe,Pocket 5
+Kamiko,Perfect,Qualcomm 0.746.0,Sudachi,1.0,60fps consistent,Pocket 5
+Kanjozoku 2,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Cant get passes loading screen docked,Pocket 5
+Katamari Damacy Reroll,Perfect,Qualcomm 0.746.0,Yuzu,1.0,perfect 30 docked,Pocket 5
+Katana Zero,Perfect,Turnip 24.3.0 9v2,Citron,1.0.5,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Katana Zero,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.5,,Pocket 5
+Katrielle And The Millionaires’ Conspiracy,Great,Turnip 24.3.0 9v2,Sudachi,1.1,"Works great, about 3 hours into the game so far",Pocket 5
+Kaze And The Wild Masks,Perfect,Qualcomm 0.746.0,Sudachi,🎮 Nome do Jogo: Kaze and the Wild Masks 🗓 Data de Lançamento: 26 de março de 2021 🆔️ ID do Programa: 010038B00F142000 📀 Formato de Arquivo: NSP + Update v2.5.3 + DLC,Smooth gameplay with default settings and driver! This is an awesome indie game and it feels a bunch like old DKC games!,Pocket 5
+Keeper’s Toll,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Keeper’s Toll,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Kero Blaster,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Plays perfectly,Pocket 5
+Kill Knight,Perfect,Qualcomm 0.746.0,Citron,1.1.0,,Pocket 5
+Kill The Crows,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Perfect 60 FPS Docked. Change accuracy level to either high or extreme. If you don’t it will constantly crash.,Pocket 5
+Kill The Crows,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+King Krieg Survivors,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Kingdom 2 Crowns,Perfect,Turnip 24.3.0 9v2,Sudachi,2.1.0,,Pocket 5
+Kirby And The Forgotten Land,Great,Turnip 24.3.0 9v2,Citron,1.0,"Game plays beautifully for the most part, even on 1x res. The only issue is that the game sometimes crashes at the very end of a level/world; still looking for a solution for this.",Pocket 5
+Kirby And The Forgotten Land,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"async on, use 1x still pretty stable",Pocket 5
+Kirby And The Forgotten Land,Poor,Turnip 24.3.0 9v2,Citron,1.0,"Could play only with fist 30 mins of game world 1, but world 2 and world 3 is crash city. Random crashes or when trying to change worlds or moving in through the 3 star doors",Pocket 5
+Kirby And The Forgotten Land,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"Runs between 23-30 fps, not perfect",Pocket 5
+Kirby Star Allies,Great,Turnip 24.3.0 9v2,Sudachi,3.0.0,The only issues (which might be bad for epileptics) is ery bad flickering sometimes. If you can get past that you can 100% beat oid Termia and beat the game,Pocket 5
+Kirby Star Allies,Great,Turnip 23.2.0,Sudachi,1.0,,Pocket 5
+Kirby’s Dream Buffet,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,"30fps in-game, 60fps in menus- same as on actual hardware.",Pocket 5
+Kirby’s Return To Dreamland Deluxe,Great,Turnip 24.3.0 9v2,Yuzu,1.0,40-60fps handheld mode some stutters but good experience,Pocket 5
+Klonoa Phantasy Reveire Series,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60 handheld,Pocket 5
+Kudzu,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+La Noire,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,Playable 30 fps but might have some fps drop during gun fight or driving,Pocket 5
+Lacuna,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Legacy Of Kain Soul Reaver 1&2 Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"(start in dock until you get through the opening animation, after that it runs great in docked",Pocket 5
+Legend Of Grimrock,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Works great, but I have just played 10 minutes. Might be problems down the line, but I doubt it. Default settings.",Pocket 5
+Legend Of Zelda – Links Awakening,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Legend Of Zelda – Links Awakening,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,60 fps mod v3 No DOF mod 1 x resolution High performance Dynamic CPU backend Runs near to 60fps even in overworld,Pocket 5
+Legend Of Zelda – Links Awakening,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Same Mods and settings as Sudachi with the same performance in Citron.,Pocket 5
+Legend Of Zelda: Breath Of The Wild,Perfect,turnip_mrpurple T19,Citron,1.6.0,The same settings as the other submissions for the game The most important setting is Force maximum clocks since it makes sure that the game doesn’t go down to 20fps and stays at 30 fps The next import thing is this driver (https://github.com/MrPurple666/purple-turnip/releases/tag/vturnip_mrpurple-T19-toasted.adpkg) by mrpurple that will fix the visual glitches in the dungeons The game runs at 1x with a few frame drops when rendering shaders,Pocket 5
+Lego Builder’s Journey,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Lego City Undercover,Great,Turnip 24.3.0 9v2,Yuzu,1.0.3,game does not work in sudachi due to ghraphical glitches with the screen,Pocket 5
+Lego Harry Potter Collection,Great,Turnip 24.1.0 R17,Yuzu,v1.2.0,Yuzu 278 (dc529a89a) Backend CPU : JIT Force max frequencies : Yes,Pocket 5
+Lego Jurassic World,Perfect,Turnip 25.2.0 R9,Yuzu,1.0,720/1080p Docked Mode,Pocket 5
+Lego Marvel Superheroes,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Won’t go over 15 even in 0.25,Pocket 5
+Lego Marvel Superheroes 2,Perfect,Qualcomm 0.746.0,Yuzu,Latest,"Crashed with Turnips, but the system drivers work great. Wouldn’t launch with Sudachi.",Pocket 5
+Lego Star Wars: The Skywalker Saga,Poor,Over 2 dozen drivers tested,Yuzu,1.0 or 1.10.0,"The intro crashes the game, but if you import a save which has played at least the 1st mission then you can skip it but once it reaches the menu it crashes your device or the app. I have managed to get into the game only 1 time but there were lots of visual bugs at 25 fps and it crashed 30 seconds later.",Pocket 5
+Leo’s Fortune,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Leo’s Fortune,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Life Is Strange Double Exposure,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,"Won’t boot at all in yuzu, boots in sudachi with Turnip 9v2 but crashes at the ery beginning of the game",Pocket 5
+Life Is Strange Remastered,Great,Turnip 24.1.0 R18,Citron,1.0.1,Use asynch shaders to help graphics stutter. CPU accuracy – Unsafe,Pocket 5
+Life Is Strange: Before The Storm Remastered,Great,Qualcomm 0.746.0,Citron,1.0,Citron 0.4v – Default settings,Pocket 5
+Link’s Awakening,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"No Blur Mod, 60 fps Mod, dock, sync off, 0.75, force max clocks, turn off NCE",Pocket 5
+"Little Kitty, Big City",Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked 😀,Pocket 5
+Little Nightmares,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.2,Seemed like it was gonna work well in handheld mode but crashes when you turn on the flashlight,Pocket 5
+Little Nightmares Ii,Great,Turnip 24.3.0 9v2,Citron,1.3,"Default settings, 30 FPS stable. working great so far. Citron 0.4",Pocket 5
+Littlewood,Perfect,Qualcomm 0.746.0,Sudachi,1.03,,Pocket 5
+Live A Live,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,NOTE: Imperial China level boss has a super that causes the game to crash no matter what I tried. Exported save and finished fight on PC ersion of emu. *some of the Debug settings may be pointless. GRAPHICS> Accuracy Level > High. GRAPHICS> Anti-aliasing method > SMAA. DEBUG > CPU Backend > Dynamic. DEBUG > CPU accuracy > Accurate.,Pocket 5
+Live A Live,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,I kind of changed all of these one at a time and with some anecdotal knowledge. So some of the Debug settings may be pointless. GRAPHICS> Accuracy Level > High. GRAPHICS> Anti-aliasing method > FXAA. DEBUG > CPU Backend > Dynamic. DEBUG > CPU accuracy > Accurate.,Pocket 5
+Live A Live,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Mostly perfect 30 handheld but has some drops in battles,Pocket 5
+Live A Live,Great,Turnip 24.3.0 9v2,Citron,1.0,It’s more than great I think but does have some frame drops.,Pocket 5
+Llamasoft: The Jeff Minter Collection,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"It’s an emulator in an emulator, and works perfectly!",Pocket 5
+Loco Motive,Perfect,Qualcomm 0.746.0,Citron,1.0,plays perfectly,Pocket 5
+Lollipop Chainsaw Repro,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Lone Fungus,Poor,Qualcomm 0.746.0,Citron,1.0,"Launches into black screen. The game itself works fine, but even with other drivers (turnip 9v2 and others) and with other emulators (eden and sudachi) the black screen remains. Installing the update didn’t help either. Someone with more knowledge might be able to get it to work, since the screen being black is really the only problem; you can hear the sounds and even move around, use the menu etc. but screen is always black.",Pocket 5
+Lone Ruin,Poor,Qualcomm 0.746.0,Citron,1.0,Major Graphical Issues,Pocket 5
+Lonely Mountains Downhill,Great,Turnip 24.3.0 9v2,Citron,1.6,"Updated game and installed all DLC. Most Emulators and Drivers work. Reduce resolution to 75%, Accuracy Level High (very important), Force Maximum Clocks. Game plays at 60 FPS (mostly), even looks like 1080 with FSR turned on. If the game freezes, pretend like you’re switching apps, and go right back to the game. It usually works.",Pocket 5
+Lonely Mountains Downhill,Poor,Turnip 25.2.0 R1,Sudachi,1.0.1,"Reduced the resolution to the lowest setting. I could select a course, the course loaded, but crashes when I start to move forward. New to this, don’t know what to try next.",Pocket 5
+Lonely Mountains Downhill,Poor,Turnip 24.3.0 9v2,Citron,1.0,Crashes when loading startup menu,Pocket 5
+Lost In Random,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 30fps handheld mode,Pocket 5
+Lovers In A Dangerous Spacetime,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4 (v262144),"4-player with bluetooth controllers, no issues.",Pocket 5
+Luigi’s Mansion 3,Playable,Qualcomm 805,Sudachi,1.4.0,"0.75x , async off , shaders cache on Graphical glitches are common. Mirror glitch present in Yoga Mat level ,needed to see a game walkthrough to get past that. Strobing glitch after few hours of gameplay ,sometimes gets so bad need to restart the game. Few compromises but still playable to beat the game.",Pocket 5
+Luigi’s Mansion 3,Great,BioSensor MK1,Citron,1.0,Perfectly playable with 0.75 resolution and can add mods like 60fps,Pocket 5
+Luigi’s Mansion 3,Playable,Qualcomm 0.746.0,Citron,1.4.0,Citron 0.3 Works with some graphics issue but seems promising Accuracy level High Resolution 0.75x Force Maximum clocks,Pocket 5
+Luna’s Fishing Garden,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Lunar Remastered Collection,Great,Qualcomm 0.746.0,Sudachi,1.0,"Set audio to Cubeb. Docked. Solid framerates in Lunar 1. Lunar 2 had ery minor studders where framerates dropped to 40fps here and there, which are present in handheld mode. Played through the first dungeon in both games, no issues. I hesitate to say “perfect” but they certainly seem 100% playable at 1-2 hours in. No issues with cutscenes and no graphic glitches that I noticed.",Pocket 5
+Lunar Remastered Collection,Playable,Turnip 24.3.0 R5,Sudachi,1.0.2 (v131072),"Lunar Silver Story Classic and Remastered both work perfectly; I ran around, watched FMVs, and did some battles with no issues. Lunar Eternal Blue Classic plays the FMVs without issues, but there are frame dips from 60 to 40 from the start when moving around. After the first boot it started exhibiting the issues that described next. Lunar Eternal Blue Remastered does not boot FMVs and gets stuck at the first in-game cutscene so I could not test in-game performance and is unplayable. I cannot recommend playing Lunar Eternal Blue on the RP5 at the current state with this configuration.",Pocket 5
+Lysfanga – The Time Shift Warrior,Great,Qualcomm 0.746.0,Yuzu,1.0,Yuzu 278 (dc529a89a) Undocked Video precision : high Force max frequencies : yes,Pocket 5
+Mahoyo: Witch On The Holy Night,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Maid Of The Dead,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Worked but crashed in Sudachi every time a “lucky dip” powerup was collected,Pocket 5
+Mario & Luigi: Brothership,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Mario & Luigi: Brothership,Perfect,Turnip 24.1.0 R17,Citron,1.0,This will fix any glitches on second island when you first meet Luigi,Pocket 5
+Mario & Luigi: Brothership,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"1x docked, Force maximum clocks and asynchronous shaders on, RP5 HP mode, 30fps. It crashed on me once, just at the beginning of the game, but didn’t happen again.",Pocket 5
+Mario & Luigi: Brothership,Playable,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Mario + Rabbids Kingdom Battle,Poor,Turnip 24.3.0 9v2,Sudachi,1.9.0 (+ 4 DLC),Glitch in shadows – Plays OK (variable fps) up to the second tutorial battle where game freezes. Tested multiple parameters adjustment without success,Pocket 5
+Mario + Rabbids Kingdom Battle,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld mode gameplay but there are graphical glitches and wrong colors during some cutscenes but gameplay is perfect. Does not work in YUZU,Pocket 5
+Mario + Rabbids Sparks Of Hope,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Gets through the intro prompts but freezes before getting to the menu,Pocket 5
+Mario Golf Super Rush,Great,Turnip 24.1.0 R18,Citron,4,Played an entire round of golf no crashes. Further testing needed to erify,Pocket 5
+Mario Kart 8 Deluxe,Great,Qualcomm 0.746.0,Citron,3.0.4,"NEAR perfect, I get lighting glitches with headlights and such but it’s not the worst thing ever and most courses don’t use them. I had system crashes and graphical issues with the turnip drivers i tried. I’ve gotten 3 stars on 150cc, mirror, and most of 200cc so it’s definitely stable and transitions between races well.",Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Turnip 25.0.0 R8,Yuzu,1.0,,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm adreno 819.1,Eden,3.0.4,Basically 60fps stable the whole time after caching shaders,Pocket 5
+Mario Kart 8 Deluxe,Playable,turnip 25.2.0 R13,Yuzu,3.0.4,System crash after first race,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm 0.746.0,Citron,3.0.4,Latest Mario Kart update gives solid 60 fps in docked mode using Qualcomm driver in Citron 0.6.1 I was able to load into a second and third race but I did not have time to complete a whole circuit.,Pocket 5
+Mario Kart 8 Deluxe,Perfect,Qualcomm 0.615.77,Sudachi,3.0.4,"3.0.4 makes the game run into 64bits NCE so the performance is highly affected positively! sOLID 60FPS FULL SPEED, only occasional and quick framedrops (very close to perfection) Sudachi (driver 0615.77) – handheld mode – 1x resoution – accuracy normal – disk shader cache > on ( I usually never disable this optioon anyways) – force maximum clock – off (I set this as the default because it fixes a lot of audio stuttering in many games without negatively affecting others) – Asynchronous Shaders – on – Audio Cubeb (i make this default since it fix lots of audio stutter in many games and don’t affect negativally in others) OBS: Turnips still crashes the device so avoid them",Pocket 5
+Mario Kart 8 Deluxe,Perfect,Turnip 24.3.0 9v2,Citron,1.0,the game crashes and the console turns off,Pocket 5
+Mario Kart 8 Deluxe,Great,Qualcomm 0.746.0,Yuzu,2.3.0,"0.75x resolution, Firmware 18.1.0. Turnips crash the game and so do certain firmware ersions.",Pocket 5
+Mario Kart 8 Deluxe,Playable,Qualcomm 0.746.0,Yuzu,1.0,gets better over time,Pocket 5
+Mario Kart 8 Deluxe,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Seems to run ery similar on the top 3 emulators,Pocket 5
+Mario Odyssey,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Runs solid 60fps, but crashes sometimes during gameplay and at the ideo sequences, if you skip them immediately you can continue",Pocket 5
+Mario Odyssey,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Mario Party Superstars,Poor,Turnip 24.3.0 9v2,Sudachi,1.1.1,Crashes after choosing to start a campaign. Also crashes when going to Mt. Minigames and choosing Free Play.,Pocket 5
+Mario Party Superstars,Poor,Qualcomm 0.746.0,Sudachi,1.1.1,Crashes after choosing to start a campaign. Also crashes when going to Mt. Minigames and choosing Free Play.,Pocket 5
+Mario Strikers Battle League,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.2,"40FPS – 50FPS, Default settings, standard mode. Had no crashes.",Pocket 5
+Mario Tennis Aces,Perfect,"Turnip – Jan. 04, 2025",Sudachi,1.0,"Graphics: 0.75x, Sync Off, FSR Sharpness: 20%",Pocket 5
+Mario vs. Donkey Kong,Perfect,Turnip 24.3.0 9v2,Yuzu,Update 1.01,"Runs at 60fps, handheld",Pocket 5
+Marsupilami – Hoobadventure,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Console: High Performance. Asynch shaders – On. Audio – cubeb. Plays 55-60fps.,Pocket 5
+Marvel Ultimate Alliance 3: The Black Order,Poor,Turnip 24.3.0 9v2,Sudachi,1.4.1,Crashes,Pocket 5
+Marvel vs. Capcom Fighting Collection: Arcade Classics,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+Mary Skelter 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Master Detective Archive: Rain Code,Poor,Turnip 24.3.0 9v2,Citron,1.4.0,"It works great, almost perfect even, up until the quick time events at the end of the train, managed to muddle my way through 2 of them but it froze pretty much no matter what during those events. Tried every other emulator as well, along with system drivers and the most up to date Turnip on each emulator. No dice.",Pocket 5
+Mega Man Legacy Collection 2,Perfect,default,Yuzu,1.0,,Pocket 5
+Mega Man X Legacy Collection,Perfect,default,Yuzu,1.0,,Pocket 5
+Mega Man X Legacy Collection 2,Perfect,default,Yuzu,1.0,,Pocket 5
+Megam Man Legacy Collection,Perfect,default,Yuzu,1.0,,Pocket 5
+Megaton Musashi W: Wired,Great,Qualcomm 777,Sudachi,3.2.3,"Erratum for game update ersion, also playable with YUZU latest ersion , ALWAYS USE FIRMWARE 17.1.0 since it freezes on game launch on other fw ersions",Pocket 5
+Megaton Musashi W: Wired,Great,Qualcomm 777,Sudachi,1.0.1,"Sudachi ersion 6178075: Vsync FIFO ON, Reso. 0.75x, FORCE MAXIMUM CLOCKS always on to avoid crashes",Pocket 5
+Metal Gear Solid – Master Collection Version,Great,Turnip 24.3.0 9v2,Yuzu,1.5.0,"Some text is invisible, but apart from that a locked 60fps in the USA ersion",Pocket 5
+Metal Slug Tactics,Perfect,Qualcomm 819.1,Citron,v1.0.2,"Game DOES NOT run perfect with Turnips, locks up during assist attacks. Use Qualcomm drivers, I used 819.1 and game runs 50-60 FPS at almost all times. No crashes after 7 hours of gameplay, chipset temp running 60-65C. Runs fine on both standard and performance power modes. Settings: Undocked, Accuracy Normal, 1x Res, sync: FIFO (On), Disc Shader Cache: ON, Force max clocks: OFF (doesn’t help fps, makes chipset run hot), Use Async Shaders: ON",Pocket 5
+Metal Slug Tactics,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,,Pocket 5
+Metallic Child,Poor,Turnip 24.3.0 9v2,Suyu,1.0,"Doesn’t load at all, tried with several emulators",Pocket 5
+Metro 2033 Redux,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,It runs at a perfect 30fps in handheld mode but has a weird screen flickering issue. Plays ery well,Pocket 5
+Metroid Dread,Perfect,BioSensor MK2,Citron,2.1.0,"Docked 60fps, looks amazing on the OLED display! Couldn’t hit a solid 60fps using 9v2 unfortunately despite the other guides suggesting it Accuracy: Normal Force maximum clocks: On Asynchronous shaders: Off",Pocket 5
+Metroid Dread,Perfect,Turnip 24.3.0 9v2,Citron,2.1.0,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If The Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Metroid Dread,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Looks great on the RP5!,Pocket 5
+Metroid Prime Remastered,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Wow it runs AMAZING in docked mode! I can’t technically say perfect because there are slight dips but it is almost perfect 60dps it looks fantastic,Pocket 5
+Metroid Prime Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Metroid Prime Remastered,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Mighty Morphin Power Rangers: Rita’s Rewind,Perfect,Turnip 25.2.0 R4,Citron,1.0,Local multiplayer works perfect,Pocket 5
+Mighty Morphin Power Rangers: Rita’s Rewind,Perfect,Turnip 24.3.0 9v2,Sudachi,v1.0.3,,Pocket 5
+Miitopia,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,Make sure to have BOTH Firmware and Keys installed on Emulator. You need the firmware to use and create Miis. Also turn of Disk Shader Cache.,Pocket 5
+Minecraft Dungeons,Playable,Turnip 24.3.0 9v2,Yuzu,1.17.0.0 and 1.0,"Audio crackles, unplayable for me, tried Sudachi and Suyu",Pocket 5
+Minecraft Legends,Great,Turnip 24.3.0 9v2,Eden,Final Update1.18.19068.0,Handheld mode 20-40 fps depending on scene. Played a few hours without issue. force adreno overclock,Pocket 5
+Minecraft Story Mode – The Complete Adventure,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Framerate is perfect docked, but there is a weird thing where the textures on the character’s shirts look blurry. Does not effect gameplay.",Pocket 5
+Minecraft: Nintendo Switch Edition (legacy Console),Perfect,Turnip 24.1.0 R18,Citron,1.0,"Runs at solid 60fps, no drops. All performance settings enabled with cube audio.",Pocket 5
+Minecraft: Nintendo Switch Edition (Legacy Console),Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Lots of audio cracking for music but no other issues. Runs at around 40-50fps on 1x resolution and 50-60fps on 0.75x resolution. If you don’t mind turning off the music, it’s ery enjoyable!",Pocket 5
+Mining Mechs,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,,Pocket 5
+Minit,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Mistover,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.9,,Pocket 5
+Monster Boy And The Cursed Kingdom,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Monster Hunter Generations Ultimate,Perfect,Turnip 24.3.0 9v2,Citron,1.4.0 + 60 FPS Patch/Mod,Citron is back in development! 60 FPS Settings: Docked 1x Res. Turn on Force Maximum Clocks and Asynchronous Shaders Everything else default.,Pocket 5
+Monster Hunter Generations Ultimate,Perfect,Turnip 24.3.0 9v2,Yuzu,1.4.0,"Runs at a solid 30fps, and solid 60fps with patch",Pocket 5
+Monster Hunter Generations Ultimate,Perfect,Turnip 24.3.0 9v2,Citron,1.4.0,Solid 30fps. No crashes after 3 hours.,Pocket 5
+Monster Hunter Rise,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"No luck with qualcomm or Turnip 9v2 on Yuzu, Sudachi, Citron, or Suyu",Pocket 5
+Monster Hunter Stories,Perfect,Qualcomm 0.746.0,Yuzu,"1.0.1, 1 DLC","Perfect 60fps handheld about 45fps docked, slight audio stutter during some cutscenes but not during gameplay",Pocket 5
+Monster Train,Great,Turnip 24.3.0 9v2,Citron,2.0.0,"Accuracy: High , Resolution 1x, Adaptive Filter: AMD FidelityFX, AA: FXAA, Force Maximum clocks, Use Async Shaders",Pocket 5
+Monster Train 2,Perfect,Qualcomm 0.746.0,Sudachi,1.1,,Pocket 5
+Monster Train 2,Poor,Turnip 25.2.0 R9,Sudachi,1.1,"Instantly crashes, but works perfect with Qualcomm 0.746.0",Pocket 5
+Moonlighter,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.0.10,,Pocket 5
+Moonstone Island,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Running great at 60fps,Pocket 5
+Moonstone Island,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.9,Locked 60 fps. Plays great!,Pocket 5
+Mutazione,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,30-45fps docked but its a isual novel so it works perfectly,Pocket 5
+My Sims,Perfect,Qualcomm 0.746.0,Ryujinx,1.0,http://mikahintz.de/ryujinxAndroid.zip,Pocket 5
+My Sims,Poor,Turnip 24.3.0 9v2,Citron,1.1,I tried many setting sadly just met with a black screen. Would love to see if someone can get it running! Even tried the base driver. No dice.,Pocket 5
+My Time At Sandrock,Great,Qualcomm 0.746.0,Yuzu,1.4.0.0,Need the update to work. Resolution 0.75 Accuracy Level : High – CPU accuracy : Accurate 20 to 30 FPS and stable so far (only 2 hours),Pocket 5
+N++,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.5,,Pocket 5
+Naiad,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Kept freezing in first scene, when tabbing out it would temporarily run.",Pocket 5
+Naruto Shippuden Ultimate Ninja Storm 4 Road To Boruto,Perfect,Turnip 24.3.0 9v2,Sudachi,v1.0.15,"Not much setting is needed other then putting it in performance mode with a steady 30fps There will be a downloading data screen when it load, but for some reason Citron will not pass that screen so use Sudachi",Pocket 5
+Naruto Ultimate Ninja Storm Collection,Great,Turnip 24.3.0 9v2,Sudachi,1.0,only issue seen is crackling audio. otherwise runs great,Pocket 5
+Naruto X Boruto Ultimate Ninja Storm Connections,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Runs stable at 30fps. Did not play with settings since it there was no need.,Pocket 5
+Nascar Heat Ultimate Edition+,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect out of the box. No setting adjustments needed.,Pocket 5
+Neckbreak,Great,Turnip 24.3.0 9v2,Suyu,1.0,Runs great at 30fps docked,Pocket 5
+Need For Speed Hot Pursuit Remastered,Perfect,Qualcomm 0.746.0,Suyu,1.0,"both Suyu and Citron, thank you for this spreadsheet",Pocket 5
+Need For Speed Hot Pursuit Remastered,Great,Turnip 24.3.0 9v2,Sudachi,1.0.3,,Pocket 5
+Needy Girl Overdose,Perfect,Turnip 24.3.0 9v2,Citron,1.1.1,Consistent 45 – 60 fps,Pocket 5
+Neo: The World Ends With You,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,,Pocket 5
+Neon Abyss,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.6,,Pocket 5
+Neon Blood,Great,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Neon White,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Looks and runs amazing, perfect 60fps handheld and 35-40 docked",Pocket 5
+Nerd Survivors,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.20240625,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Neuro Voider,Perfect,Turnip 24.3.0 9v2,Citron,1.0.5,Perfect 60 FPS Docked,Pocket 5
+Neva,Perfect,Qualcomm 0.746.0,Citron,1.2.0,"60 FPS Docked during gameplay, some very minor dips in between some cutscenes",Pocket 5
+New Pokémon Snap,Great,Turnip 24.3.0 9v2,Citron,Latest,"disk shader cache = true, force maximum clocks = true Game works nearly perfect! Professor registers photos you take, little to no frame drops, overall really responsive. Only problem I’ve seen is that any pictures you take, beyond the initial run down with the professor, will just appear as blank black images.",Pocket 5
+New Pokémon Snap,Great,Qualcomm 0.746.0,Suyu,1.0,Handheld mode,Pocket 5
+New Super Lucky’s Tale,Perfect,Qualcomm 0.746.0,Yuzu,1.5.9,Perfect 30fps docked,Pocket 5
+New Super Mario Bros. U Deluxe,Perfect,Qualcomm 0.746.0,Suyu,1.0,"Firmware 17.0.1 runs perfect in yuzu, couldnt get it running in any other emu",Pocket 5
+Nexomon,Perfect,Qualcomm 0.746.0,Yuzu,1.02,"Perfect 60fps docked, looks great",Pocket 5
+Ni No Kuni Wrath Of The White Witch,Great,Turnip 24.3.0 R3,Sudachi,v1.0.11,You will need firmware 17.0.1 other firmwares will make the title screen bootloop but with firmware 17.0.1 you will go past that screen. Frames betwen 23-30 played until Ding Dong Dell so don’t know if completable,Pocket 5
+Nickelodeon All-Star Brawl 2,Great,Qualcomm 0.746.0,Yuzu,1.0,Works well handheld mode almost perfect 30fps just takes awhile to load in game,Pocket 5
+Nickelodeon Kart Racers,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Night In The Woods,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2,Played for around 30 minutes without any issues,Pocket 5
+Night Slashers Remake,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Turnips unplayable,Pocket 5
+Nights Of Azure 2,Playable,Turnip 24.3.0 9v2,Citron,1.0,Thought I’d give it a shot but when it came to combat the frame drops a bit too much. It’s for sure playable but I wouldn’t suggest it in this state.,Pocket 5
+Nine Sols,Perfect,Qualcomm 0.746.0,Sudachi,1.1,,Pocket 5
+Ninja Gaiden Sigma,Perfect,Turnip 24.1.0 R18,Citron,1.0.4,works perfect now with sound unlike older switch emulators. the game has washed out blacks go into grapics menu in game and turn gamma down to 0.5,Pocket 5
+Ninja Gaiden Sigma,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.2,Plays perfectly but no sound in game even after changing emulator audio settings,Pocket 5
+Ninja Slayer: Neo-Saitama In Flames,Playable,Turnip 24.3.0 9v2,Citron,1.0,Runs 60 FPS with no enemies on screen Killing or attacking enemies causes the fps to drop. Many FPS dips makes it annoying to play,Pocket 5
+Nintendo World Championship,Perfect,Qualcomm 0.746.0,Citron,1.0,Plays perfectly when I set graphics to 0.75,Pocket 5
+No More Heroes,Poor,Turnip 24.3.0 9v2,Sudachi,1.2.0,Graphical glitches making it unplayable,Pocket 5
+No More Heroes 2: Desperate Struggle,Poor,Turnip 24.3.0 9v2,Sudachi,1.2.0,Graphical glitches making text unreadable in game,Pocket 5
+No More Heroes 3,Playable,Turnip 24.3.0 9v2,Sudachi,1.1.1,Playable with low fps and some graphical glitches and lag,Pocket 5
+Nuclear Blaze,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Octodad: Dadliest Catch,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Black screen on yuzu and sudachi with both drivers,Pocket 5
+Octopath Traveler,Perfect,Mr. Purple T18,Citron,v1.0.1,"Docked, 1x Res, Disk Shader Cache:ON, Force Max Clocks:OFF, Async Shaders:ON All other settings default. Game is locked at 30FPS at all times, no stuttering, crashing, or glitches. Current save file time is at 13 hours.",Pocket 5
+Octopath Traveler,Great,Turnip 24.3.0 9v2,Citron,1.0.1,"Citron 0.4. Handheld Mode, Disabled Shader Cache, Disabled Asynchronous Shader Compilation. RP5 Performance and Smart Fan. Pretty smooth and stable",Pocket 5
+Octopath Traveler,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,(works surprisingly well when docked but dips down to ~15fps),Pocket 5
+Octopath Traveler,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Octopath Traveler,Perfect,Turnip 25.2.0 R4,Citron,1.0.4,x0.75,Pocket 5
+Octopath Traveler II,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Some graphical glitching in different lighting.,Pocket 5
+Octopath Traveler II,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"(same as OT1, both hold closer to 30fps docked)",Pocket 5
+Octopath Traveler II,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.1,"Graphics Accuracy Level: High; Use async shaders; Use reactive flushing; Handheld Mode// Performance Mode: Performance; Fan: Smart; No more lighting glitches!! Smooth 30FPS, Minor dips to high 20s.",Pocket 5
+Octopath Traveler II,Great,Turnip 24.3.0 9v2,Sudachi,1.1.1,"Graphics -> Accuracy Level: High; Performance: High; Fan: Smart. This solves the lighting glitches. Battles at 30FPS, Overworld mostly 30fps, Drops in some areas to mid 20s. ery playable.",Pocket 5
+Octopath Traveler II,Great,Turnip 24.3.0 9v2,Sudachi,1.02,Runs well at 30 fps with occasional dips. Only problem is the occasional random crash during combat which is quite annoying.,Pocket 5
+Oddworld: New ‘n’ Tasty!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Okami HD,Great,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 30fps handheld, some isual glitching",Pocket 5
+Okinawa Rush,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Old School Musical,Perfect,Qualcomm 0.746.0,Citron,1.3 + DLC,,Pocket 5
+Olliolli World,Perfect,Qualcomm 0.746.0,Yuzu,1.2.0,"Perfect 60dps docked, great game",Pocket 5
+Omega Labyrinth Life,Perfect,Turnip 25.2.0 R2,Eden,1.0,Drops frames in the overworld but nothing major,Pocket 5
+Omori,Perfect,Qualcomm 0.746.0,Eden,1.0,,Pocket 5
+One Piece Pirate Warriors 3,Great,Qualcomm 0.746.0,Yuzu,1.0,"About 45fps handheld mode, good experience",Pocket 5
+One Piece Unlimited World Red Deluxe Edition,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps docked, looks great",Pocket 5
+One Step From Eden,Perfect,Turnip 24.3.0 9v2,Sudachi,1.5.6,,Pocket 5
+Onimusha: Warlords,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Plays flawlessly docked at 60fps,Pocket 5
+Ori And The Blind Forest,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Ori And The Blind Forest,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,"Perfect 60 docked, looks incredible on the OLED",Pocket 5
+Ori And The Blind Forest,Great,Qualcomm 0.746.0,Yuzu,Update 1.0.2,,Pocket 5
+Ori And The Blind Forest (Definitive Edition),Great,Turnip 24.1.0 R18,Citron,1.0.2,"This game does NOT run perfectly on RP5, despite what other entries in this sheet say. I tried a huge combination of emulators, drivers, settings etc. The best overall performance I got was docked mode 1x, Citron 0.4, Turnip 24.1.0 R18, force maximum clocks, asynchronous shaders, everything else default. The game would often hit 60fps, but it was not stable. It would often dip down to 30-50fps, and even when frame rate was 50+ there was frequent (albeit minor) stuttering. It’s absolutely playable and ery enjoyable but it is NOT 60fps locked.",Pocket 5
+Ori And The Will Of The Wisps,Playable,Turnip 24.3.0 9v2,Citron,1.2.0,Only successfully boots 1/4 of the time. FPS ranges from 10-35. Some minor graphical issues.,Pocket 5
+Otherwar,Perfect,Qualcomm 0.746.0,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Otxo,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Our Summer Festivals 2,Perfect,Qualcomm v615. 77,Sudachi,1.0.15,Set Accuracy Level to High. No need to change other settings. I played two times with these settings and it went perfectly well.,Pocket 5
+Our Summer Festivals 2,Perfect,Qualcomm v615. 77,Sudachi,1.0.15,"Uses both firmware and prodkeys 19.0.1. Set Accuracy Level High. Disable shader cache. Dont change anything else, this is the complete setting. Make sure play High Performance on your retroid pocket flip 2.",Pocket 5
+Outer Wilds,Perfect,Turnip 24.3.0 9v2,Citron,1.1.15.1027,.75 | Force maximum clocks | Use asynchronous shaders. Once shaders complie it runs at full speed,Pocket 5
+Overcooked 2 + All Dlc,Perfect,Turnip 25.0.0 R5,Yuzu,1.0,30 FPS LOCKED,Pocket 5
+Owlboy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.5,,Pocket 5
+Paint The Town Red,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,,Pocket 5
+Panzer Paladin,Perfect,Qualcomm 0.746.0,Yuzu,1.2.2,Play perfect,Pocket 5
+Paper Mario: The Origami King,Poor,Qualcomm 0.746.0,Sudachi,1.01,"Tried with yuzu, sudachi, and Skyline. All crash at the beginning sequence, if you use a save to skip that it crashes if you go into the loading zones. what a shame",Pocket 5
+Paper Mario: The Thousand-Year Door,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,froze after into battle,Pocket 5
+Paper Mario: The Thousand-Year Door,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Papwr Mario The Thousand Year Door,Great,Qualcomm adreno 819.1,Citron,1.0,Tried multiple drivers. Most crashed Citron. The qualcomm adreno 819.1 with high performance turned on and fan set to auto works. Undocked mode,Pocket 5
+Party Hard,Poor,Qualcomm 0.746.0,Kenji-nx,1.0,Crashes at boot.,Pocket 5
+Party Hard,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Passpartout,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Passpartout 2,Playable,Turnip 24.3.0 9v2,Yuzu,1.1.1,,Pocket 5
+Pato Box,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Perfect 60fps docked,Pocket 5
+Patrick’s Parabox,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Perfect 60 FPS Docked,Pocket 5
+Pentiment,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Pepper Grinder,Perfect,Turnip 24.3.0 9v2,Citron,1.0.4,,Pocket 5
+Persona 3 Portable,Perfect,Turnip 24.1.0 R18,Citron,1.0,Citron 0.4 Sounds set to Cubeb Res 1x native,Pocket 5
+Persona 4 Arena Ultimax,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked looks and plays great,Pocket 5
+Persona 4 Golden,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Great 60 fps. Occasionally crashes, but I find these settings most stable.",Pocket 5
+Persona 4 Golden,Perfect,Qualcomm 0.746.0,Sudachi,1.0,"Perfect 60fps docked, don’t play in yuzu it has audio issues there",Pocket 5
+Persona 4 Golden,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Runs flawlessly at 1x (710p) handled mode, 60FPS on performance mode. Audio set to cubeb",Pocket 5
+Persona 5 Royal,Perfect,Turnip Driver 24.1.0 r18 fix for a6xx,Yuzu,1.0,Docked Mode. Accuray level high.Resolution 0.75 Vsync mode FIFO (On) Use asynchronous shaders on disk shader cache on audiocubeb Api vulkan CPU backend dynarmic (slow) CPU accuracy auto high performance fan on sport 13:25 minutes beat castle 5/9 also clear shader cache if you have issues 30 fps,Pocket 5
+Persona 5 Royal,Great,Turnip 9v2,Sudachi,1.0.2,Accuracy: High,Pocket 5
+Persona 5 Royal,Perfect,Qualcomm 777,Yuzu,1.0,,Pocket 5
+Persona 5 Royal,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Crashes seem to be fixed by setting graphics accuracy to “high”. Runs at 30fps with minor slowdowns in some areas.,Pocket 5
+Persona 5 Royal,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,"Runs ery smooth, experienced one crash in first 40min of game play.",Pocket 5
+Persona 5 Royal,Perfect,Turnip 25.2.0 R2,Citron,1.0,,Pocket 5
+Persona 5 Royal,Great,Mr.Purple T19,Eden,1.0,"Works well with 60fps mod, however some crashes may happen. Change accuracy level to High if crashes happen",Pocket 5
+Persona 5 Strikers,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Boots and gets past menus but crashes as soon as gameplay starts,Pocket 5
+Persona 5 Tactica,Poor,Qualcomm 0.746.0,Yuzu,1.0,"Black screen in yuzu and sudachi with qualcomm, Turnip 9v2, and Turnip 25",Pocket 5
+Pga Tour 2k21,Poor,Qualcomm 0.746.0,Sudachi,1.9.0,"Tested at 0.75x resolution and in high performance mode. The game experiences a sudden drop in frame rate after the first screen, then closes.",Pocket 5
+Phoenix Wright: Ace Attorney Trilogy,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Plays perfectly at 60fps,Pocket 5
+Phoenotopia Awakening,Perfect,Turnip 24.3.0 9v2,Citron,1.3.3,Runs at a perfect 60fps in docked mode,Pocket 5
+Pikmin 1,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,Game plays great with Turnips. Only reason it’s not rated higher is that the audio is bad,Pocket 5
+Pikmin 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Pikmin 2 runs perfect in it’s first hour of gameplay, no audio issues like the first game",Pocket 5
+Pikmin 3 Deluxe,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"runs smoothly with no graphical problems or crashes, highly reccomend!! :3",Pocket 5
+Pikmin 3 Deluxe,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Perfect up until the Armored Mawdad, I haven’t tested afterwards.",Pocket 5
+Pikmin 4,Great,Turnip 24.0.0,Citron,1.0,9v2 doesnt work after the intro part. use this driver.,Pocket 5
+Pikmin 4,Great,Turnip 24.3.0 9v2,Sudachi,1.0,30fps,Pocket 5
+Pikuniku,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Plays perfectly,Pocket 5
+Pixel Cup Soccer Ultimate Edition,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,Perfect 60fps docked,Pocket 5
+Pixel Retro Drift,Playable,Turnip 24.3.0 9v2,Suyu,1.0,"60fps, however crashes randomly",Pocket 5
+Pizza Tower,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,runs good at default settings,Pocket 5
+Pizza Tower,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Planescape Tournament And Icewind Dale,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Ensure update is disabled. Crashes unless played on 1.0,Pocket 5
+Plateup!,Perfect,Qualcomm 0.746.0,Yuzu,7.1.29,"Sometimes the game shows 0.0 fps and freezes on a black loading screen. If this happens, swipe up on the game screen as if you were going to close the process, but don’t close it. Then go back to the game.",Pocket 5
+Poison Control,Playable,Turnip 24.3.0 9v2,Suyu,1.0,I have it set to Nearest Neighbor for the adapting filter and that seems to work great. It goes between 50s and 40s for FPS but it ery playable.,Pocket 5
+Pokemon,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Pokemon Arceus,Perfect,Turnip 23.3.0-devel,Yuzu,1.0,"I’m running firmware 19.0.1 and prod.key 19.0.0 and getting consistent 30fps in handheld mode at 1x. No freezing, etc. like I was getting on other drivers.",Pocket 5
+Pokemon Brilliant Diamond,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,"With Luminiscent Platinum 2.1, use accuracy level high and handheld mode or it will freeze/crash",Pocket 5
+Pokemon Brilliant Diamond,Great,Turnip 24.3.0 9v2,Sudachi,1.3.0,Added the Luminescent Platinum mod as well. Runs at 30FPS. May hang but if you minimize the game and open again it fixes itself,Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 24.1.0 R18,Sudachi,1.0,Performance mode with fan set to auto to keep temps at 52-55 Celsius. Default settings in Sudachi,Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 24.3.0 9v2,Citron,1.0,"Max clocks on, async on,",Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 23.2.0,Sudachi,1.1.1,"Slow in some places, glitchy polygons in places, but plays pretty smoothly",Pocket 5
+Pokemon Legends: Arceus,Perfect,Turnip 24.3.0 9v2,Citron,1.1.1,TV Mode 1x resolution with texture pack,Pocket 5
+Pokemon Legends: Arceus,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Pokemon Mystery Dungeon DX,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Using Uzuy emulator,Pocket 5
+Pokemon Scarlet,Playable,Turnip 24.3.0 9v2,Yuzu,3.0.1,"Intro is ery rough, maybe set resolution to 0.5x just until after you beat Nemona the first time, after that can raise to 0.75x. Runs pretty close to 26-30fps after the opening scene, but occasionally crashes/freezes. Possibly memory leaking is the cause? There are minor graphical glitches throughout. Some slow downs in battles and near pokemon centers. SETTINGS: DEVICE: high performance mode fan: smart GRAPHICS: accuracy: normal resolution: 0.75x vsync mode: FIFO (on) Window Adapting Filter: AMD FidelityFX Super Resolution FSR Sharpnes: 24% Anti-Aliasing Method: FXAA Anisotropic filtering: Default Aspect: 16:9 Disk Shader Cache: enabled Force Maximum Clocks: enabled Use asynchronous shaders: enabled Use reactive flushing: disabled AUDIO: Output engine: cubeb DEBUG: API: ulkan CPU backend: Native Code Execution (NCE) CPU Accuracy: unsafe",Pocket 5
+Pokemon Scarlet,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Pokemon Scarlet,Great,Turnip 25.2.0 R4,Yuzu,3.0.1,Is playable with 1x resolution. With 0.75x Resolution it works great.,Pocket 5
+Pokemon Shining Pearl,Perfect,Turnip 24.3.0 9v2,Yuzu,1.3.0,"Handheld mode; Graphics settings: accuracy: normal; 1x resolution; vsync: off; window adapting filter: AMD FidelityFX SuperResolution; FSR 25%; anisotropic filtering: default; disk shader cache: enabled; force maximum clocks: enabled; use asynchronous shaders: enabled; use reactive flushing: disabled; Audio output engine: cubeb; debug: api: ulkan; CPU backend: dynarmic; cpu accuracy: accurate; cpu debugging: disabled I believe crashes and freezes are caused by having apps running in the background. I had some crashing and freezing at first, but once I started paying attention and making triple sure nothing else was open at all, the game has been running flawlessly, 30fps.",Pocket 5
+Pokemon Shining Pearl,Great,Turnip 24.3.0 9v2,Yuzu,1.3.0,stable 30 fps,Pocket 5
+Pokemon Shining Pearl,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Pokemon Snap,Great,Turnip 24.3.0 9v2,Citron,2.0.1,"1x resolution, AMD FidelityFX filtering, FXAA AA Method, Force Maximum Clock, Use Asynch shaders, 50-60 FPS Stable",Pocket 5
+Pokemon Sword,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Haven’t done any post-game stuff, but you can play from A-Z. If you try to use Y-Comm it will crash",Pocket 5
+Pokemon Sword,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,"Crash when naming char – import a save with char created, available with help from google",Pocket 5
+Pokemon Violet,Great,Turnip 24.3.0 9v2,Eden,0.0.2 Pre Alpha,Runs stready at 0.75 res,Pocket 5
+Pokemon Violet,Great,Turnip 24.3.0 9v2,Sudachi,v1.0.15,"1x is playable 0.75x runs great (<30 fps on cutscenes, <25 fps on fights) Use High Performance mode(smart fan) Force Clock turned on graphics glitchs on some trees and some weird texture on pokemons, it gets the job done",Pocket 5
+Pokemon Violet,Playable,Turnip 25.0.0 R8,Sudachi,3.0.1,"Low FPS (around 15.0fps) makes game slow, experienced one crash redeeming DLC costumes (but they did get into inventory)",Pocket 5
+Pokemon: Let’s Go Eevee!,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,"Stable 30fps, force max clock enabled",Pocket 5
+Pokemon: Let’s Go Pikachu!,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,"30FPS stable, Force Maximum Clocks enabled",Pocket 5
+Pokemon: Shield,Perfect,Turnip 24.3.0 9v2,Citron,1.3.2 + 2DLC,"Adaptive filter: AMD FidelityFX, AA: FXAA, Force Maximum Clock, Use Asynch shaders",Pocket 5
+Pokemon: Sword,Great,Turnip 24.3.0 9v2,Citron,1.3.2,"Locked to 30FPS AMD FidelityFX Async shaders If it crashes after creating your character: Switch the CPU Backend to “JIT” in the Advanced Settings for character-creation until you can save the game, then switch back",Pocket 5
+Pokemon: Sword,Perfect,Turnip 24.3.0 9v2,Citron,1.3.2,"30 FPS 1x…Adaptive filter: AMD FidelityFX, AA: FXAA, Force Maximum Clock, Use Asynch shaders",Pocket 5
+Pokken Tournament Dx,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.3,,Pocket 5
+Portal,Perfect,Turnip 24.3.0 9v2,Citron,1.0.2,,Pocket 5
+Portal,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Portal,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Portal 2,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Perfect 60fps docked, beautiful",Pocket 5
+Post Void,Perfect,Qualcomm 0.746.0,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Postal: Brain Damaged,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Perfect 60 FPS Docked. Change Accuracy level to High,Pocket 5
+Potion Craft,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Nice interactive use of touchscreent too!,Pocket 5
+Power Rangers: Battle For The Grid,Great,Qualcomm 0.746.0,Sudachi,2.9.2 + DLC,"45-60fps FPS Improves with time once all characters, colors and arenas have shaders – sometimes takes a few crashes and resets to get shaders built Occasional crashes, Yuzu has similar performance RP5 – High performance mode 1x Res. Handheld mode Graphics Accuracy Level: High (Can be moved to “Normal” once shaders downloaded – fps improves but not ery stable) Disk shader cache: On CPU Debug: Accurate Audio: cubeb Work in progress: Not much improvement with Force max clock and Asynch shaders on",Pocket 5
+Power Rangers: Battle For The Grid,Great,Turnip 24.3.0 9v2,Sudachi,2.8.0,Occasional crashes but plays great,Pocket 5
+Powerwash Simulator,Great,Qualcomm 805,Sudachi,1.10.0 + 7 DLC,"It locks up when saving. You can get around this by turning off auto save. You can then manual save the game. If it locks up during the save, tap the power button and it should continue (then you should save again)",Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Qualcomm 0.746.0,Citron,1.4.1 + DLC,"Works really good at basically a locked 60 fps. It has a few graphical issues here and there. Play with the qualcomm drivers, because the Turnip ones crashes the game when you open the map!",Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Qualcomm 0.746.0,Citron,1.4.1 + DLC,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Qualcomm 0.746.0,Yuzu,1.4.2,"Turnip 9v2 crashes when openning the map, only qualcomm driver doesnt, gameplay performance wise is the same",Pocket 5
+Prince Of Persia: The Lost Crown,Perfect,Turnip 24.3.0 9v2,Yuzu,1.4.1,Update make the game run smoother,Pocket 5
+Princess Peach: Showtime!,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,"Crashes before first cutscene ends. My Settings: 1x Resolution, High Accuracy, VSync Off, Disk Shader Cache on, Force maximum clocks on, asynchronous shaders off.",Pocket 5
+Princess Peach: Showtime!,Great,Turnip 24.3.0 9v2,Citron,1.0,"Resolution scale 1x (This is important otherwise Peach and Toad’s face will be glitchy), Accuracy High (these seemed to determine whether game had sound or not), Sync Off, Disk shader cache on, For maximum clocks on, asynchronous shaders off, reactive flushing off.",Pocket 5
+Princess Peach: Showtime!,Great,Turnip 24.3.0 9v2,Citron,1.0,Citron 6b9dd40 Video precision : High Resolution : 0.75x Force max frequencies : Yes Still some minor glitches (ex : Peach’s face),Pocket 5
+Prodeus,Great,Qualcomm 805,Citron,1.0.1,Docked mode @ 0.75 resolution fluctuates 40 – 60 fps but doesn’t feel like it stutters. Really nice doom-like shooter,Pocket 5
+Pumpkin Jack,Playable,Turnip 24.3.0 9v2,Yuzu,1.4.4,Gameplay is smooth 30 in handheld mode but there is lots of audio stutter enough that I personally would not play it,Pocket 5
+Punch A Bunch,Playable,Turnip 25.2.0 R4,Yuzu,1.0,"Mostly 60fps, but some stages have major graphical glitches.",Pocket 5
+Quake 2,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Full 60fps – Does not run as well on Turnip/the other emulators,Pocket 5
+R-Type Final 2,Playable,Turnip 24.3.0 9v2,Sudachi,2.0.3,As a 60fps game it is running around 35-50fps. Major Graphical glitches on effects like explosions and lights all the time. Not enjoyable like this.,Pocket 5
+Racine,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Rain World,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+Rainbow Moon,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"Crashed on other emus I tried, playing 60 fps with undocked, high accuracy, 1x reso, mailbox sync, bilinear adapting filter, 25% fsr sharpness",Pocket 5
+Rayman Legends,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Rayman Legends: Definitive Edition,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Runs at a perfect 60fps in docked mode,Pocket 5
+Rebel Transmute,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Red Dead Redemption,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,Looks like its gonna be playable at first but crashes,Pocket 5
+Red Wings American Aces,Great,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Resident Evil 0,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Locked 30fps. Extremely beautiful on RP5.,Pocket 5
+Resident Evil 4,Poor,Turnip 24.3.0 9v2,Citron,1.0,Out of sync intro scene and game runs at 20-25 fps in handheld mode.,Pocket 5
+Resident Evil HD Remake,Great,Turnip 24.3.0 9v2,Citron,1.0,30 fps docked. Noticed some character flickering during certain lighting effects. Just about perfect but had to dock it a little for that.,Pocket 5
+Resident Evil Revelations,Great,Qualcomm 0.746.0,Suyu,1.0.1,Handheld mode firmware 17.0.1 runs great 60fps some minor slowdown here and there,Pocket 5
+Resident Evil Revelations,Playable,Qualcomm 0.746.0,Yuzu,1.0.1,It is playable and mostly plays 60fps handheld mode but there are enough dips and stutters to make it not ery enjoyable,Pocket 5
+Resident Evil Revelations 2,Perfect,Qualcomm 0.746.0,Sudachi,1.0.2,"1x Res. Async Shaders. Run full speed 30 fps. Slight hiccup or stutters when compiling shaders but if you put Async Shaders., The textures would load late but the stutters almost all gone. I have only played for like 15 minutes without any crash. So.. it is perfect so far",Pocket 5
+Retro City Rampage Dx,Perfect,Qualcomm 0.746.0,Yuzu,2.0.0,Perfect 60fps docked,Pocket 5
+Retrorealms,Perfect,Qualcomm 0.746.0,Citron,1.0.892068,"(Plus 4 DLCs) Freezes briefly on title, continues to play after a second or two.",Pocket 5
+Retrorealms,Perfect,Qualcomm 0.746.0,Yuzu,1.0.892068,(Including 4 DLCs) Runs smoothly if it doesn’t freeze on the title screen.,Pocket 5
+Return,Poor,Turnip 24.3.0 9v2,Suyu,1.0,wont launch,Pocket 5
+Return Of The Obra Dinn,Perfect,Qualcomm 0.746.0,Sudachi,1.0.1,"Docked mode, game gets to 60fps most of the time but then gets to 50 fps drops after a while because of the rain",Pocket 5
+Return Of The Obra Dinn,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,"60 fps, Plays Great!",Pocket 5
+Revita,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Riptide Gp Renegade,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Smooth as!,Pocket 5
+Rise Of The Third Power,Great,Turnip 24.3.0 9v2,Citron,1.0.5,"Generally runs perfectly, though I experienced crashes with any other driver",Pocket 5
+Risk Of Rain 2,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Risk Of Rain 2,Great,Turnip 24.3.0 9v2,Sudachi,1.2.2.1 + Survivors of The oid DLC,"This runs between 35-60 fps with the update. With no update it will run 30 fps and no more. The game is totally playable, got past the first boss and it didn’t struggle too much. The times where it drops below 40 fps don’t affect input latency so I didn’t really notice the frame rate affecting gameplay.",Pocket 5
+Risk Of Rain Returns,Perfect,Qualcomm 0.746.0,Citron,1.0.4,Citron is back in development! Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Risk Of Rain Returns,Great,Qualcomm 0.746.0,Yuzu,1.0.5,"Perfect 60fps, but has audio crackle",Pocket 5
+Rival Megagun,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Rival Megagun,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+River City Girls,Perfect,default,Citron,1.0,"When Booting it up on Yuzu, it gets stuck on Loading Shaders, But loading it up on Citron Boots it up immediately with no Problems",Pocket 5
+River City Girls 2,Perfect,default,Yuzu,1.0,Boots up and Runs No Problem,Pocket 5
+Road 96,Perfect,Qualcomm 0.746.0,Yuzu,1.04,Perfect 30fps handheld,Pocket 5
+Rocket League,Perfect,Turnip 24.3.0 9v2,Sudachi,2.0.1,,Pocket 5
+Rogue Heroes: Ruins Of Tasos,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.8,Sometimes crashes when I mess with controller setups mid-game,Pocket 5
+Rogue Legacy 2,Great,Qualcomm 615.50,Sudachi,v1.1.0,"No issues playing, sometimes crashes upon wake from sleep (pause emu before sleep helps most of the time).No data ever lost, though.",Pocket 5
+Rogue Legacy 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.0,,Pocket 5
+Roller Coaster Tycoon 3 Complete,Perfect,Turnip 24.3.0 9v2,Citron,Latest,,Pocket 5
+Rollercoaster Tycoon Classic,Perfect,Turnip 24.3.0 9v2,Sudachi,1.2.174,Runs really well,Pocket 5
+Romance Of The Three Kingdoms 8 : Remake,Poor,Turnip 24.3.0 9v2,Citron,1.0,Cannot boot to main menu. Tried Qualcom and also firmware 18.0 and 17.0,Pocket 5
+Romancing Saga 2: Revenge Of The Seven,Poor,Turnip 24.3.0 9v2,Citron,Latest,Would technically load the game but the graphics glitched out in a way that made everything shine with blinding light,Pocket 5
+Roots Of Pacha,Perfect,Turnip 24.3.0 9v2,Yuzu,1.2.0.5,"Apart from graphical glitches when creating player, game seems to be working fine on 1x docked with locked 60fps.",Pocket 5
+Ruiner,Great,Turnip 24.3.0 9v2,Citron,1.1S15773077ab,"Docked, 0.75x Resolution. Mostly Smooth 30 FPS, occasional dips.",Pocket 5
+Rune Factory 3,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Quick travel warp has massive graphical bugs that take over the entire screen. Everything else has been flawless.,Pocket 5
+Rune Factory 4s,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Text doesn’t appear. Tried with several other emulators and drivers and it’s the same,Pocket 5
+Rune Factory 5,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Some slight graphical glitches,Pocket 5
+Runnyk,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Runnyk,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Rusted Moss,Perfect,Turnip 24.3.0 9v2,Citron,1.29.2,,Pocket 5
+S.T.A.L.K.E.R.: Call Of Prypiat,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.2,Won’t start no matter what settings I play with,Pocket 5
+S.T.A.L.K.E.R.: Clear Sky,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.2,Won’t start no matter what settings I play with,Pocket 5
+S.T.A.L.K.E.R.: Shadow Of Chornobyl,Playable,Turnip 24.3.0 9v2,Citron,1.0,"Crashed the first time, after that it worked fine Citron 0.3 Enable USE_AUTO_STUB setting Force maximum clock speed 25-30FPS @ 1x resolution",Pocket 5
+Saga Frontier 2 Remastered,Perfect,Qualcomm 0.746.0,Citron,1.0.1,No noticeable issues. Docked 1X.,Pocket 5
+Saga Frontier Remastered,Great,Qualcomm 0.746.0,Yuzu,1.0.3,"Perfect 60fps docked, some micro stutters that effect audio",Pocket 5
+Saints Row IV,Playable,Qualcomm 0.746.0,Citron,1.1.0,"System – 110%, Handheld mode, Rest your choice Graphic – 1X, Sync off, Bilinear (important), 25% FSR, AA off, AF Auto, DSC on, Max freq on, ASync shader Off, Urf off Audio – Auto Debug – ulkan, NCE, unsafe, CPU Debugging on, Fastmem on not Final, Work in progress, a bit Dark but still playable",Pocket 5
+Saints Row: The Third – The Full Package,Poor,Qualcomm 0.746.0,Yuzu,1.6.1,"Gameplay is all black in yuzu and sudachi, no launch with 9v2",Pocket 5
+Sakuna: Of Rice And Ruin,Great,Qualcomm 777,Sudachi,1.0.9,"Grapihical glitches and crashes with Turnip 9v2. Plays smoothly with Qualcomm drivers instead, although minor graphical glitches and laggy cutscenes are still there",Pocket 5
+Salt And Sanctuary,Great,Turnip 24.3.0 9v2,Yuzu,1.0.3,"Almost perfect, ery slight dips in some places but super playable",Pocket 5
+Sam & Max: Save The World,Playable,Turnip 24.3.0 9v2,Sudachi,2.0.0,Handheld 0.75x res for 60fps,Pocket 5
+Samurai Jack: Battle Through Time,Perfect,Turnip 24.1.0 R18,Citron,1.0.3,"Citron 0.4 , 1x Native, all default. Runs amazing and looks Beautiful",Pocket 5
+Samurai Shodown,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Sanabi,Great,Qualcomm 0.746.0,Suyu,1.0,40fps docked,Pocket 5
+Savant – Ascent Remix,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Schim,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Put Accuracy Level on high or extreme. 1x Res – 30-35 FPS 0.75x Res – 50-60 FPS,Pocket 5
+Schim,Great,Qualcomm 0.746.0,Yuzu,1.0,Yuzu 278 (dc529a89a) Video precision : high Resolution : 0.75x Force max frequencies : Yes,Pocket 5
+Sclash,Playable,Turnip 24.3.0 9v2,Suyu,1.0,"30fps handheld, some stutters.",Pocket 5
+Scott Pilgrim vs. The World: The Game – Complete Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,,Pocket 5
+ScourgeBringer,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+ScourgeBringer,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Sd Gundam G Generation Genesis,Perfect,Qualcomm 0.746.0,Sudachi,1.0,60fps without problem,Pocket 5
+Sea Of Stars,Poor,Turnip 24.3.0 9v2,Citron,2.0.5,"Performance wise very playable, but there a lot of crashes in the progress of the story, even early on, so you cant really play the game, sadly",Pocket 5
+Sea Of Stars,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Game runs fine. But at some moments, like Elder mist or other places it crashed. All forks have the same problem. Qualcomm driver has missed textures.",Pocket 5
+Sea Of Stars,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.53846,,Pocket 5
+Seers Isle,Perfect,Qualcomm 0.746.0,Yuzu,2.0.1,Perfect 60fps docked,Pocket 5
+Sega Ages – Virtua Racing,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Senran Kagura Peach Ball,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,Works perfectly,Pocket 5
+Senran Kagura Peach Ball,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,Fullspeed (30FPS) throughout. Never encountered any bugs or slowdowns.,Pocket 5
+Serial Cleaner,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Shadow Labyrinth,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Shadowrun Returns,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.0,Used all default settings and it ran at a stable 60fps. Only issue is I had to use the overlay controls to advance one screen during character creation. Turned them off once I got into the game proper.,Pocket 5
+Shantae Half Genie Hero,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Default settings on Sudachi. Graphics at 1x. Device doesn’t even get hot. Temps stay around 42-45 Celsius.,Pocket 5
+Shantae: 1/2 Genie Hero – Ultimate Edition,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Run smoothly but has a long input lag. Makes it quite unplayable for a platformer… Same with Citron, with or without update.",Pocket 5
+Shantae: 1/2 Genie Hero – Ultimate Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Shashingo: Learn Japanese With Photography,Perfect,Turnip 25.2.0 R7,Yuzu,1.0,".75x , synch OFF. Graphics bugs far away but won’t ruin the game or stop from playing.",Pocket 5
+Shin Megami Tensei III Nocturne HD Remaster,Perfect,Turnip 24.1.0 R18,Citron,1.0.3,Citron 0.4 Limit speed 200% for 60fps .75 res Force Clocks Disk Shader Cache Use Reactive Flushing Ran into one crash after name creation (fixed by swiping up technique) played an hour no crashes.,Pocket 5
+Shin Megami Tensei III Nocturne HD Remaster,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.3,Its perfect 30fps in handheld mode but it goes to 0fps black screen every time you enter a new room which can be fixed by sliding up on the app as if you were going to close it then it will unfreeze. Playable but don’t think I would choose this over the ps2 ersion.,Pocket 5
+Shin Megami Tensei Vengeance,Great,Turnip 24.1.0 R18,Citron,1.0,Citron 0.4 30fps with minor dips Possible crashing in new scenes (save frequently) Played up to second battle with pixie Disk cache on Reactive flushing on (fixes graphics) Overdrive on (better fps) .5 res or .75 res .5 res felt like less crashing,Pocket 5
+Shin Megami Tensei Vengeance,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Shin-Chan: Shiro And The Coal Town,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Solid 30fps!,Pocket 5
+Shiren The Wanderer: The Mystery Dungeon Of Serpentcoil Island,Perfect,Qualcomm 0.746.0,Yuzu,2.1.2,Plays wonderfully!,Pocket 5
+Shogun Showdown,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Standard docked, default settings",Pocket 5
+Shovel Knight King Of Cards,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Shovel Knight Shovel Of Hope,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Shovel Knight: Treasure Trove,Perfect,Qualcomm 0.746.0,Yuzu,1.0,For me any Turnips on yuzu makes it crash when you enter the first level,Pocket 5
+Sifu,Playable,Turnip 24.3.0 9v2,Yuzu,1.11_790,"Handheld mode .5x resolution, barely playable gets 25-30fps most of the time but dips down to 15 or even a little lower. Playable if you don’t mind it looking and playing like a 3DS port",Pocket 5
+Signalis,Perfect,Qualcomm 0.746.0,Sudachi,1.4,Docked Mode 30 Fps locked Emulation Quality: High (fixes random crashes),Pocket 5
+Signalis,Perfect,Qualcomm 0.746.0,Yuzu,1.4,Perfect 30fps docked,Pocket 5
+Skater Xl,Perfect,Qualcomm 0.746.0,Yuzu,Updated 1.2.8.7,"1x Native, sync Off , Nearest Neigbor, Force maximum clocks, use Asynchronous Shaders, Use reactive Flushing. Note: The game will crash a couple times as the shaders will adjust and then run smoothly.",Pocket 5
+Skater Xl,Perfect,Qualcomm 0.746.0,Yuzu,Updated 1.2.8.7,"1x Native, sync Off , Nearest Neigbor, Force maximum clocks, use Asynchronous Shaders, Use reactive Flushing. Note: The game will crash a couple times as the shaders will adjust and then run smoothly.",Pocket 5
+Skul: The Hero Slayer,Perfect,Turnip 24.3.0 9v2,Sudachi,1.7.6,,Pocket 5
+Skullgirls: 2nd Encore,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.6,,Pocket 5
+Sky Oceans: Wings For Hire,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Would not boot in yuzu or sudachi with or without update on Turnip 9v2 or Qualcomm 0.746.0,Pocket 5
+Sky Rogue,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Skylanders Imaginators,Poor,Turnip 25.2.0 R11,Sudachi,1.1.1,"The game allows me to play the first level, but when I reach the HUB and I explore it for a bit, the game crashes. After restarting, the game crashes even earlier.",Pocket 5
+Skylanders Imaginators,Poor,Turnip 23.2.0,Citron,1.0,"The game, like how I tested it on Sudachi, allows me to play the first level, but when I reach the HUB and I explore it for a bit, the game crashes. After restarting, the game crashes even earlier.",Pocket 5
+Skylanders Imaginators,Poor,Turnip 25.2.0 R11,Citron,1.1.1,The game doesn’t get past the character selection screen because of a black screen covering everything,Pocket 5
+Skyrim,Playable,Turnip 24.3.0 9v2,Sudachi,1.1.392.3925134,"Plays fine, consistent 30fps at 0.75 res. Occasional crashes. Flickering lighting issue in dungeons. Worked around it somewhat by installing Enhanced Lights mod which makes flickering less intense, but also makes dungeons too dark in some areas. Mods can be installed by putting .esp/.esm files in sudachi/files/sdmc/atmosphere/contents/01000A10041EA000/romfs/Data. Edit Skyrim.ini folder in romfs folder. Add one if not there from Nexus mods Skyrim Switch Toolkit.",Pocket 5
+Slay The Spire,Perfect,Qualcomm 0.746.0,Yuzu,2.2.1,,Pocket 5
+Slay The Spire,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Slay The Spire,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Slay The Spire,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Slayers X: Terminal Aftermath: Vengance Of The Slayer,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Slime 3k – Rise Against Despot,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Sudachi 1.0.11 (99775b8) All default parameters,Pocket 5
+Slime Rancher,Poor,Turnip 24.3.0 9v2,Eden,1.0,Will crash before game file creation. Could not start new game.,Pocket 5
+Sludge Life,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Freezes a lot with yuzu and sudachi with both drivers,Pocket 5
+Snake Pass,Great,Turnip 24.3.0 9v2,Yuzu,1.4,"25fps docked, isuals are broken in handheld mode",Pocket 5
+Sniper Elite 3: Ultimate Edition,Poor,Turnip 25.2.0 R4,Yuzu,Both base and latest update crash after some time,Get perhaps 60 seconds of runtime then crashes,Pocket 5
+Sniper Elite 4,Great,Qualcomm 0.746.0,Yuzu,"1.0.3, 13 DLC",Seems to be mostly perfect 30 in handheld,Pocket 5
+Sniper Elite 4,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,game menu has some weird glitching but the game is playable,Pocket 5
+Snk Heroines Tag Team Frenzy,Poor,Turnip 24.3.0 9v2,Citron,1.0,Launches but characters are not visible. Tried Yuzu and Sudachi as well,Pocket 5
+SNK vs. Capcom: SVC Chaos,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Snowboarding The Next Phase,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.0.1,Yuzu 278 (dc529a89a) All default parameters,Pocket 5
+Solar Ash,Great,Turnip 25.0.0 R5,Suyu,1.0,"20-25fps, runs good and looks good",Pocket 5
+Sonic Frontiers,Poor,Turnip 24.3.0 9v2,Citron,1.0,Crashes after completing the first level. People need to play a little further before listing a game as playable,Pocket 5
+Sonic Frontiers,Great,Turnip 24.3.0 9v2,Citron,1.0,"0.75x, force maximum clocks, use asynchronous shaders",Pocket 5
+Sonic Generations,Great,Turnip 24.3.0 9v2,Citron,1.01,"Works with 60fps mod, make sure to place it in the right folder, only Sonic generations part not shadow generations",Pocket 5
+Sonic Mania,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Sonic Origins,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Sonic Superstars,Perfect,Qualcomm 0.746.0,Sudachi,1.1.8,"Handheld mode, accuracy high, NCE/Qualcomm",Pocket 5
+Sonic Superstars,Great,Qualcomm 0.746.0,Suyu,1.0,,Pocket 5
+Sonic Wings Reunion,Poor,Qualcomm 0.746.0,Citron,1.0,crash and freeze,Pocket 5
+Sonic X Shadow Generations,Great,Turnip 24.1.0 R18,Citron,1.0,.75 resolution,Pocket 5
+Sonic X Shadow Generations,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Audio Output: cubeb to correct audio issues,Pocket 5
+Sonic X Shadow Generations,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+South Park: The Fractured Butt Whole,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,doesn´t render graphics. same for qualcom drivers,Pocket 5
+South Park: The Stick Of Truth,Perfect,Turnip 24.3.0 9v2,Yuzu,1.01,"Mode: Docked, Graphics Accuracy level: High",Pocket 5
+South Park: The Stick Of Truth,Perfect,Turnip 24.3.0 9v2,Citron,1.01,,Pocket 5
+Speed Overflow,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Speed Overflow,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Spelunky,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.5,"Played through the tutorial caves with 0 issues, 60fps.",Pocket 5
+Spelunky 2,Perfect,Turnip 24.3.0 9v2,Citron,1.27.0,"Debug > CPU Backend > Dynarmic …otherwise game doesn’t launch at all. Despite Dynarmic saying it is slow, it was running at 60fps.",Pocket 5
+Spelunky 2,Great,Turnip 24.3.0 9v2,Yuzu,1.28,"Before installing this driver, the game was unplayable, but it works great after the install.",Pocket 5
+Spintires: Mud Runner (Mudrunner – American Wilds),Great,Turnip 24.3.0 9v2,Yuzu,v3.6,Yuzu 278 (dc529a89a) CPU debugging : Yes Resolution : 0.75x Force max frequencies : Yes Cashes quite often,Pocket 5
+Spirit Hunter: Death Mark 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.04,"plays perfectly, default settings",Pocket 5
+Splatoon 3,Great,Turnip 24.3.0 9v2,Citron,DLC + 9.1.0,Occasional dips in fps but is surprisingly stable,Pocket 5
+Spongebob Squarepants: The Cosmic Shake,Playable,Turnip 24.3.0 9v2,Yuzu,1.0.7,Handheld mode High performance Accuracy Level high 1x = 20-25fps 0.75x = 25-30fps Disk shader on Async shader on Audio cubeb Bloom glitch is easily fixable by having the accuracy level on high so its pretty much mandatory. Can crash during cutscene so I suggest to just skip all of it,Pocket 5
+Spyro Reignited Trilogy,Great,Turnip 25.2.0 R1,Yuzu,1.0,"Set Accuracy level to High, .75x Res, Asynchronous shaders on, Sharpness 25% or higher. Stable 30fps",Pocket 5
+Spyro Reignited Trilogy,Great,BioSensor MK1,Citron,1.0.1,Citron Optimized ersion (yes it runs better for this game) Docked // Accuracy to High for the color issue. Resolution 0.75 // -sync : immediate Disk shader cache: enabled Force maximum clocks (Aderno only): enabled Use asynchronous shaders: enabled Output engine: cubeb,Pocket 5
+Spyro Reignited Trilogy,Great,Turnip 25.0.0 R5,Citron,1.01,"Docked Mode, Graphics Accuracy: High, Resolution: 0.75X, Sync mode: Immediate (Off), Audio: cubeb Prerendered cutscenes have no audio. Minor slowdown in parts.",Pocket 5
+Stacklands,Great,Qualcomm 0.746.0,Citron,1.0,Could only get to 50-60% full speed,Pocket 5
+Stacklands,Perfect,Qualcomm 0.746.0,Sudachi,1.4.0.2,I beat the Demon Lord but have not played the expansion stuff yet. It plays perfectly but turn the fan on because the system starts getting hot the larger your board gets.,Pocket 5
+Star Ocean: First Departure R,Perfect,Qualcomm 0.746.0,Citron,1.0,Crashes during the first battle when using Turnips. Works flawlessly with standard. I have played about 20 minutes.,Pocket 5
+Star Ocean: The Second Story R,Perfect,Turnip 24.3.0 9v2,Sudachi,Latest,Crashes occasionally (after around an hour of straight gameplay) for seemingly no reason. Game autosaves enough that it’s not a real issue.,Pocket 5
+Star Ocean: The Second Story R,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1 + DLC,"Stable 30FPS in docked mode, cubeb audio engine, RP5 on standard performance mode",Pocket 5
+Star Of Providence,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 60 FPS Docked,Pocket 5
+Star Overdrive,Poor,Qualcomm 0.746.0,Citron,1.0.7,"Cutscenes load fine, but there is constant texture flickering during gameplay.",Pocket 5
+Star Wars – Knights Of The Old Republic,Great,Turnip 24.3.0 9v2,Yuzu,Base or Update 1.0.1,Seemed to work great. Only played into the main story a couple minutes,Pocket 5
+Star Wars – Knights Of The Old Republic II,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Seems to run great. Played through the first bit of the game.,Pocket 5
+Star Wars The Force Unleashed,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"The game launches and runs fine, but the pause menu options are transparent once you get into the game, making it quite difficult to navigate. Could play, if you’re determined or desperate.",Pocket 5
+Star Wars: Dark Forces,Perfect,Turnip 25.2.0 R4,Yuzu,1.0,,Pocket 5
+Stardew Valley,Perfect,Qualcomm 0.746.0,Citron,1.5.4.2,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Stardew Valley,Perfect,Qualcomm 0.746.0,Citron,1.6.9.37,Perfect 60 fps,Pocket 5
+Stardew Valley,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Stardew Valley,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Stardew Valley,Playable,Turnip 24.3.0 9v2,Yuzu,1.5.4.2,Controls are very painstakingly hard to go through,Pocket 5
+Steamworld Build,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Steamworld Dig,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.12.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Steamworld Heist II,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Steins Gate: My Darlings Embrace,Perfect,Turnip 24.3.0 9v2,Citron,1.0,60fps,Pocket 5
+Steins;Gate Elite,Perfect,Qualcomm 0.746.0,Yuzu,1.0.2E,Perfect 60fps docked,Pocket 5
+Stella Of The End,Perfect,Qualcomm 0.746.0,Sudachi,1.0,It just works,Pocket 5
+Story Of Seasons: Friends Of Mineral Town,Perfect,Turnip 25.2.0 R11,Sudachi,1.1.7,Looks amazing too,Pocket 5
+Story Of Seasons: Pioneers Of Olive Town,Great,Turnip 24.3.0 9v2,Sudachi,Newest game update and newest update of Sudachi,"The newest sudachi update resolved issues with crashing. Using the 4gb of swap memory as well. It runs pretty consistently from 50-60fps. I normally run it on performance mode, but high performance gives it a couple extra frames per second.",Pocket 5
+Stranger Things,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,works great. would not load on standard driver. Only tried Yuzu.,Pocket 5
+Stray,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Handheld mode, resolution 0.75, CPU backend to dynamic slow. Some crashes and slowdown, but most of it runs at 29fps",Pocket 5
+Streets Of Rage 4,Perfect,Qualcomm 805,Citron,1.0.9,Tried default and Turnip but it glitches and you miss the “story ideos” found the latest Qualcomm fixes that.,Pocket 5
+Streets Of Rage 4,Perfect,Qualcomm 0.746.0,Sudachi,1.0.9,60 fps – Works perfectly with default settings,Pocket 5
+Streets Of Rogue,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect. I played 1 playthrough with soldier and got to the last floor without any problem.,Pocket 5
+Strike Suit Zero,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,Start in handheld then switch to docked,Pocket 5
+Subnautica,Perfect,Turnip 24.3.0 9v2,Yuzu,1.21.71113,Stable 30 fps in performance mode handheld 1x res,Pocket 5
+Subnautica,Perfect,Turnip 24.3.0 9v2,Yuzu,1.21.71113,Stable 30fps in docked mode,Pocket 5
+Suika Game,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Runs perfect 60FPS, even with default driver. Performance mode",Pocket 5
+Suika Game,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Suikoden I & Ii Hd Remaster: Gate Rune And Dunan Unification Wars,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,Game hits a black screen once you enter Kyaro Town in Suikoden II.,Pocket 5
+Super Bomberman R,Perfect,Turnip 24.1.0 R18,Citron,1.0,,Pocket 5
+Super Bomberman R 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.3.1,,Pocket 5
+Super Lone Survivor,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Seems to run perfectly,Pocket 5
+Super Mario 3d All Stars,Perfect,Qualcomm 0.746.0,Sudachi,1.0,Works flawlessly with a consistent 60 fps.,Pocket 5
+Super Mario 3D All Stars,Poor,Qualcomm 0.746.0,Yuzu,1.1.1,"Yuzu not playable with either Qualcomm 0.746.0 or Mesa Turnip 25.0.0 R5 (low fps and sound cracks). Not playable with Sudachi AT ALL, game crashes with Qualcomm 0.746.0 + ulkan 1.4.303",Pocket 5
+Super Mario 3D World + Bowser’s Fury,Perfect,Turnip 24.3.0 9v2,Citron,1.1.0,"Citron is back in development! Settings: Docked 45 – 50 FPS, Handheld 60 FPS 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.",Pocket 5
+Super Mario 3D World + Bowser’s Fury,Perfect,Turnip 24.3.0 9v2,Suyu,1.1.0,Handheld mode,Pocket 5
+Super Mario 3D World + Bowser’s Fury,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Super Mario Bros. Wonder,Playable,Turnip 24.3.0 9v2,Citron,1.01 + FPS mod,"Citron 0.5 + Turnip 9v2 or 24.1.0 R18 fix The game will freeze and restart the device at times, sometimes even corrupting the save games or configuration of the emulator. Much less issues now with Citron 0.5 but perhaps 7 levels are still problematic. Consider using Syncthing to save your game progress elsewhere and remove some of the frustration. If the issue with restart occurs, change CPU + Graphics accuracy to high, revert to default qualcomm driver and disable shader cache. Finish the level and revert config.",Pocket 5
+Super Mario Bros. Wonder,Great,BioSensor MK2,Yuzu,1.0,"Tested on standard performance (RP5), ery tiny slowdowns, Build d590cfb9d, firmware 18.1.0 (same for prod/keys), handheld mode, 1x resolution, disk cache on, basically all on default. It was the only emu and driver combination that didn’t crashed and rebooted the RP5/reset the emu after a second load, qualcomm drivers worked (didn’t reboot on second load) but was slow and gave graphic glitches. Same config on other ersions of yuzu, sudachi or citron, reboots the device. Decreasing the resolution, putting RP5 on high performance, or activating “force maximum clocks” might make it perfect. Update 1.0.1 doesn’t load the game, black screen.",Pocket 5
+Super Mario Bros. Wonder,Perfect,Turnip 24.3.0 9v2,Citron,1.0.1,"This setup stopped the issue where loading an existing save would hard crash the RP5 (two users confirmed.) Citron builds e2808ec and c718cc2 work (other ersions might work too.) Change audio engine to cubeb to stop stuttering. Undocked performance is 60fps, docked hovers around ~50fps. Optional fps stabilizing mod acquired here: https://github.com/theboy181/switch-ptchtxt-mods/blob/main/Super%20Mario%20Bros.%20Wonder/%5B010015100B514000%5D/v1.0.0/Stabilize%20FPS.rar",Pocket 5
+Super Mario Bros. Wonder,Perfect,Turnip 23.2.0,Yuzu,1.0,Use Turnip 23.2.0-devel to prevent crashes with shader cache enabled and Stabilize FPS mod from https://github.com/theboy181/switch-ptchtxt-mods/tree/main/Super%20Mario%20Bros.%20Wonder/%5B010015100B514000%5D/v1.0.0 to improve performance.,Pocket 5
+Super Mario Bros. Wonder,Great,Qualcomm 0.746.0,Yuzu,1.0,Emulator Uzuy Edge 0.0.5-13,Pocket 5
+Super Mario Bros. Wonder,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Super Mario Bros. Wonder,Great,Turnip 24.3.0 9v2,Yuzu,1.0,skip animations to avoid crashes,Pocket 5
+Super Mario Maker 2,Perfect,Turnip 24.3.0 9v2,Yuzu,3.0.3,"Consistent 60FPS! Had some rare audio crackling but this was fixed by switching audio engine to cubeb. Shame the app doesn’t support online, because Open Course World would have been good for this.",Pocket 5
+Super Mario Odyssey,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"You can beat the game, but here are some issues that I found: 1. Seaside Kingdoms boss will crash the game due to lag 2. Wooden Kingdom S Spewart fight has the same fate, but other Spewart fights (luncheon) seem to be A-OK 3. Cutscene music WILL GET CHOPPY 4. USE 0.75",Pocket 5
+Super Mario Odyssey,Great,Turnip 24.3.0 9v2,Citron,1.0.3,"Very Playable, use .75 resolution, plays at 60 fps to high 50s unless ery zoomed out at a large zone. Then fps drops to mid 40s. Overall a great play!",Pocket 5
+Super Mario Odyssey,Great,Turnip 24.3.0 9v2,Sudachi,1.3.0,"Almost perfect, above 50 FPS, ery few micro stutters",Pocket 5
+Super Mario Odyssey,Perfect,Turnip 25.2.0 R11,Eden,1.0,"Limitar porcentaje emulación: 85% Docked mode = On Resolution: 0,5x Vsync = Off Two hous playing without problems",Pocket 5
+Super Mario Party Jamboree,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Crashed during loading screen with both eden and sudachi,Pocket 5
+Super Mario RPG,Perfect,Qualcomm 0.746.0,Citron,1.0.1,Citron is back in development! 30-60 FPS Settings: Docked 1x Res.(Might Have More Stable Performance On Handheld) Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Super Mario RPG,Great,Qualcomm 0.746.0,Yuzu,1.0,"If your audio is crackling, change audio setting to ‘oboe’ instead of ‘Auto’. Only minor graphical issues happen when opening the item quick menu or saving progress (thumbnails), but nothing game-breaking. Smooth 60FPS on Performance mode.",Pocket 5
+Super Mario RPG,Great,Qualcomm 0.746.0,Yuzu,1.0,Crashes after the Main menu on the Turnips I tested (9v2 / 25.0.0 rev3). Might sometimes dip to 40/50fps,Pocket 5
+Super Mario Wonder,Great,Turnip 24.3.0 9v2,Yuzu,1.0,"Almost perfect, weird graphical glitches in overworld",Pocket 5
+Super Meat Boy,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Work perfectly with default settings,Pocket 5
+Super Monkey Ball Banana Rumble,Great,Qualcomm 0.746.0,Suyu,2,"Accuracy level = HIGH, or else menus will crash a lot. Undocked stays around 50-60fps and dropping to ~40 with certain menus on screen. Docked mode isn’t recommended; gameplay performance drops to about ~30fps.",Pocket 5
+Super Monkey Ball Banana Rumble,Playable,Qualcomm 0.746.0,Suyu,2,"Game has plenty of freezes when interacting with certain menus which can be strangely overcome by swiping up into the recent apps iew and then immediately returning to the game. Sometimes you have to do this consistently to make it through a menu. Once you’re in a stage there’s only rare freezes which can be fixed with the aforementioned trick. When not frozen, the game has solid 60fps in singleplayer. Must use stock driver as Turnip (9v2) crashes when trying to load any 3D content.",Pocket 5
+Super Robot Wars,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Super Smash Bros Ultimate,Perfect,Qualcomm 819.1,Yuzu,1.0,,Pocket 5
+Super Smash Bros Ultimate,Perfect,Turnip 25.2.0 R7,Yuzu,1.0,,Pocket 5
+Super Smash Bros Ultimate,Perfect,Qualcomm 682,Yuzu,1.0,Disk shader cache enabled Force maximum clocks enabled Use asynchronous shaders enabled (light stutters but gameplay is 60 fps),Pocket 5
+Super Woden GP 2,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.5,Does not boot,Pocket 5
+Superhot,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Emulator Uzuy Edge 0.0.5-13,Pocket 5
+Sword Of The Vagrant,Poor,Turnip 24.3.0 9v2,Citron,1.0,"Not playable on Sudachi, or Yuzu either",Pocket 5
+Symphonia,Perfect,Qualcomm 0.746.0,Citron,1.0,,Pocket 5
+Tactics Ogre Reborn,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Runs between 29 and 30 FPS perfectly.,Pocket 5
+Tales Of Vesperia,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.2,"Force Maximum Clocks. Resolution: .75x Audio Driver: Cubeb(required for audio to not glitch out. Game may crash once in a while, so save often.",Pocket 5
+Teenage Mutant Ninja Turtles: Mutants Unleashed,Poor,Turnip 24.3.0 9v2,Sudachi,1.0,Tried with sudachi and citron and combination of drivers. Maybe a preloaded shader cache patch will help.,Pocket 5
+Teenage Mutant Ninja Turtles: Shredders Revenge,Poor,Turnip 24.3.0 9v2,Eden,1.0,"No matter the driver, no matter the update, no matter the dlc, this game doesnt boot on Eden.",Pocket 5
+Teenage Mutant Ninja Turtles: Shredders Revenge,Great,Turnip 25.2.0 R4,Yuzu,1.0,Main gameplay is perfect but the intro cutscene and audio is stuttery,Pocket 5
+Teenage Mutant Ninja Turtles: Splintered Fate,Perfect,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.9.0,"It works perfectly, between 50-60 FPS",Pocket 5
+Teenage Mutant Ninja Turtles: Splintered Fate,Playable,Qualcomm 0.746.0,Yuzu,1.0,gets better as you play,Pocket 5
+Teenage Mutant Ninja Turtles: Splintered Fate,Playable,Qualcomm 0.746.0,Sudachi,1.0,(works with R9v2 but seems happier with System),Pocket 5
+Tennis In The Face,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Terminal Velocity,Perfect,Turnip 24.3.0 9v2,Yuzu,v1.2.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Terraria,Perfect,Qualcomm 0.746.0,Citron,4.4.11,Citron is back in development! 60 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On Everything Else Default.,Pocket 5
+Terraria,Perfect,Qualcomm 0.746.0,Yuzu,4.4.11,Perfect 60fps docked,Pocket 5
+Terraria,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Teslagrad,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Tetris 99,Poor,Turnip 24.3.0 9v2,Suyu,2.1.0,The tetris pieces are invisible.,Pocket 5
+Tetris Effect,Great,Turnip 24.3.0 9v2,Citron,1.0,Resolution set to 0.75x. 30-60FPS depending on the current background.,Pocket 5
+Thank Goodness You’re Here!,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+The Binding Of Isaac: Afterbirth+,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,the game runs smoothly no change in drivers since its a ery lightweight game.,Pocket 5
+The Binding Of Isaac: Repentance,Perfect,Turnip 24.3.0 9v2,Sudachi,1.7.2,Change CPU backend to dynamic to eliminate graphical glitches.,Pocket 5
+The Binding Of Isaac: Repentance,Great,Turnip 24.3.0 9v2,Citron,1.7.9b,"Disable sync to fix a texture glitch. 55-60 fps on average, wouldn’t really notice it without the fps counter.",Pocket 5
+The Binding Of Isaac: Repentance,Great,Turnip 24.3.0 9v2,Sudachi,1.7.2,The frames do dip slightly at times however it is only ever so slightly slower than the original on switch which also has slowdown during busy moments (rerolling 100s of items etc.),Pocket 5
+The Case Of The Golden Idol,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Qualcomm 0.746.0,Yuzu,1.1.392.3925134,,Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Qualcomm 0.746.0,Yuzu,1.1.392.3925134,"Tried with Turnip but after some Gameplay it would exit, found the default gpu driver works fine and so far no exits.",Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Qualcomm 0.746.0,Yuzu,1.1.392.3925134,"Tried with Turnip but after some Gameplay it would exit, found the default gpu driver works fine and so far no exits.",Pocket 5
+The Elder Scrolls: Skyrim,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Default settings, otherwise it crashes, handheld mode, 30fps at start",Pocket 5
+The Flame In The Flood,Great,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+The Hong Kong Massacre,Playable,Qualcomm 0.746.0,Suyu,1.0,25fps docked,Pocket 5
+The House In Fata Morgana: Dreams Of The Revenants Edition,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+The House Of The Dead Remake,Poor,Turnip 24.3.0 9v2,Sudachi,1.0.1,Game can be started but will crash once the first enemy attacks,Pocket 5
+The Hundred Line: Last Defense Academy,Great,Mr. Purple T18,Sudachi,1.0.3,"Definitely not perfect but runs at a pretty consistent 30fps. Crashes do occur, so save often! I tried other drivers, but it _feels_ like there may be better options, although this one is pretty stable overall.",Pocket 5
+The King of Fighters XIII: Global Match,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.3,Runs smooth at 60fps docked,Pocket 5
+The King of Fighters XIII: Global Match,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+The Last Campfire,Perfect,Turnip 24.3.0 9v2,Citron,1.0,,Pocket 5
+The Legend Of Heroes: Trails From Zero,Poor,Qualcomm 0.746.0,Sudachi,1.0,"Freezes upon starting a New Game, also freezes occasionally in the options part of the title screen.",Pocket 5
+The Legend Of Heroes: Trails From Zero,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+The Legend Of Heroes: Trails To Azure,Poor,Turnip 24.3.0 9v2,Sudachi,1.1.17,It gets to menu but freezes soon after hitting new game. No idea if loading a save works. No change in setting or driver solved it.,Pocket 5
+The Legend Of Heroes: Trials Through Daybreak,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,"30FPS gameplay, runs smooth all the way through first battle, some dips to high 20s in cutscenes.",Pocket 5
+The Legend Of Zelda: Breath Of The Wild,Great,Turnip 24.3.4-Unified (@Mr_Purple_666),Citron,1.6.0,Very stable with the 1.6.0 BOTW update. Hovers around 26-30fps at 1x res and consistently 28-30fps at .75 res.,Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 24.1.0 R18,Citron,1.6.0,"At 1× resolution I’m getting about 28 FPS with minor drops; at 0.75× it’s around 30 FPS, falling to 28 FPS in heavily loaded scenes. In dungeons there are rendering issues – the image seems to split – but you can still get through.",Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 23.2.0,Yuzu,1.6.0,28 – 30 FPS Avg. Handheld Mode Graphics: Resolution – 0.75x (1.0x loses about 5-8 FPS and creates slowdown) Adapting Filter – Bilinear (AMD FidelityFX loses 2-3 FPS) Anti-aliasing – FXAA Disk Shader Cache – On Force Maximum Clocks – On Use Asynchronous Shaders – On,Pocket 5
+The Legend of Zelda: Breath of the Wild,Playable,Turnip 24.3.0 9v2,Yuzu,1.14,,Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 24.0.0-devel R12,Citron,1.6.0 + DLC 1+2,"System – 100% max Speed, Handheld mode Graphic – 1X, Sync FIFO on, Scaleforce, 25% FSR, AA off, AF 16x, DSC on, Max freq on, ASync Shader on Audio – cubeb Debug – ulkan, NCE, unsafe, CPU Debugging On, Fastmem on GPU-Driver – Mesa Turnip 24.0.0-devel – R12 + Aggressive mode not Final, Work in progress, still ghosting in shrines",Pocket 5
+The Legend of Zelda: Breath of the Wild,Perfect,Turnip 24.1.0 R17,Yuzu,1.6.0,“docked mode 0.75 x AMD fidelity FX FXAA disk shader cache force maximum clocks use asynchronous shaders on Shrine & water fixed works perfectly for me in the Shrine”,Pocket 5
+The Legend of Zelda: Breath of the Wild,Perfect,Turnip 24.1.0 R17,Yuzu,1.6.0,docked mode 1x AMD fidelity FX FXAA disk shader cache force maximum clocks use asynchronous shaders on Shrine & water fixed works perfectly for me in the Shrine,Pocket 5
+The Legend of Zelda: Breath of the Wild,Great,Turnip 24.3.0 9v2,Sudachi,1.6,"In shrines, I experienced some data moshing effects and some crashes but that all happened while fiddling with the settings so It needs more testing. Otherwise, the game is basically locked at 30 fps on the great plateau",Pocket 5
+The Legend of Zelda: Breath of the Wild,Playable,Turnip 24.3.0 9v2,Yuzu,1.6.0,Crashes after some playing time. Mostly when speak to NPC. I wish some one can help with that. Also some graphical issues inside sanctuarys,Pocket 5
+The Legend of Zelda: Breath of the Wild,Perfect,Turnip 24.3.0 9v2,Yuzu,1.5.0,BOTW SETTINGS (getting 25-30fps) SYSTEM Limit speed: enabled Limit speed percent: 100% Docked mode: disabled Emulated region: USA Custom etc: disabled GPU Turnips R9v2 GRAPHICS Accuracy level: normal Resolution: 2x 1440p/2160p) (slow) Vsync mode: FIFO (on) Window adapting filter: AMD FidelityFX super resolution FSR sharpness: 25% Anti-aliasing method: FXAA Anoscopic filtering: default Aspect ratio: Default (16:9) Disk shader cache: enabled Force maximum clocks (Aderno only): enabled Use asynchronous shaders: enabled Use reactive flushing: disabled DEBUG API: ulkan CPU: Native code execution (NCE) CPU accuracy: unsafe CPU Debugging: Disabled AUDIO: Output engine: cubeb DLC 3.0 UPDATE 1.5.0,Pocket 5
+The Legend Of Zelda: Echoes Of Wisdom,Playable,Qualcomm 0.746.0,Citron,1.0.1,"Very playable bordering great using handheld mode, RP5 in Performance, graphics accuracy High, sync Immediate, window adapting filter FSR, disk shader cache/max clocks/async shaders all turned on. The mod “Remove DOF/BLUR Proper” (https://gamebanana.com/mods/544570) is a must. 20 FPS in new scenes and when in combat game is semi slow motion. In open world/cutscenes/dungeons 30-45 FPS. Played as far as entering the first rift.",Pocket 5
+The Legend Of Zelda: Echoes Of Wisdom,Great,GPU 0.746.0 Qualcomm,Sudachi,1.0.2,Needs a mod for the blur and unlocking fps. Some graphical glitches. Run mailbox mandatory for now. Super fun!,Pocket 5
+The Legend Of Zelda: Skyward Sword HD,Perfect,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+The Legend Of Zelda: Skyward Sword HD,Perfect,Turnip 23.3.0-devel,Yuzu,1.0,"If you have crashing issues, use this driver. Game hasn’t dropped below 60fps once yet, and I have completed the first 3 dungeons.",Pocket 5
+The Legend Of Zelda: Skyward Sword HD,Perfect,Turnip 24.3.0 9v2,Suyu,1.0.1,"Sudachi didn’t work, have to use Suyu",Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Great,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Playable,Qualcomm 0.746.0,Citron,1.2.1,"System – 100% max Speed, Docked Mode(important), Rest your choice Graphic – Extreme, 1X, Sync Off, nearest neighbors, 25% FSR, AA Off, AF standart, 16:9, DSC On, Max freq On, ASync Shader On, URF Off Audio – cubeb Debug – ulkan, NCE, unsafe, CPU Debugging On, Fastmem On not Final, Work in progress",Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Playable,Qualcomm 0.746.0,Suyu,1.0,Some lighting glitches but 25-30 fps consistently,Pocket 5
+The Messenger,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+The Messenger,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+The Messenger,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+The Outer Worlds,Great,Turnip 24.3.0 9v2,Sudachi,1.0,runs at 25 to 30 fps. Crashes a few times in the beginning but able to restart and continue playing from saved state. so save frequently,Pocket 5
+The Outer Worlds,Poor,Turnip 24.3.0 9v2,Citron,Update +2DLC,"Framerate seems ok at .75x but big graphical glitching, someone could potentially tweak it to be playable",Pocket 5
+The Pathless,Poor,Turnip 24.3.0 9v2,Citron,1.0,Black screen and crash during first cinematic,Pocket 5
+The Pedestrian,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Perfect 30 FPS,Pocket 5
+The Plucky Squire,Playable,Turnip 24.3.0 9v2,Citron,1.0.4,"FAR from perfect – playable but not an enjoyable experience. Works around 30 FPS on the 2D sections, but an hour in the game jumps to 3D and the framerate tanks to 10-20 FPS.",Pocket 5
+The Plucky Squire,Great,Turnip 24.3.0 9v2,Yuzu,1.0.5,"DISCLAIMER: I did not get to the 3D part yet, the 2d part plays perfect in handheld mode and looks stunning",Pocket 5
+The Settlers: New Allies,Poor,Qualcomm 0.746.0,Yuzu,1.0.5,Game not launching,Pocket 5
+The Smurfs 2 : The Prisoner Of The Green Stone,Perfect,Turnip 24.3.0 9v2,Yuzu,1.03.03,Audio – cubeb. Asynch shaders on Plays well 30fps locked – Haven’t tried docked mode,Pocket 5
+The Smurfs Mission Villeaf,Perfect,Qualcomm 0.746.0,Yuzu,1.0.17.8,Perfect 30fps docked,Pocket 5
+The Stanley Parable: Ultra Deluxe,Great,Qualcomm 0.746.0,Yuzu,1.04,"50-60fps docked, feels great",Pocket 5
+The Tale Of Bistun,Poor,Turnip 24.3.0 9v2,Citron,1.0,"Crashes after the initial start ideo, tried with other emulators as well, same result",Pocket 5
+The Thing Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+The Wandering Village,Perfect,Qualcomm 0.746.0,Yuzu,1.0,60 fps,Pocket 5
+The Wardrobe: Even Better Edition,Perfect,Qualcomm 0.746.0,Citron,1.0,"Perfect 60fps with stock driver, won’t boot with Turnips.",Pocket 5
+The Wild At Heart,Perfect,Qualcomm 0.746.0,Yuzu,1.1.5,"Perfect 60fps docked, looks great",Pocket 5
+The Witcher 3: Wild Hunt,Playable,Turnip 24.3.0 9v2,Citron,Version 3.7,".5x on latest citron gets you 12-25fps, playable if you are extremely desperate. Seems promising for future citron builds.",Pocket 5
+The World Ends With You: Final Remix,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Choppy during animated cutscenes but plays great,Pocket 5
+There Is No Game,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.4,,Pocket 5
+Thief Simulator,Perfect,Qualcomm 0.746.0,Sudachi,1.4.0,minor texture error and occasional crash,Pocket 5
+This War Of Mine Complete Edition,Great,Turnip 24.3.0 9v2,Yuzu,1.0.4,50-60fps handheld,Pocket 5
+Thronefall,Perfect,Qualcomm 0.746.0,Citron,1.94,Almost Perfect 60 FPS Docked (FPS sits around 45-60 but you can’t really tell and it stays smooth with not FPS drops.),Pocket 5
+Thunder Ray,Perfect,Qualcomm 0.746.0,Yuzu,1.0,"Ran perfectly fine in dock/handheld modes at 30fps. One possible crash, unrepeatable.",Pocket 5
+Titan Quest,Perfect,Turnip 25.2.0 R9,Yuzu,1.0,720/1080p Docked Mode,Pocket 5
+To The Moon,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked,Pocket 5
+Toem,Perfect,Qualcomm 0.746.0,Yuzu,3,"Flawless 60fps docked, looks great on oled",Pocket 5
+Toki,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Little audio stutter on starting cinematics. But game maintains 60 fps,Pocket 5
+Toki,Perfect,Turnip 25.0.0 R5,Yuzu,1.0,"60fps flawless, played first 2 stages. Standard settings",Pocket 5
+Tokyo Mirage Sessions #Fe Encore,Great,Qualcomm 0.746.0,Yuzu,1.0,"Mostly 30fps handheld, some dips down to 20 and minor audio stutter",Pocket 5
+Tomb Raider I-III Remastered,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,Perfect 60fps docked,Pocket 5
+Tomb Raider I-III Remastered,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"Runs fine, but the colors are oversaturated and ery dark in both PS1 and Remastered modes, to the point where some areas are almost impossible to see",Pocket 5
+Tonight We Riot,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Tony Hawk’s Pro Skater 1+2,Great,Turnip 23.3.0-devel,Sudachi,1.0,"Capped at 30fps, runs between 25-30fps most of the time except for more wide/open levels which occasionally drop to around 20fps at points. Graphical glitches are fairly common, but aren’t too distracting. No problems otherwise.",Pocket 5
+Tony Hawk’s Pro Skater 1+2,Perfect,Turnip 23.2.0,Sudachi,Latest,,Pocket 5
+Torchlight 2,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.5,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Torchlight 3,Perfect,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.9.1,Runs great. Shaders and clock enabled.,Pocket 5
+Torchlight II,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.98762,Plays ery well !,Pocket 5
+Torchlight II,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Torchlight II,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Totally Accurate Battle Simulator,Great,Turnip 24.3.0 9v2,Yuzu,v1.0.34,Yuzu 278 (dc529a89a) Video precision : High,Pocket 5
+Transistor,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,,Pocket 5
+Trek To Yomi,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,"very playable but a bit stuttery, assuming its a shader issue",Pocket 5
+Trials Of Mana,Playable,Turnip 24.3.0 9v2,Citron,1.1.1,"Handheld Mode, Graphics Accuracy: High, Resolution: 0.75X, Sync mode: Immediate (Off), Audio: cubeb, CPU Accuracy: Accurate FPS can dip in towns, and in some cutscenes. Otherwise smooth most other places. Can be unstable initially.",Pocket 5
+Triangle Strategy,Poor,Turnip 24.3.0 9v2,Citron,1.1.1,Game crash at around 3hours mark. I tried different setting (CPU / GPU to high) and different drivers but the game is really unstable and crash mid fight,Pocket 5
+Triangle Strategy,Great,Turnip 23.2.0,Yuzu,1.1,"0.75x resolution, game speed capped, docked mode. FPS is a pretty stable 30 throughout. Only would see the occasional dip when entering a new map or the occasional in battle skill. Only played the first hour so far.",Pocket 5
+Trinity Trigger,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.4,Plays perfectly at 60fps. 2 hours in with no dips so far.,Pocket 5
+Trombone Champ,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,Runs great at 60fps,Pocket 5
+Trouser Critters Long Dagger,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Trouser Critters Long Dagger,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Trouser Critters Shiny Clam Rocks,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Tsukihime – A Piece Of Blue Glass Moon,Perfect,Turnip 24.3.0 R5,Sudachi,1.01,Set RP5 to Performance mode as effect heavy cutscenes will dip to 30 fps. Run 60fps at 1080p Docked mode with no issues. Tested all the way to chapter 8.,Pocket 5
+Tunic,Great,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Tunic,Perfect,Turnip 24.3.0 9v2,Citron,1.0,Tested first 30 minutes,Pocket 5
+Turbo Overkill,Great,Qualcomm 0.746.0,Citron,1.1.0,FPS stays around 20-30. Occasional dips but surprisingly good,Pocket 5
+Turbo Overkill,Poor,Turnip 24.3.0 9v2,Yuzu,1.0,"Failed to boot, tried with Citron and had the same result",Pocket 5
+Twelve Minutes,Great,Turnip 24.3.0 9v2,Citron,1.0,Minor lightning glitch at the start. Good performance. Default Settings.,Pocket 5
+Two Point Hospital,Perfect,Turnip 24.3.0 9v2,Citron,Latest,,Pocket 5
+Ubermosh: Omega,Perfect,Qualcomm 0.746.0,Citron,1.0.1,Perfect 60 FPS Docked,Pocket 5
+Ugly,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,"I couldnt figure out how to complete the first puzzle so I cant say much, but it seems to be perfect 60fps docked",Pocket 5
+Ultimate Marvel vs. Capcom 3,Great,Turnip 25.2.0 R4,Yuzu,1.0,,Pocket 5
+Ultra Street Fighter II: The Final Challengers,Perfect,Turnip 24.3.0 9v2,Citron,1.0,"720p, standard performance",Pocket 5
+Ultra Street Fighter II: The Final Challengers,Great,Turnip 24.3.0 9v2,Suyu,1.0,,Pocket 5
+Umineko No Naku Koro Ni Catbox,Perfect,Turnip 24.1.0 R17,Sudachi,1.0.3,"It just works. It’s a visual novel, so I imagine it’s not taxing to the system.",Pocket 5
+Unavowed,Poor,Turnip 24.3.0 9v2,Citron,1.0,Does not work on any of the Drivers I have tested. Pixels are broken on screen. Tried many different settings.,Pocket 5
+Undead Horde,Great,Turnip 24.3.0 9v2,Yuzu,1.2.1,frame drops some times when summoning the large amt of undead,Pocket 5
+Undead Horde 2,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Under Defeat,Perfect,Turnip 25.0.0 R5,Citron,1.0,"Works great, also with dock mode. I recommend two joystick setting in game.",Pocket 5
+Undermine,Perfect,Turnip 24.3.0 9v2,Sudachi,1.2.0.0,,Pocket 5
+Undernauts: Labyrinth Of Yomi,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2bo,Runs great.,Pocket 5
+Undertale,Perfect,Qualcomm 0.746.0,Citron,1.11,Citron is back in development! 30 FPS Settings: Docked 1x Res. Force Maximum Clocks and Use Asynchronous Shaders On If Audio Is Stuttering/Crackling Change Output To cubeb Everything Else Default.,Pocket 5
+Undertale,Perfect,Qualcomm 0.746.0,Sudachi,1.11,Locked to 30FPS,Pocket 5
+Unicorn Overlord,Great,Turnip 25.2.0 R2,Citron,v1.05,"Game is ery playable and enjoyable, but not perfect, like the other entry says. Tried several drivers, got the best framerate with 25.2.0_R2. Framerate is typically directly tied to the number of entities on-screen, with the world map usually being 50-60fps, battle maps being about 45, and 6v6 combat screens dipping down to 30fps. Being a tactical RPG, this really isn’t a problem, and feels great to play. Running in Handheld mode, with 0.75 resolution and FidelityFX. Cache, Max clocks, and Async Shaders turned on, CPU accuracy auto/graphics accuracy normal. May sometimes get the odd audio crackle, this can be fixed by switching audio to cubeb, but isn’t really necessary.",Pocket 5
+Unicorn Overlord,Perfect,Turnip 24.3.0 9v2,Sudachi,1.03,,Pocket 5
+Unmetal,Perfect,Turnip 25.2.0 R9,Yuzu,1.0,720/1080p Docked Mode,Pocket 5
+Unsighted,Perfect,Turnip 24.3.0 9v2,Citron,1.1.4,,Pocket 5
+Urban Myth Dissolution Center,Perfect,Turnip 24.3.0 9v2,Yuzu,1.1,"60 fps docked, plays perfectly",Pocket 5
+Valiant Hearts: The Great War,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Perfect 60fps docked mode,Pocket 5
+Valkyria Chronicles,Great,Qualcomm 0.746.0,Yuzu,1.0,Perfect 30fps docked but some minor isual and audio glitches,Pocket 5
+Valkyria Chronicles 4,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Locked 30fps. Handheld or Docked.,Pocket 5
+Vampire Hunters,Great,Qualcomm 0.746.0,Citron,1.1.5.cl11438,Turn accuracy level to high. Stable 60 FPS when not in combat FPS ranges from 25-60 FPS while in combat Depends on amount of enemies and effects on screen,Pocket 5
+Vampire Survivors,Perfect,Qualcomm 0.746.0,Yuzu,"1.6.10, 2DLC",Perfect 60fps docked,Pocket 5
+Velocity 2x,Perfect,Turnip 24.3.0 9v2,Suyu,1.0,60fps docked,Pocket 5
+Victory Heat Rally,Great,Turnip 24.3.0 9v2,Yuzu,1.0,Yuzu 278 (dc529a89a) Default parameters,Pocket 5
+Victory Heat Rally,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"Seems to be running at full speed during races. There is a bit of slowdown during the intro to the races, but I am not sure if that happens on actual console. Played about 30 mins in.",Pocket 5
+Void Bastards,Great,Turnip 24.3.0 9v2,Sudachi,2.0.24,"Plays mostly 60fps in handheld, some drops in busy situations. Occasionally random crashes when loading new level. Game saves ery frequently so no biggie. Plays well overall.",Pocket 5
+Void Prison,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Void Prison,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Void Scrappers,Perfect,Qualcomm 0.746.0,Citron,1.3,Perfect 60 FPS Docked,Pocket 5
+Void Scrappers,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Void Scrappers,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Voidwrought,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Voltaire: The Vegan Vampire,Playable,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Wall World,Perfect,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Wargroove,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Intro ideo did not play, but was skippable and game runs.",Pocket 5
+"Warhammer 40,000: Boltgun",Great,Turnip 24.3.0 9v2,Citron,1.0.0.7,"30 fps. Completed two levels. Settings: 1x, handheld, Disk shader Cache: On, force maximum clocks: On, Asynchronous Shader: On",Pocket 5
+Wavetale,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2.0,Update is required. Game is ery buggy without it.,Pocket 5
+We Love Katamari Reroll+ Royal Reverie,Great,Turnip 24.3.0 9v2,Yuzu,1.0.2,Gameplay locked 30fps. Dipped only on loading screen.,Pocket 5
+What Lies In The Multiverse,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,"Plays perfectly, fun game!",Pocket 5
+What Remains Of Edith Finch,Playable,Turnip 24.3.0 9v2,Citron,1.0.1,game 1.0.0 (doesn’t work on Yuzu with the same settings) Docked Resolution 0.75 Accuracy High Vsync mode Immediate (off) Force maximum clocks Use asynchronous shaders,Pocket 5
+What The Golf,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Worked great right out of the box with firmware 19.0.1,Pocket 5
+Wild Bastards,Playable,Qualcomm 0.746.0,Sudachi,1.0,,Pocket 5
+Wild Bastards,Playable,Qualcomm 0.746.0,Yuzu,1.0,,Pocket 5
+Windjammers 2,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.2,,Pocket 5
+Wolffang Skullfang,Poor,Turnip 24.3.0 9v2,Suyu,1.0,Crashes,Pocket 5
+World Of Goo,Perfect,Turnip 24.3.0 9v2,Yuzu,0.0.2,Only boots in handheld mode but runs at perfect 60,Pocket 5
+World Of Horror,Perfect,Qualcomm 0.746.0,Sudachi,1.0.3,,Pocket 5
+Worms Armageddon: Anniversary Edition,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.1,"Docked mode locked 60fps, default settings",Pocket 5
+Wytchwood,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,"1x Docked – around 40-45 fps, 0.75x docked – almost solid 60, but there are some slight graphical glitches. Force max clocks and asynchronous shader set to on, rest of the settings are at default. High Performance RP5 setting. /Turnip 9v2 doesn’t improve performance or glitches, Turnip 25.0.0 rev2 crashes the game.",Pocket 5
+XCOM 2,Poor,Turnip 24.3.0 9v2,Yuzu,1.0.3,"With or without the update, on yuzu, sudachi and citron, the game freezes when choosing either the game without DLCs or the game with dlcs.",Pocket 5
+Xenoblade Chronicles 2,Great,Turnip 23.3.0-devel,Sudachi,Version 1.4 and All DLC,"Courtesy of @Kewa from Discord: handheld mode, Resolution 1x accuracy high, FIFO(On) AMD FidelityFX 70-100% FXAA on Anisotropic Filtering default disk shader on, max clocks off async on reactive flushing off VULKAN NCE Debugging on and fastmem on",Pocket 5
+Xenoblade Chronicles X: Definitive Edition,Great,Turnip 24.3.0 9v2,Citron,1.0,Handheld mode 1x Resolution High performance Citron 0.6.1 Force Max Clocks On Async Shaders On,Pocket 5
+Xenoblade Chronicles X: Definitive Edition,Great,Turnip 24.3.0 9v2,Citron,1.0,Some slight frame drops but only rarely.,Pocket 5
+XIII,Great,Turnip 24.1.0 R18,Suyu,1.0,"105 % speedlimit, precision level high, high performance",Pocket 5
+Yakuza Kiwami,Great,Turnip 24.3.0 9v2,Sudachi,1.0,Sudachi 1.0.11 (99775b8) Force max frequencies : Yes,Pocket 5
+Yakuza Kiwami,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Perfect 30fps handheld,Pocket 5
+Yo-Kai Watch 1 For Nintendo Switch,Perfect,Qualcomm 0.746.0,Yuzu,1.0.3,Also installed fan made German language patch,Pocket 5
+Yokai Watch 1,Great,Qualcomm 0.746.0,Yuzu,1.3,"Globally, the game is running at 30 fps stable, some frame drops during the cinematics like when Nate is tracked by the Oni",Pocket 5
+Yokai Watch 4,Poor,Qualcomm 0.746.0,Eden,1.0,FPS average: between 2 and 7 fps with 0.75% res,Pocket 5
+Yoku’s Island Express,Great,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Yooka-Laylee And The Impossible Lair,Perfect,Qualcomm 0.746.0,Yuzu,1.0.4,Perfect 60fps docked,Pocket 5
+Yoshi’s Crafted World,Perfect,Turnip 24.3.0 9v2,Citron,8128d9b,Any Yuzu clones should work. Just need Graphics->Accuracy level->Extreme. It will get a bit hotter. Set the fan to Smart.,Pocket 5
+You Suck At Parking,Great,Qualcomm 0.746.0,Yuzu,v1.10.7,Yuzu 278 (dc529a89a),Pocket 5
+Youtubers Life,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0,,Pocket 5
+Ys IX: Monstrum Nox,Great,Qualcomm 0.746.0,Sudachi,1.0.3,"Using Qualcomm driver made the performance great for this game. Running around in the city causes some stutter, but seems fine other than that.",Pocket 5
+Ys IX: Monstrum Nox,Great,Turnip 24.3.0 9v2,Sudachi,1.0,"I’m tagging it as great and I don’t really notice any significant frame drops after over 3 hours of gameplay, but I need to play it a bit longer to tag it as perfect. However, I do believe we can tweak the emulator to get maximum performance out of it. Android Preset: Standard (), Performance() ,High Performance(x) System: Docked Mode – Off Graphics: 1x (720p/1080p) Vsync – On Disk Shader Cache – On Force Maximum Clocks – On Audio: Output Engine – Auto Debug: API: ulkan CPU: NCE CPU Accuracy: Auto",Pocket 5
+Ys Memoire: The Oath In Felghana,Perfect,Qualcomm 0.746.0,Yuzu,1.0.1,"Perfect 60fps docked, use audio engine cubeb to prevent audio glitching",Pocket 5
+Ys Memoire: The Oath In Felghana,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Played through the first dungeon,Pocket 5
+Ys Origin,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Runs flawlessly. Android Preset: Standard (), Performance(x) ,High Performance() System: Docked Mode – Off Graphics: 1x (720p/1080p) Vsync – On Disk Shader Cache – On Audio: Output Engine – Auto Debug: API: ulkan CPU: NCE CPU Accuracy: Auto",Pocket 5
+Ys Viii,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,Runs very smoothly without issues thus far.,Pocket 5
+Planet Of Lana,Playable,Turnip 9v2,Sudachi,1.2.0.0,Plays really well but there is an black screen error in about 20 mins into the game. There is no mod yet to fix this as of 30/7/2025,Pocket 5
+Xenoblade Chronicles Definitive Edition,Poor,Turnip 25.2.0,Eden,0.0.3-rc1,"Runs at a decent framerate, but there are constant and severe graphical glitches",Pocket 5
+Castle Crashers,Poor,Turnip 24.3.0 9v2,Sudachi,Latest,"Sound works, but no picture.",Pocket 5
+The Legend Of Heroes: Trails From Zero,Poor,Turnip 25.2.0 R4,Eden,1.4,Runs and starts great but then Constant 0 fps crashes with audio still playing. Ive tried most of the recent drivers,Pocket 5
+Front Mission 3,Great,Qualcomm 0.746.0,Sudachi,1.0.1,,Pocket 5
+9th Dawn Remake,Perfect,Qualcomm 0.777,Sudachi,1.175,,Pocket 5
+A Short Hike,Perfect,Qualcomm 0.777,Sudachi,1.9.21,Completed Game. No issues,Pocket 5
+Ace Attorney Investigations Collection,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.0.1,,Pocket 5
+Advance Wars 1+2 Re-boot Camp,Perfect,Qualcomm 0.777,Sudachi,1.0.0,,Pocket 5
+Animal Crossing New Horizons,Perfect,24.3.0 9v2,Yuzu,2.0.8,,Pocket 5
+Animal Well,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.5,,Pocket 5
+Annalynn,Perfect,Turnip 24.3.0 9v2,Sudachi,1.6.1,,Pocket 5
+Another Code Recollection,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.0,,Pocket 5
+Ao Tennis 2,Playable,Turnip 24.3.0 9v2,Sudachi,1.0.0,Runs at 20-30 FPS,Pocket 5
+Astral Ascent,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.14,,Pocket 5
+Astral Chain,Perfect,Turnip 25.3.0-R1,Sudachi,1.0.1,,Pocket 5
+Axiom Verge,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.2,If you install update it is not recognised in Sudachi,Pocket 5
+20 Minutes Till Dawn,Perfect,Turnip 24.3.0 9v2,Sudachi,1.1.1,,Pocket 5
+30xx,Perfect,Qualcomm 0.777,Sudachi,1.1.03,Screen is inverted (upside down) and crashes after a few minutes,Pocket 5
+Anomaly Agent,Perfect,Qualcomm 0.777,Sudachi,1.0.0.15,,Pocket 5
+Armored Lab Force Vulvehicles,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,,Pocket 5
+Ato,Perfect,Qualcomm 0.777,Sudachi,1.0.0,,Pocket 5
+"Warhammer 40,000: Boltgun",Perfect,Mesa Turnip 24.3.0 R9 v2,Eden,1.0.0.7,Need to use Prod Key v18.0.0 and use exact update and turnip driver listed or it will NOT work. This also runs perfect on Sudachi. Expect minor initial stutters as the emulator savesshader cache. Runs 30fps stable.,Pocket 5
+Balatro,Perfect,Qualcomm 0.746.0,Yuzu,1.0,Just buy the game on Android and support the developer!,Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Great,Turnip 24.3.4-Unified (@Mr_Purple_666),Eden,1.0,,Pocket 5
+The Legend Of Zelda: Tears Of The Kingdom,Great,Turnip 24.3.0 9v2,Eden,1.0,,Pocket 5
+Ender Magnolia Bloom In The Mist,Playable,Turnip 24.3.0 9v2,Citron,0.6,"v1.0 & v1.0.1 handheld mode, high accuracy game will stutter during combat and drop frames",Pocket 5
+Pinball Fx,Poor,Turnip 24.3.0 9v2,Citron,1.0,Games launches into menu and as soon as you press a button to advance it crashes. Tested multiple drivers and settings,Pocket 5
+Cookie Clicker,Perfect,Qualcomm 0.746.0,Eden,1.0.3,"Its Cookie Clicker, of course it runs well. Locked 60.",Pocket 5
+The Legend Of Zelda: Echoes Of Wisdom,Poor,Turnip 24.3.0 9v2,Yuzu,1.4.0.0,Freezes in the middle of loading the game,Pocket 5
+Raidou Remastered The Mystery Of The Soulless Army,Poor,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.0,"The game runs fine, but for some reason crashes as soon as you try to WALK?? Really weird. Tried a few more drivers and had no luck whatsoever",Pocket 5
+Outlast,Perfect,Turnip 24.3.0 9v2,Yuzu,1.0.1,Prod Key 20.0.0 with last release of Yuzu. Played for 30 minutes and it kept a pretty stable 30 FPS at 1x resolution. No issues I could see during that time at all.,Pocket 5
+Ufo 50,Perfect,Turnip 23.3.0-devel,Eden,1.0,"Wouldn’t work on YUZU but works on Eden right out of the box, seemingly perfectly",Pocket 5
+Ufo 50,Poor,Qualcomm 0.746.0,Yuzu,1.0,"Wouldn’t work on YUZU no matter what I do. Back screen 0 FPS. I tried every driver I could, but no dice. Works perfectly in Eden though",Pocket 5
+Saints Row Iv,Poor,Turnip 24.3.0 9v2,Eden,1.0,doesnt even load,Pocket 5
+Warriors Abyss,Poor,Turnip 24.3.0 9v2,Eden,1.0,does load menu but lag at loading in game,Pocket 5
+Naruto Ultimate Ninja Storm 2,Perfect,Turnip 24.3.0 9v2,Sudachi,1.0,"Working perfectly pretty much out of the box, 30fps solid at 1x",Pocket 5
+Minecraft: Nintendo Switch Edition (legacy Console),Perfect,Turnip 24.3.0 9v2,Sudachi,1.0.16,"There are 3 different configurations I found that have advantages and disadvantages. 1. Handheld mode, 1x resolution This is the most stable setting, but is only 720p and has a 7-chunk render distance. Perfect 60fps, extremely rarely freezes (but there is auto-save every minute or so, so don’t worry). 2. Docked mode, 0.75x resolution. Less stable, but gives a 810p resolution (not a typo, it is actually 810p) and has a 10-chunk render distance. Gameplay is almost always at 60fps, with rare dips to 55 or so. Freezes are infrequent, but not impossible. 3. Docked mode, 1x resolution. The least stable, but most impressive graphics. 1080p and 10-chunk render distance. Performance is also almost always at 60fps, but freezes are pretty common, maybe every 10-15 minutes or so. Also, make sure you use Turnip Driver 9v2 AND cubeb audio. Audio is totally messed up without cubeb.",Pocket 5
+Factorio,Poor,Turnip 24.3.0 9v2,Eden,1.0,Crash before loading in game,Pocket 5
+Pokken Tournament Dx,Great,Turnip 24.2.0 R4-fix,Citron,1.0,"1x res, cache shader on, async shader on. OPTION max clock 50-60fps",Pocket 5
+Hatsune Miku: Project Diva Mega Mix,Perfect,Qualcomm 0.746.0,Eden,1.0.6,"The game runs perfect without any extra setting, tested on latest eden build up to this date, used 19.0.1 firmware",Pocket 5
+Dragon Ball Xenoverse 2,Great,Turnip 24.3.0 9v2,Eden,v0.0.3,"Runs pretty well with the tweaks I made. Nearly stable 30fps in battle, which is really all that matters. Sometimes dips into low 20s when loading and in open world. I The game has to take a pretty big hit graphically and with resolution to make it work, but it still doesn’t look horrible. RP5 needs to be in High Performance Mode. .75 Resolution Handheld mode Played about an hour with no game breaking moments.",Pocket 5
+Dragon Ball Z: Kakarot,Poor,Turnip 24.3.0 9v2,Sudachi,Sudachi 1.0.15,"Game was running okay during opening fight and when you are flashing with Gohan, but then when you get home bright lights on screen make it unplayable. Could maybe work with some tweaking, but didn’t want to try. Used default settings.",Pocket 5
+Dragon Ball Z: Kakarot,Poor,Turnip 24.3.0 9v2,Eden,Eden v.0.0.3-rc2,"Game was running okay during opening fight and when you are flashing with Gohan, but then when you get home bright lights on screen make it unplayable. Could maybe work with some tweaking, but didn’t want to try. Used default settings.",Pocket 5
+Enclave Hd,Perfect,Qualcomm 0.746.0,Citron,1.0,Works Perfect in docked mode with default settings! No crashes or bugs so far.,Pocket 5
+Outward – Definitive Edition,Perfect,turnip_mrpurple T19,Eden,.0.03,Runs perfectly @ 30fps no dips so far,Pocket 5
+Sifu,Playable,Turnip 24.3.0 9v2,Yuzu,1.0,"Handheld mode .75x, asynchronous shaders & force maximum clocks on gets 25-30fps in combat but ~20 going from area to area. Playable but compromised.",Pocket 5
+Red Dead Redemption,Poor,Turnip 24.3.4-Unified (@Mr_Purple_666),Sudachi,1.0.4,Drops to 15 fps in populated areas on 0.5x,Pocket 5
+Red Dead Redemption,Playable,Turnip 24.3.4-Unified (@Mr_Purple_666),Eden,1.0,"30 fps locked at 0.5x, probably would drop in a more populated area than the first town. I tried the same configuration on Sudachi and was just 15 fps on the same town, another point for Eden emulator I guess!",Pocket 5
+Mega Man 11,Perfect,Turnip 24.3.0 9v2,Sudachi,1.01,,Pocket 5
+Dragon Ball Fighterz,Poor,Turnip 25.1.0,Eden,1.0,Game crashes even with crash fix mod and 540p resolution,Pocket 5
+Dragon Ball Fighterz,Perfect,Turnip 25.3.0-R4,Eden,1.33,Settings: 1) Crash fix enabled for 540p: https://www.mediafire.com/file/llur8mo8d2zln93/DBFZ_540p_crash_fix.zip/file ***THIS ONLY WORKS ON VERSION 1.33 2. Handheld mode .75 resolution 3. Disk shader cache/Async shaders on 4. FXAA/4x AA 5. ScaleForce on,Pocket 5
+Red Dead Redemption,Playable,Turnip 25.2.0-deveal-unified (@Mr_Purple_666),Eden,1.0,"Forced maximun clocks and used asynchronous shaders. 30 fps at native resolution with a few drops once in a while, runs almost as in original hardware, but that isn’t much saying",Pocket 5
+8-bit Adventures 2,Great,Qualcomm 805,Sudachi,1.0,,Pocket 5
+Mario Kart 8 Deluxe,Perfect,System GPU driver,Citron,3.0.5,Runs at 60fps with update and DLC. System GPU is the best option for running this game on Citron. I have attempted with multiple Turnip drivers and have ran into drops in FPS and Colors in the game.,Odin 2 Portal
+Metroid Dread,Perfect,Mesa Turnip Driver V25.2.0-R2,Citron,none,Game runs flawlessly with Mesa Turnip Driver V25.2.0-R2. Attempted with revision 5 and 7 and ran into crashes during game beginning cut scene.,Odin 2 Portal
+Zelda Botw,Perfect,Mesa Turnip Driver V25.2.0-R7,Citron,1.6.0,Update 1.6.0 really helped this game run with better frame rates. Barely any drops in framerates and game runs as it does on the Secret Console.,Odin 2 Portal
+Tetris Effect,Perfect,Mesa Turnip Driver V25.2.0-R2,Citron,none,Mesa Turnip Driver V25.2.0-R2 seems to be the holy grail on games for the Odin 2 Portal. Attempted multiple drivers. Game still plays but ran into issues when attempting to reload after a loss in a level. System would drop to 0 fps and Citron would crash.,Odin 2 Portal
+Super Mario Wonder,Perfect,Mesa Turnip Driver V25.2.0-R7,Citron,1.0,Runs flawlessly with Mesa Turnip Driver V25.2.0-R2 through R7. Played in single and multiplayer mode with 0 issues.,Odin 2 Portal
+Shadow Labyrinth,Perfect,Mesa Turnip Driver V25.2.0-R7,Citron,none,60fps steady with Mesa Turnip Driver V25.2.0-R7 and R2,Odin 2 Portal
+Astral Chain,Unplayable,Multiple,Citron,none,attempted to play this game on Citron using multiple drivers including the stock driver and game locks up as soon as you get to naming portion.,Odin 2 Portal
+Mario Party Superstars,Perfect,9v2,Sudachi,1.1.1,"Works perfectly with almost double speed on 1080p resolution. I played on *SUMI* emulator, jamboree is crashing for me",Odin 2 Portal
+Cyber Shadow,Perfect,Mesa Turnip Driver V25.3.0-R4,Yuzu,1.0.2,"Yuzu, Suyu, and Sudashi are the best. Eden and Citron, although they work well, have too much input lag.",Odin 2 Portal
+The House Of Dead 2 Remake,Playable,Mesa Turnip Driver V25.2.0-R2,Eden,1.0.1,"The game works well, but it has random crashes, usually in the intros, I can’t find a good driver that can fix it completely, the one mentioned is the one that works best",Odin 2 Portal
+Metroid Prime Remastered,Perfect,Mesa Turnip Driver V25.3.0-R4,Yuzu,1.0,,Odin 2 Portal
+Super Mario 3d World,Playable,System GPU driver,Citron,1.0,,Odin 2 Portal
+Bomberman R2,Unplayable,System GPU driver,Citron,1.0,,Odin 2 Portal
+Asd,Great,ad,Yuzu,1.0,delete me,Odin 2 Portal
+The Legend Of Zelda: Breath Of The Wild,Perfect,Mesa Turnip Driver V25.2.0-R2,Citron,1.2,Game completed. only a couple of issues. Sometimes water shader looks white but I found that any driver with vulkan 1.3.274 fixes that issue. In adition I used BOTW NX Optimizer mod to get 60fps but you will need to disable it in the final Boss of Vah Naboris to avoid bugs during the battle (it happens on any PC or Android emulator),Odin 2 Portal

--- a/scripts/import-csv-games.ts
+++ b/scripts/import-csv-games.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env tsx
+
+import { PrismaClient } from '@orm'
+import csvGamesSeeder from '../prisma/seeders/csvGamesSeeder'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  console.log('🚀 Starting CSV games import...')
+
+  try {
+    await csvGamesSeeder(prisma)
+    console.log('🎉 CSV games import completed successfully!')
+  } catch (error) {
+    console.error('💥 CSV games import failed:', error)
+    process.exit(1)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch((error) => {
+  console.error('💥 Unexpected error:', error)
+  process.exit(1)
+})

--- a/scripts/import-csv-listings.ts
+++ b/scripts/import-csv-listings.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env tsx
+
+import { PrismaClient } from '@orm'
+import csvListingsSeeder from '../prisma/seeders/csvListingsSeeder'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  console.log('🚀 Starting CSV listings import...')
+
+  try {
+    await csvListingsSeeder(prisma)
+    console.log('🎉 CSV listings import completed successfully!')
+  } catch (error) {
+    console.error('💥 CSV listings import failed:', error)
+    process.exit(1)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch((error) => {
+  console.error('💥 Unexpected error:', error)
+  process.exit(1)
+})


### PR DESCRIPTION


## Description

The initial setup to import listing from Ryan retro listing, this only covers Switch games with all the devices supported on the page, if this helps, I can continue working on the other platforms

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ x] Other (please describe): Listing migrations

## How Has This Been Tested?

Tested on local environments, this use the CSV added, first it should run the game import with: 
```npx tsx scripts/import-csv-games.ts```
The we can check the games listed on the app.
Once that's is completed, we can import the listing for each game with: 
```npx tsx scripts/import-csv-listings.ts```

- [ x] Local build
- [ ] Lint
- [ ] Typecheck
- [ ] Unit tests
- [ ] Manual testing

## Screenshots (if applicable)
<img width="2116" height="1376" alt="image" src="https://github.com/user-attachments/assets/72973079-77d8-46ac-a117-383294c79d90" />
<img width="2116" height="1376" alt="image" src="https://github.com/user-attachments/assets/1c86a282-88fd-4360-9002-f245099a5250" />


## Checklist

- [x ] My code follows the [style guidelines](../CONTRIBUTING.md#code-style) of this project
- [x ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ x] I have checked that all checks (lint, typecheck, test) pass

