### PR TITLE
fix: add unit tests for bulk approval confirmation and submission ris…

### DIFF
--- a/src/app/admin/utils/bulkApprovalConfirmation.test.ts
+++ b/src/app/admin/utils/bulkApprovalConfirmation.test.ts
@@ -72,6 +72,25 @@ describe('confirmBulkApproval', () => {
     expect(confirm.mock.calls[0]?.[0].description).toContain('highest: high')
   })
 
+  it('uses the loaded selected listing count in risk warnings', async () => {
+    const confirm = createConfirm()
+
+    await confirmBulkApproval<TestListing>(
+      [
+        {
+          id: 'listing-1',
+          author: { name: 'Risky Author' },
+          submissionRiskProfile: { highestSeverity: 'high' },
+        },
+      ],
+      ['listing-1', 'stale-listing-id'],
+      confirm,
+      'listings',
+    )
+
+    expect(confirm.mock.calls[0]?.[0].description).toContain('approve 1 listings')
+  })
+
   it('uses the normal confirmation when selected listings have no risk', async () => {
     const confirm = createConfirm()
 

--- a/src/app/admin/utils/bulkApprovalConfirmation.test.ts
+++ b/src/app/admin/utils/bulkApprovalConfirmation.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import { type Severity } from '@/schemas/common'
+import { confirmBulkApproval } from './bulkApprovalConfirmation'
+
+interface TestRiskProfile {
+  highestSeverity: Severity | null
+}
+
+interface TestListing {
+  id: string
+  author?: { name: string | null } | null
+  authorRiskProfile?: TestRiskProfile | null
+  submissionRiskProfile?: TestRiskProfile | null
+}
+
+interface ConfirmOptions {
+  title: string
+  description: string
+  confirmText: string
+}
+
+function createConfirm() {
+  return vi.fn((options: ConfirmOptions) => Promise.resolve(options.confirmText.length > 0))
+}
+
+describe('confirmBulkApproval', () => {
+  it('warns when a selected listing only has submission risk', async () => {
+    const confirm = createConfirm()
+
+    const result = await confirmBulkApproval<TestListing>(
+      [
+        {
+          id: 'listing-1',
+          author: { name: 'New User' },
+          authorRiskProfile: null,
+          submissionRiskProfile: { highestSeverity: 'high' },
+        },
+      ],
+      ['listing-1'],
+      confirm,
+      'listings',
+    )
+
+    expect(result).toBe(true)
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Bulk Approval Warning',
+        confirmText: 'Approve Selected',
+      }),
+    )
+    expect(confirm.mock.calls[0]?.[0].description).toContain('including 1 with review risk signals')
+    expect(confirm.mock.calls[0]?.[0].description).toContain('highest: high')
+  })
+
+  it('uses the highest severity across author and submission risk', async () => {
+    const confirm = createConfirm()
+
+    await confirmBulkApproval<TestListing>(
+      [
+        {
+          id: 'listing-1',
+          author: { name: 'Risky Author' },
+          authorRiskProfile: { highestSeverity: 'medium' },
+          submissionRiskProfile: { highestSeverity: 'high' },
+        },
+      ],
+      ['listing-1'],
+      confirm,
+      'listings',
+    )
+
+    expect(confirm.mock.calls[0]?.[0].description).toContain('highest: high')
+  })
+
+  it('uses the normal confirmation when selected listings have no risk', async () => {
+    const confirm = createConfirm()
+
+    await confirmBulkApproval<TestListing>(
+      [
+        {
+          id: 'listing-1',
+          author: { name: 'Clean Author' },
+          authorRiskProfile: { highestSeverity: null },
+          submissionRiskProfile: { highestSeverity: null },
+        },
+      ],
+      ['listing-1'],
+      confirm,
+      'listings',
+    )
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Bulk Approval Confirmation',
+      }),
+    )
+  })
+
+  it('uses the normal confirmation when selected listings have no risk profiles loaded', async () => {
+    const confirm = createConfirm()
+
+    await confirmBulkApproval<TestListing>(
+      [
+        {
+          id: 'listing-1',
+          author: { name: 'Unknown Risk Author' },
+        },
+      ],
+      ['listing-1'],
+      confirm,
+      'listings',
+    )
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Bulk Approval Confirmation',
+      }),
+    )
+  })
+})

--- a/src/app/admin/utils/bulkApprovalConfirmation.ts
+++ b/src/app/admin/utils/bulkApprovalConfirmation.ts
@@ -1,19 +1,34 @@
-type RiskSeverity = 'low' | 'medium' | 'high'
+import { type Severity } from '@/schemas/common'
+
+const SEVERITY_ORDER: Record<Severity, number> = { low: 1, medium: 2, high: 3 }
+
+interface RiskProfileSummary {
+  highestSeverity: Severity | null
+}
 
 interface ListingWithRiskProfile {
   id: string
   author?: { name: string | null } | null
-  authorRiskProfile?: { highestSeverity: string | null } | null
+  authorRiskProfile?: RiskProfileSummary | null
+  submissionRiskProfile?: RiskProfileSummary | null
 }
 
 interface ConfirmFn {
   (opts: { title: string; description: string; confirmText: string }): Promise<boolean>
 }
 
-/**
- * Analyzes risk profiles in a selection of listings and prompts the admin
- * for confirmation before bulk approval. Returns true if the admin confirmed.
- */
+function getHighestRiskSeverity(listing: ListingWithRiskProfile): Severity | null {
+  const severities = [
+    listing.submissionRiskProfile?.highestSeverity,
+    listing.authorRiskProfile?.highestSeverity,
+  ].filter((severity): severity is Severity => Boolean(severity))
+
+  return severities.reduce<Severity | null>((highest, severity) => {
+    if (!highest) return severity
+    return SEVERITY_ORDER[severity] > SEVERITY_ORDER[highest] ? severity : highest
+  }, null)
+}
+
 export async function confirmBulkApproval<T extends ListingWithRiskProfile>(
   allListings: T[],
   selectedIds: string[],
@@ -21,23 +36,20 @@ export async function confirmBulkApproval<T extends ListingWithRiskProfile>(
   entityLabel: string,
 ): Promise<boolean> {
   const selectedListings = allListings.filter((listing) => selectedIds.includes(listing.id))
-  const riskyListings = selectedListings.filter(
-    (listing) => listing.authorRiskProfile?.highestSeverity !== null,
-  )
+  const riskyListings = selectedListings.filter((listing) => getHighestRiskSeverity(listing))
 
   if (riskyListings.length > 0) {
     const riskyAuthors = [...new Set(riskyListings.map((l) => l.author?.name || 'Unknown'))]
-    const severityOrder: Record<RiskSeverity, number> = { low: 1, medium: 2, high: 3 }
-    const highestRisk = riskyListings.reduce<string | null>((max, l) => {
-      const severity = l.authorRiskProfile?.highestSeverity as RiskSeverity | null
-      if (!severity) return max
-      if (!max) return severity
-      return severityOrder[severity] > severityOrder[max as RiskSeverity] ? severity : max
+    const highestRisk = riskyListings.reduce<Severity | null>((highest, listing) => {
+      const severity = getHighestRiskSeverity(listing)
+      if (!severity) return highest
+      if (!highest) return severity
+      return SEVERITY_ORDER[severity] > SEVERITY_ORDER[highest] ? severity : highest
     }, null)
 
     return confirm({
       title: 'Bulk Approval Warning',
-      description: `You are about to approve ${selectedIds.length} ${entityLabel}, including ${riskyListings.length} from authors with risk signals (highest: ${highestRisk}).\n\nFlagged authors:\n${riskyAuthors.map((name) => `  ${name}`).join('\n')}\n\nAre you sure you want to proceed?`,
+      description: `You are about to approve ${selectedIds.length} ${entityLabel}, including ${riskyListings.length} with review risk signals (highest: ${highestRisk}).\n\nFlagged authors:\n${riskyAuthors.map((name) => `  ${name}`).join('\n')}\n\nAre you sure you want to proceed?`,
       confirmText: 'Approve Selected',
     })
   }

--- a/src/app/admin/utils/bulkApprovalConfirmation.ts
+++ b/src/app/admin/utils/bulkApprovalConfirmation.ts
@@ -35,7 +35,8 @@ export async function confirmBulkApproval<T extends ListingWithRiskProfile>(
   confirm: ConfirmFn,
   entityLabel: string,
 ): Promise<boolean> {
-  const selectedListings = allListings.filter((listing) => selectedIds.includes(listing.id))
+  const selectedIdSet = new Set(selectedIds)
+  const selectedListings = allListings.filter((listing) => selectedIdSet.has(listing.id))
   const riskyListings = selectedListings.filter((listing) => getHighestRiskSeverity(listing))
 
   if (riskyListings.length > 0) {
@@ -49,7 +50,7 @@ export async function confirmBulkApproval<T extends ListingWithRiskProfile>(
 
     return confirm({
       title: 'Bulk Approval Warning',
-      description: `You are about to approve ${selectedIds.length} ${entityLabel}, including ${riskyListings.length} with review risk signals (highest: ${highestRisk}).\n\nFlagged authors:\n${riskyAuthors.map((name) => `  ${name}`).join('\n')}\n\nAre you sure you want to proceed?`,
+      description: `You are about to approve ${selectedListings.length} ${entityLabel}, including ${riskyListings.length} with review risk signals (highest: ${highestRisk}).\n\nFlagged authors:\n${riskyAuthors.map((name) => `  ${name}`).join('\n')}\n\nAre you sure you want to proceed?`,
       confirmText: 'Approve Selected',
     })
   }

--- a/src/server/services/submission-risk.service.test.ts
+++ b/src/server/services/submission-risk.service.test.ts
@@ -75,6 +75,30 @@ describe('computeSubmissionRiskProfiles', () => {
     expect(signal?.severity).toBe('high')
   })
 
+  it('keeps placeholder severity high for a new author with rejected listings', async () => {
+    const profile = computeSubmissionRiskProfile(
+      createSubmission('v0.1.4'),
+      createAuthorRiskProfile([
+        {
+          type: RISK_SIGNAL_TYPES.NEW_AUTHOR,
+          severity: 'low',
+          label: 'New Author',
+          description: 'No previously approved listings',
+        },
+        {
+          type: RISK_SIGNAL_TYPES.PREVIOUSLY_REJECTED,
+          severity: 'low',
+          label: 'Previously Rejected',
+          description: '2 rejected listings',
+        },
+      ]),
+      { trustScore: 0, approvedListings: 0 },
+    )
+
+    expect(profile.signals[0]?.severity).toBe('high')
+    expect(profile.highestSeverity).toBe('high')
+  })
+
   it('lowers placeholder severity for authors with multiple approved listings', async () => {
     const profile = computeSubmissionRiskProfile(createSubmission('v0.14'), undefined, {
       trustScore: 0,

--- a/src/server/services/submission-risk.service.ts
+++ b/src/server/services/submission-risk.service.ts
@@ -145,9 +145,9 @@ async function batchGetAuthorCredibility(
   return credibilityMap
 }
 
-function hasOnlyNewAuthorRisk(authorRiskProfile: AuthorRiskProfile | undefined): boolean {
+function hasNewAuthorRisk(authorRiskProfile: AuthorRiskProfile | undefined): boolean {
   if (!authorRiskProfile || authorRiskProfile.signals.length === 0) return false
-  return authorRiskProfile.signals.every((signal) => signal.type === RISK_SIGNAL_TYPES.NEW_AUTHOR)
+  return authorRiskProfile.signals.some((signal) => signal.type === RISK_SIGNAL_TYPES.NEW_AUTHOR)
 }
 
 function getPlaceholderVersionSeverity(params: {
@@ -162,7 +162,9 @@ function getPlaceholderVersionSeverity(params: {
   if (isCredibleAuthor) return 'low'
 
   if (params.authorRiskProfile?.highestSeverity === 'high') return 'high'
-  if (!params.authorRiskProfile || hasOnlyNewAuthorRisk(params.authorRiskProfile)) return 'high'
+  if (!params.authorRiskProfile) return 'high'
+  if (credibility.approvedListings === 0 || hasNewAuthorRisk(params.authorRiskProfile))
+    return 'high'
   if (params.authorRiskProfile.highestSeverity === 'medium') return 'high'
 
   return 'medium'


### PR DESCRIPTION
## Description

add unit tests for bulk approval confirmation and submission risk service logic

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

- [x] Local build
- [x] Lint
- [x] Typecheck
- [x] Unit tests
- [x] Manual testing

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have checked that all checks (lint, typecheck, test) pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk approval confirmation now considers both author and submission risk profiles and surfaces the computed highest severity in warnings.

* **Bug Fixes**
  * Adjusted submission risk logic so placeholder-version severity is treated as high when appropriate (no author profile, no approvals, or presence of new-author signals).

* **Tests**
  * Added tests covering bulk approval warnings across risk combinations and submission risk computation for placeholder versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Producdevity/EmuReady/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->