### PR TITLE
Fix issue template links

### DIFF
--- a/src/app/listings/components/shared/selectors/EmulatorSelector.tsx
+++ b/src/app/listings/components/shared/selectors/EmulatorSelector.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-hook-form'
 import { GitHubIcon, EmulatorIcon } from '@/components/icons'
 import { Autocomplete } from '@/components/ui'
+import { env } from '@/lib/env'
 import { cn } from '@/lib/utils'
 import { type Nullable } from '@/types/utils'
 import { SelectedItemCard } from '../SelectedItemCard'
@@ -137,7 +138,7 @@ export function EmulatorSelector<TFieldValues extends FieldValues = FieldValues>
                         <strong>{props.selectedGame.system.name}</strong>. Try a different search
                         term, or request to add your emulator by opening a GitHub issue.
                         <a
-                          href="https://github.com/Producdevity/EmuReady/issues/new?template=emulator_request.md"
+                          href={env.GITHUB_REQUEST_EMULATOR_URL}
                           target="_blank"
                           rel="noopener noreferrer"
                           aria-label="Request Emulator on GitHub"

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -65,9 +65,9 @@ export const env = {
 
   GITHUB_URL,
   GITHUB_README_URL: `${GITHUB_URL}/blob/master/README.md`,
-  GITHUB_SUPPORT_URL: `${GITHUB_URL}/issues/new?template=question.md`,
+  GITHUB_SUPPORT_URL: `${GITHUB_URL}/issues/new?template=question.yml`,
   GITHUB_CONTRIBUTING_URL: `${GITHUB_URL}/blob/master/CONTRIBUTING.md`,
-  GITHUB_REQUEST_EMULATOR_URL: `${GITHUB_URL}/issues/new?template=emulator_request.md`,
+  GITHUB_REQUEST_EMULATOR_URL: `${GITHUB_URL}/issues/new?template=emulator_request.yml`,
 
   GITHUB_ISSUES_URL: `${GITHUB_URL}/issues`,
 


### PR DESCRIPTION
## Description

Fixes GitHub issue links that were pointing at Markdown template filenames even though the repository now uses YAML issue forms. The support and emulator-request URLs now target the matching `.yml` templates, and the emulator selector reuses the shared env URL instead of duplicating the GitHub link.

Fixes #415

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [ ] Typecheck
- [ ] Unit tests
- [x] Manual testing

Checked with:

- `./node_modules/.bin/eslint src/lib/env.ts src/app/listings/components/shared/selectors/EmulatorSelector.tsx`
- `rg -n "issues/new\?template=.*\.md|template=question\.md|template=emulator_request\.md" src .github`
- `git diff --check`

I also tried `./node_modules/.bin/tsc --noEmit --pretty false`; it currently stops on `src/components/icons/systems/SegaSaturnIcon.tsx` because the PNG asset import has no matching module declaration in this local setup.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

This is limited to GitHub issue creation links. The regular issue picker config is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated GitHub support links to use improved template formats.
  * Improved external link configuration management for emulator requests and documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->