### PR TITLE
feat: add admin auto-reject for review-risk reports

### DIFF
--- a/src/app/admin/approvals/page.tsx
+++ b/src/app/admin/approvals/page.tsx
@@ -15,6 +15,7 @@ import {
   AdminStatsDisplay,
   AdminSearchFilters,
   AdminTableNoResults,
+  ReviewRiskAutoRejectPanel,
   ReviewRiskFilterButton,
   ReviewRiskIndicator,
 } from '@/components/admin'
@@ -55,6 +56,8 @@ import toast from '@/lib/toast'
 import { type RouterOutput, type RouterInput } from '@/types/trpc'
 import getErrorMessage from '@/utils/getErrorMessage'
 import { hasPermission, PERMISSIONS } from '@/utils/permission-system'
+import { hasRolePermission } from '@/utils/permissions'
+import { Role } from '@orm'
 
 type PendingListing = RouterOutput['listings']['getPending']['listings'][number]
 type ApprovalSortField =
@@ -213,12 +216,47 @@ function AdminApprovalsPage() {
     },
   })
 
+  const autoRejectRiskyMutation = api.listings.autoRejectRiskyListings.useMutation({
+    onSuccess: async (result) => {
+      toast.success(result.message)
+
+      if (result.rejectedCount > 0) {
+        analytics.admin.bulkOperation({
+          operation: 'reject',
+          entityType: 'listing',
+          count: result.rejectedCount,
+          adminId: currentUserQuery.data?.id ?? 'unknown',
+        })
+      }
+
+      await invalidateQueries()
+      setSelectedListingIds([])
+    },
+    onError: (err) => {
+      logger.error('Failed to auto-reject review-risk handheld reports:', err)
+      toast.error(`Failed to auto-reject review-risk reports: ${getErrorMessage(err)}`)
+    },
+  })
+
   const handleBulkApprovalWithConfirmation = async (listingIds: string[]) => {
     const confirmed = await confirmBulkApproval(listings, listingIds, confirm, 'listings')
     if (!confirmed) return
 
     await bulkApproveMutation.mutateAsync({ listingIds })
     approvalModal.close()
+  }
+
+  const handleAutoRejectRiskyReports = async () => {
+    const confirmed = await confirm({
+      title: 'Reject review-risk reports?',
+      description:
+        'This will reject every pending handheld report you can review when submission risk is high or author risk has any signal. Rejection notes will be generated automatically.',
+      confirmText: 'Reject Reports',
+      cancelText: 'Cancel',
+    })
+    if (!confirmed) return
+
+    await autoRejectRiskyMutation.mutateAsync()
   }
 
   const handleSelectAll = (selected: boolean) => {
@@ -259,6 +297,7 @@ function AdminApprovalsPage() {
 
   const listings = pendingListingsQuery.data?.listings ?? []
   const pagination = pendingListingsQuery.data?.pagination
+  const canAutoRejectRiskyReports = hasRolePermission(currentUserQuery.data?.role, Role.ADMIN)
 
   return (
     <AdminPageLayout
@@ -329,6 +368,16 @@ function AdminApprovalsPage() {
           onToggle={reviewRiskFilter.toggleRiskFilter}
         />
       </AdminSearchFilters>
+
+      {canAutoRejectRiskyReports && reviewRiskFilter.isRiskOnly && (
+        <ReviewRiskAutoRejectPanel
+          reportLabel="handheld"
+          isSubmitting={autoRejectRiskyMutation.isPending}
+          onAutoReject={() => {
+            void handleAutoRejectRiskyReports()
+          }}
+        />
+      )}
 
       {/* Bulk Actions */}
       {listings.length > 0 && (

--- a/src/app/admin/approvals/page.tsx
+++ b/src/app/admin/approvals/page.tsx
@@ -57,6 +57,7 @@ import { type RouterOutput, type RouterInput } from '@/types/trpc'
 import getErrorMessage from '@/utils/getErrorMessage'
 import { hasPermission, PERMISSIONS } from '@/utils/permission-system'
 import { hasRolePermission } from '@/utils/permissions'
+import { formatCountLabel } from '@/utils/text'
 import { Role } from '@orm'
 
 type PendingListing = RouterOutput['listings']['getPending']['listings'][number]
@@ -77,6 +78,14 @@ const APPROVALS_COLUMNS: ColumnDefinition[] = [
   { key: 'submittedAt', label: 'Submitted', defaultVisible: false },
   { key: 'actions', label: 'Actions', alwaysVisible: true },
 ]
+
+function formatOptionalCountLabel(word: string, count: number | undefined): string {
+  return count === undefined ? 'Loading...' : formatCountLabel(word, count)
+}
+
+function getRejectButtonLabel(count: number): string {
+  return `Reject ${count.toLocaleString()} Report${count === 1 ? '' : 's'}`
+}
 
 function AdminApprovalsPage() {
   const router = useRouter()
@@ -104,6 +113,7 @@ function AdminApprovalsPage() {
   })
 
   const currentUserQuery = api.users.me.useQuery()
+  const canAutoRejectRiskyReports = hasRolePermission(currentUserQuery.data?.role, Role.ADMIN)
   const pendingListingsQuery = api.listings.getPending.useQuery({
     page: table.page,
     limit: table.limit,
@@ -112,6 +122,12 @@ function AdminApprovalsPage() {
     search: isEmpty(table.search) ? null : table.search,
     riskFilter: reviewRiskFilter.riskFilter,
   })
+  const autoRejectRiskyPreviewQuery = api.listings.autoRejectRiskyListingsPreview.useQuery(
+    undefined,
+    {
+      enabled: canAutoRejectRiskyReports && reviewRiskFilter.isRiskOnly,
+    },
+  )
 
   const gameStatsQuery = api.games.stats.useQuery()
   const listingStatsQuery = api.listings.stats.useQuery()
@@ -128,6 +144,7 @@ function AdminApprovalsPage() {
       utils.listings.getProcessed.invalidate(),
       utils.listings.get.invalidate(),
       utils.listings.stats.invalidate(),
+      utils.listings.autoRejectRiskyListingsPreview.invalidate(),
       utils.games.stats.invalidate(),
       // Force refetch the stats
       utils.listings.stats.refetch(),
@@ -247,12 +264,34 @@ function AdminApprovalsPage() {
   }
 
   const handleAutoRejectRiskyReports = async () => {
+    if (autoRejectRiskyPreviewQuery.isError) {
+      toast.error('Failed to load the auto-reject count. Please refresh and try again.')
+      return
+    }
+
+    const eligibleCount = autoRejectRiskyPreviewQuery.data?.eligibleCount ?? 0
+    if (eligibleCount === 0) {
+      toast.warning('No handheld reports currently match the auto-reject rule.')
+      return
+    }
+
+    const eligibleReportCount = formatCountLabel('handheld report', eligibleCount)
+    const reviewRiskQueueCount = autoRejectRiskyPreviewQuery.data?.reviewRiskQueueCount
     const confirmed = await confirm({
-      title: 'Reject review-risk reports?',
-      description:
-        'This will reject every pending handheld report you can review when submission risk is high or author risk has any signal. Rejection notes will be generated automatically.',
-      confirmText: 'Reject Reports',
+      title: `Reject ${eligibleReportCount}?`,
+      description: `This scans all pending handheld reports and rejects ${eligibleReportCount} with high author risk, or with high submission risk and at least one author risk signal. Rejection notes will be generated automatically.`,
+      details: [
+        { label: 'Will reject', value: eligibleReportCount, tone: 'danger' },
+        { label: 'Scope', value: 'All pending handheld reports' },
+        {
+          label: 'All pending review-risk queue',
+          value: formatOptionalCountLabel('handheld report', reviewRiskQueueCount),
+        },
+        { label: 'Rule', value: 'High author risk, or high submission risk + author risk signal' },
+      ],
+      confirmText: getRejectButtonLabel(eligibleCount),
       cancelText: 'Cancel',
+      confirmVariant: 'danger',
     })
     if (!confirmed) return
 
@@ -297,7 +336,6 @@ function AdminApprovalsPage() {
 
   const listings = pendingListingsQuery.data?.listings ?? []
   const pagination = pendingListingsQuery.data?.pagination
-  const canAutoRejectRiskyReports = hasRolePermission(currentUserQuery.data?.role, Role.ADMIN)
 
   return (
     <AdminPageLayout
@@ -372,6 +410,10 @@ function AdminApprovalsPage() {
       {canAutoRejectRiskyReports && reviewRiskFilter.isRiskOnly && (
         <ReviewRiskAutoRejectPanel
           reportLabel="handheld"
+          eligibleCount={autoRejectRiskyPreviewQuery.data?.eligibleCount}
+          reviewRiskQueueCount={autoRejectRiskyPreviewQuery.data?.reviewRiskQueueCount}
+          isCountLoading={autoRejectRiskyPreviewQuery.isPending}
+          hasCountError={autoRejectRiskyPreviewQuery.isError}
           isSubmitting={autoRejectRiskyMutation.isPending}
           onAutoReject={() => {
             void handleAutoRejectRiskyReports()

--- a/src/app/admin/pc-listing-approvals/page.tsx
+++ b/src/app/admin/pc-listing-approvals/page.tsx
@@ -59,6 +59,7 @@ import getErrorMessage from '@/utils/getErrorMessage'
 import getImageUrl from '@/utils/getImageUrl'
 import { hasPermission, PERMISSIONS } from '@/utils/permission-system'
 import { hasRolePermission } from '@/utils/permissions'
+import { formatCountLabel } from '@/utils/text'
 import { Role } from '@orm'
 
 type PendingPcListing = RouterOutput['pcListings']['pending']['pcListings'][number]
@@ -82,6 +83,14 @@ const PC_APPROVALS_COLUMNS: ColumnDefinition[] = [
   { key: 'createdAt', label: 'Submitted', defaultVisible: false },
   { key: 'actions', label: 'Actions', alwaysVisible: true },
 ]
+
+function formatOptionalCountLabel(word: string, count: number | undefined): string {
+  return count === undefined ? 'Loading...' : formatCountLabel(word, count)
+}
+
+function getRejectButtonLabel(count: number): string {
+  return `Reject ${count.toLocaleString()} Report${count === 1 ? '' : 's'}`
+}
 
 function PcListingApprovalsPage() {
   const router = useRouter()
@@ -109,6 +118,7 @@ function PcListingApprovalsPage() {
   })
 
   const currentUserQuery = api.users.me.useQuery()
+  const canAutoRejectRiskyReports = hasRolePermission(currentUserQuery.data?.role, Role.ADMIN)
   const pendingPcListingsQuery = api.pcListings.pending.useQuery({
     page: table.page,
     limit: table.limit,
@@ -116,6 +126,9 @@ function PcListingApprovalsPage() {
     sortDirection: table.sortDirection ?? undefined,
     search: isEmpty(table.search) ? undefined : table.search,
     riskFilter: reviewRiskFilter.riskFilter,
+  })
+  const autoRejectRiskyPreviewQuery = api.pcListings.autoRejectRiskyPreview.useQuery(undefined, {
+    enabled: canAutoRejectRiskyReports && reviewRiskFilter.isRiskOnly,
   })
 
   const gameStatsQuery = api.games.stats.useQuery()
@@ -132,6 +145,7 @@ function PcListingApprovalsPage() {
     await Promise.all([
       pendingPcListingsQuery.refetch(),
       utils.pcListings.stats.invalidate(),
+      utils.pcListings.autoRejectRiskyPreview.invalidate(),
       utils.games.stats.invalidate(),
       utils.pcListings.stats.refetch(),
       utils.games.stats.refetch(),
@@ -250,12 +264,34 @@ function PcListingApprovalsPage() {
   }
 
   const handleAutoRejectRiskyReports = async () => {
+    if (autoRejectRiskyPreviewQuery.isError) {
+      toast.error('Failed to load the auto-reject count. Please refresh and try again.')
+      return
+    }
+
+    const eligibleCount = autoRejectRiskyPreviewQuery.data?.eligibleCount ?? 0
+    if (eligibleCount === 0) {
+      toast.warning('No PC reports currently match the auto-reject rule.')
+      return
+    }
+
+    const eligibleReportCount = formatCountLabel('PC report', eligibleCount)
+    const reviewRiskQueueCount = autoRejectRiskyPreviewQuery.data?.reviewRiskQueueCount
     const confirmed = await confirm({
-      title: 'Reject review-risk PC reports?',
-      description:
-        'This will reject every pending PC report you can review when submission risk is high or author risk has any signal. Rejection notes will be generated automatically.',
-      confirmText: 'Reject PC Reports',
+      title: `Reject ${eligibleReportCount}?`,
+      description: `This scans all pending PC reports and rejects ${eligibleReportCount} with high author risk, or with high submission risk and at least one author risk signal. Rejection notes will be generated automatically.`,
+      details: [
+        { label: 'Will reject', value: eligibleReportCount, tone: 'danger' },
+        { label: 'Scope', value: 'All pending PC reports' },
+        {
+          label: 'All pending review-risk queue',
+          value: formatOptionalCountLabel('PC report', reviewRiskQueueCount),
+        },
+        { label: 'Rule', value: 'High author risk, or high submission risk + author risk signal' },
+      ],
+      confirmText: getRejectButtonLabel(eligibleCount),
       cancelText: 'Cancel',
+      confirmVariant: 'danger',
     })
     if (!confirmed) return
 
@@ -300,7 +336,6 @@ function PcListingApprovalsPage() {
 
   const pcListings = pendingPcListingsQuery.data?.pcListings ?? []
   const pagination = pendingPcListingsQuery.data?.pagination
-  const canAutoRejectRiskyReports = hasRolePermission(currentUserQuery.data?.role, Role.ADMIN)
 
   return (
     <AdminPageLayout
@@ -378,6 +413,10 @@ function PcListingApprovalsPage() {
       {canAutoRejectRiskyReports && reviewRiskFilter.isRiskOnly && (
         <ReviewRiskAutoRejectPanel
           reportLabel="PC"
+          eligibleCount={autoRejectRiskyPreviewQuery.data?.eligibleCount}
+          reviewRiskQueueCount={autoRejectRiskyPreviewQuery.data?.reviewRiskQueueCount}
+          isCountLoading={autoRejectRiskyPreviewQuery.isPending}
+          hasCountError={autoRejectRiskyPreviewQuery.isError}
           isSubmitting={autoRejectRiskyMutation.isPending}
           onAutoReject={() => {
             void handleAutoRejectRiskyReports()

--- a/src/app/admin/pc-listing-approvals/page.tsx
+++ b/src/app/admin/pc-listing-approvals/page.tsx
@@ -16,6 +16,7 @@ import {
   AdminSearchFilters,
   AdminStatsDisplay,
   AdminTableNoResults,
+  ReviewRiskAutoRejectPanel,
   ReviewRiskFilterButton,
   ReviewRiskIndicator,
 } from '@/components/admin'
@@ -57,6 +58,8 @@ import { type RouterOutput, type RouterInput } from '@/types/trpc'
 import getErrorMessage from '@/utils/getErrorMessage'
 import getImageUrl from '@/utils/getImageUrl'
 import { hasPermission, PERMISSIONS } from '@/utils/permission-system'
+import { hasRolePermission } from '@/utils/permissions'
+import { Role } from '@orm'
 
 type PendingPcListing = RouterOutput['pcListings']['pending']['pcListings'][number]
 type PcApprovalSortField =
@@ -216,12 +219,47 @@ function PcListingApprovalsPage() {
     },
   })
 
+  const autoRejectRiskyMutation = api.pcListings.autoRejectRisky.useMutation({
+    onSuccess: async (result) => {
+      toast.success(result.message)
+
+      if (result.rejectedCount > 0) {
+        analytics.admin.bulkOperation({
+          operation: 'reject',
+          entityType: 'listing',
+          count: result.rejectedCount,
+          adminId: currentUserQuery.data?.id ?? 'unknown',
+        })
+      }
+
+      await invalidateQueries()
+      setSelectedListingIds([])
+    },
+    onError: (err) => {
+      logger.error('Failed to auto-reject review-risk PC reports:', err)
+      toast.error(`Failed to auto-reject review-risk PC reports: ${getErrorMessage(err)}`)
+    },
+  })
+
   const handleBulkApprovalWithConfirmation = async (listingIds: string[]) => {
     const confirmed = await confirmBulkApproval(pcListings, listingIds, confirm, 'PC listings')
     if (!confirmed) return
 
     await bulkApproveMutation.mutateAsync({ pcListingIds: listingIds })
     approvalModal.close()
+  }
+
+  const handleAutoRejectRiskyReports = async () => {
+    const confirmed = await confirm({
+      title: 'Reject review-risk PC reports?',
+      description:
+        'This will reject every pending PC report you can review when submission risk is high or author risk has any signal. Rejection notes will be generated automatically.',
+      confirmText: 'Reject PC Reports',
+      cancelText: 'Cancel',
+    })
+    if (!confirmed) return
+
+    await autoRejectRiskyMutation.mutateAsync()
   }
 
   const handleSelectAll = (selected: boolean) => {
@@ -262,6 +300,7 @@ function PcListingApprovalsPage() {
 
   const pcListings = pendingPcListingsQuery.data?.pcListings ?? []
   const pagination = pendingPcListingsQuery.data?.pagination
+  const canAutoRejectRiskyReports = hasRolePermission(currentUserQuery.data?.role, Role.ADMIN)
 
   return (
     <AdminPageLayout
@@ -335,6 +374,16 @@ function PcListingApprovalsPage() {
           onToggle={reviewRiskFilter.toggleRiskFilter}
         />
       </AdminSearchFilters>
+
+      {canAutoRejectRiskyReports && reviewRiskFilter.isRiskOnly && (
+        <ReviewRiskAutoRejectPanel
+          reportLabel="PC"
+          isSubmitting={autoRejectRiskyMutation.isPending}
+          onAutoReject={() => {
+            void handleAutoRejectRiskyReports()
+          }}
+        />
+      )}
 
       {pcListings.length > 0 && (
         <BulkActions

--- a/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.test.tsx
+++ b/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { ReviewRiskAutoRejectPanel } from './ReviewRiskAutoRejectPanel'
+
+describe('ReviewRiskAutoRejectPanel', () => {
+  it('explains the matching rule and calls the auto-reject action', async () => {
+    const user = userEvent.setup()
+    const onAutoReject = vi.fn()
+
+    render(
+      <ReviewRiskAutoRejectPanel
+        reportLabel="PC"
+        isSubmitting={false}
+        onAutoReject={onAutoReject}
+      />,
+    )
+
+    expect(screen.getByText('Auto-reject matching review-risk reports')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Applies to all pending PC reports with high submission risk or any author risk signal.',
+      ),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /reject matching reports/i }))
+
+    expect(onAutoReject).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the action while submitting', () => {
+    render(<ReviewRiskAutoRejectPanel reportLabel="handheld" isSubmitting onAutoReject={vi.fn()} />)
+
+    expect(screen.getByRole('button')).toBeDisabled()
+    expect(screen.getByText(/pending handheld reports/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.test.tsx
+++ b/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.test.tsx
@@ -11,6 +11,10 @@ describe('ReviewRiskAutoRejectPanel', () => {
     render(
       <ReviewRiskAutoRejectPanel
         reportLabel="PC"
+        eligibleCount={3}
+        reviewRiskQueueCount={8}
+        isCountLoading={false}
+        hasCountError={false}
         isSubmitting={false}
         onAutoReject={onAutoReject}
       />,
@@ -19,19 +23,48 @@ describe('ReviewRiskAutoRejectPanel', () => {
     expect(screen.getByText('Auto-reject matching review-risk reports')).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Applies to all pending PC reports with high submission risk or any author risk signal.',
+        'Scans all pending PC reports and matches high author risk, or high submission risk plus at least one author risk signal.',
       ),
     ).toBeInTheDocument()
+    expect(screen.getByText('Eligible: 3 PC reports')).toBeInTheDocument()
+    expect(screen.getByText('All pending review-risk queue: 8 PC reports')).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /reject matching reports/i }))
+    await user.click(screen.getByRole('button', { name: /reject 3 reports/i }))
 
     expect(onAutoReject).toHaveBeenCalledTimes(1)
   })
 
   it('disables the action while submitting', () => {
-    render(<ReviewRiskAutoRejectPanel reportLabel="handheld" isSubmitting onAutoReject={vi.fn()} />)
+    render(
+      <ReviewRiskAutoRejectPanel
+        reportLabel="handheld"
+        eligibleCount={2}
+        reviewRiskQueueCount={4}
+        isCountLoading={false}
+        hasCountError={false}
+        isSubmitting
+        onAutoReject={vi.fn()}
+      />,
+    )
 
     expect(screen.getByRole('button')).toBeDisabled()
     expect(screen.getByText(/pending handheld reports/i)).toBeInTheDocument()
+  })
+
+  it('disables the action when no reports match the auto-reject rule', () => {
+    render(
+      <ReviewRiskAutoRejectPanel
+        reportLabel="handheld"
+        eligibleCount={0}
+        reviewRiskQueueCount={5}
+        isCountLoading={false}
+        hasCountError={false}
+        isSubmitting={false}
+        onAutoReject={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Eligible: 0 handheld reports')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /no matching reports/i })).toBeDisabled()
   })
 })

--- a/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.tsx
+++ b/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.tsx
@@ -1,28 +1,65 @@
 import { ShieldAlert } from 'lucide-react'
-import { Button } from '@/components/ui'
+import { Badge, Button } from '@/components/ui'
+import { formatCountLabel } from '@/utils/text'
 
 interface Props {
   reportLabel: 'handheld' | 'PC'
+  eligibleCount: number | undefined
+  reviewRiskQueueCount: number | undefined
+  isCountLoading: boolean
+  hasCountError: boolean
   isSubmitting: boolean
   onAutoReject: () => void
 }
 
 export function ReviewRiskAutoRejectPanel(props: Props) {
-  const reportLabel = props.reportLabel === 'PC' ? 'PC reports' : 'handheld reports'
+  const singularReportLabel = props.reportLabel === 'PC' ? 'PC report' : 'handheld report'
+  const pluralReportLabel = `${singularReportLabel}s`
+  const eligibleCount = props.eligibleCount ?? 0
+  const canReject = !props.isCountLoading && !props.hasCountError && eligibleCount > 0
+  const eligibleCountLabel = props.hasCountError
+    ? 'Unavailable'
+    : props.isCountLoading
+      ? 'Checking...'
+      : formatCountLabel(singularReportLabel, eligibleCount)
+  const queueCountLabel =
+    props.reviewRiskQueueCount === undefined
+      ? '...'
+      : formatCountLabel(singularReportLabel, props.reviewRiskQueueCount)
+  const buttonLabel = props.hasCountError
+    ? 'Count Unavailable'
+    : props.isCountLoading
+      ? 'Checking Reports'
+      : eligibleCount === 0
+        ? 'No Matching Reports'
+        : `Reject ${eligibleCount.toLocaleString()} Report${eligibleCount === 1 ? '' : 's'}`
 
   return (
-    <div className="mb-4 border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/30 rounded-lg p-4">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex items-start gap-3">
-          <ShieldAlert className="mt-0.5 size-5 shrink-0 text-red-600 dark:text-red-400" />
-          <div>
+    <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/60 dark:bg-red-950/30">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="mt-0.5 rounded-md bg-red-100 p-2 text-red-700 dark:bg-red-900/50 dark:text-red-300">
+            <ShieldAlert className="size-5" />
+          </div>
+          <div className="min-w-0">
             <h2 className="text-sm font-semibold text-red-900 dark:text-red-100">
               Auto-reject matching review-risk reports
             </h2>
             <p className="mt-1 text-sm text-red-800 dark:text-red-200">
-              Applies to all pending {reportLabel} with high submission risk or any author risk
-              signal.
+              Scans all pending {pluralReportLabel} and matches high author risk, or high submission
+              risk plus at least one author risk signal.
             </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Badge variant="danger" size="md">
+                Eligible: {eligibleCountLabel}
+              </Badge>
+              <Badge variant="warning" size="md">
+                All pending review-risk queue: {queueCountLabel}
+              </Badge>
+              <Badge variant="default" size="md">
+                Notes generated per report
+              </Badge>
+            </div>
           </div>
         </div>
         <Button
@@ -30,11 +67,11 @@ export function ReviewRiskAutoRejectPanel(props: Props) {
           size="sm"
           icon={ShieldAlert}
           onClick={props.onAutoReject}
-          disabled={props.isSubmitting}
+          disabled={!canReject || props.isSubmitting}
           isLoading={props.isSubmitting}
-          className="w-full sm:w-auto"
+          className="w-full shrink-0 sm:w-auto"
         >
-          Reject Matching Reports
+          {buttonLabel}
         </Button>
       </div>
     </div>

--- a/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.tsx
+++ b/src/components/admin/review-risk/ReviewRiskAutoRejectPanel.tsx
@@ -1,0 +1,42 @@
+import { ShieldAlert } from 'lucide-react'
+import { Button } from '@/components/ui'
+
+interface Props {
+  reportLabel: 'handheld' | 'PC'
+  isSubmitting: boolean
+  onAutoReject: () => void
+}
+
+export function ReviewRiskAutoRejectPanel(props: Props) {
+  const reportLabel = props.reportLabel === 'PC' ? 'PC reports' : 'handheld reports'
+
+  return (
+    <div className="mb-4 border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/30 rounded-lg p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-start gap-3">
+          <ShieldAlert className="mt-0.5 size-5 shrink-0 text-red-600 dark:text-red-400" />
+          <div>
+            <h2 className="text-sm font-semibold text-red-900 dark:text-red-100">
+              Auto-reject matching review-risk reports
+            </h2>
+            <p className="mt-1 text-sm text-red-800 dark:text-red-200">
+              Applies to all pending {reportLabel} with high submission risk or any author risk
+              signal.
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="danger"
+          size="sm"
+          icon={ShieldAlert}
+          onClick={props.onAutoReject}
+          disabled={props.isSubmitting}
+          isLoading={props.isSubmitting}
+          className="w-full sm:w-auto"
+        >
+          Reject Matching Reports
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/review-risk/index.ts
+++ b/src/components/admin/review-risk/index.ts
@@ -1,2 +1,3 @@
+export * from './ReviewRiskAutoRejectPanel'
 export * from './ReviewRiskIndicator'
 export * from './ReviewRiskWarningBanner'

--- a/src/components/ui/AlertDialog.tsx
+++ b/src/components/ui/AlertDialog.tsx
@@ -2,8 +2,8 @@
 
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 import { type ComponentProps } from 'react'
-import { buttonVariants } from '@/components/ui'
 import { cn } from '@/lib/utils'
+import { buttonVariants, type ButtonVariant } from './Button'
 
 function AlertDialog({ ...props }: ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
@@ -100,9 +100,15 @@ function AlertDialogDescription({
 
 function AlertDialogAction({
   className,
+  variant,
   ...props
-}: ComponentProps<typeof AlertDialogPrimitive.Action>) {
-  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />
+}: ComponentProps<typeof AlertDialogPrimitive.Action> & { variant?: ButtonVariant }) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants({ variant }), className)}
+      {...props}
+    />
+  )
 }
 
 function AlertDialogCancel({

--- a/src/components/ui/ConfirmDialogProvider.test.tsx
+++ b/src/components/ui/ConfirmDialogProvider.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { ConfirmDialogProvider, useConfirmDialog } from './ConfirmDialogProvider'
+
+function ConfirmDialogHarness(props: { onConfirm: (confirmed: boolean) => void }) {
+  const confirm = useConfirmDialog()
+
+  const handleOpen = async () => {
+    const confirmed = await confirm({
+      title: 'Reject review-risk reports?',
+      description: 'This action will reject matching reports.',
+      details: [
+        { label: 'Will reject', value: '3 handheld reports', tone: 'danger' },
+        { label: 'Rule', value: 'High author risk, or high submission risk + author risk signal' },
+      ],
+      confirmText: 'Reject 3 Reports',
+      confirmVariant: 'danger',
+    })
+
+    props.onConfirm(confirmed)
+  }
+
+  return <button onClick={() => void handleOpen()}>Open confirm</button>
+}
+
+describe('ConfirmDialogProvider', () => {
+  it('renders detail rows and destructive confirm styling', async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+
+    render(
+      <ConfirmDialogProvider>
+        <ConfirmDialogHarness onConfirm={onConfirm} />
+      </ConfirmDialogProvider>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /open confirm/i }))
+
+    expect(screen.getByText('Will reject')).toBeInTheDocument()
+    expect(screen.getByText('3 handheld reports')).toBeInTheDocument()
+    expect(screen.getByText('Rule')).toBeInTheDocument()
+
+    const confirmButton = screen.getByRole('button', { name: /reject 3 reports/i })
+    expect(confirmButton).toHaveClass('bg-red-600')
+
+    await user.click(confirmButton)
+
+    expect(onConfirm).toHaveBeenCalledWith(true)
+  })
+
+  it('resolves false when the dialog is dismissed', async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+
+    render(
+      <ConfirmDialogProvider>
+        <ConfirmDialogHarness onConfirm={onConfirm} />
+      </ConfirmDialogProvider>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /open confirm/i }))
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith(false)
+    })
+  })
+})

--- a/src/components/ui/ConfirmDialogProvider.tsx
+++ b/src/components/ui/ConfirmDialogProvider.tsx
@@ -18,12 +18,22 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from '@/components/ui'
+import { cn } from '@/lib/utils'
+import { type ButtonVariant } from './Button'
+
+interface ConfirmDialogDetail {
+  label: string
+  value: string
+  tone?: 'default' | 'danger'
+}
 
 interface ConfirmDialogOptions {
   title?: string
   description?: string
+  details?: ConfirmDialogDetail[]
   confirmText?: string
   cancelText?: string
+  confirmVariant?: ButtonVariant
 }
 
 type ConfirmFn = (options: ConfirmDialogOptions) => Promise<boolean>
@@ -33,30 +43,48 @@ const ConfirmDialogContext = createContext<ConfirmFn>(() => Promise.resolve(fals
 export function ConfirmDialogProvider(props: PropsWithChildren) {
   const [open, setOpen] = useState(false)
   const [options, setOptions] = useState<ConfirmDialogOptions>({})
-  const resolveRef = useRef<(result: boolean) => void>(() => {})
+  const resolveRef = useRef<((result: boolean) => void) | null>(null)
 
-  const confirm: ConfirmFn = useCallback((opts) => {
-    setOptions(opts)
-    setOpen(true)
-    return new Promise((resolve) => {
-      resolveRef.current = resolve
-    })
+  const resolveDialog = useCallback((result: boolean) => {
+    const resolve = resolveRef.current
+    resolveRef.current = null
+    resolve?.(result)
   }, [])
+
+  const confirm: ConfirmFn = useCallback(
+    (opts) => {
+      resolveDialog(false)
+      setOptions(opts)
+      setOpen(true)
+      return new Promise((resolve) => {
+        resolveRef.current = resolve
+      })
+    },
+    [resolveDialog],
+  )
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      if (!nextOpen) resolveDialog(false)
+    },
+    [resolveDialog],
+  )
 
   const handleCancel = useCallback(() => {
     setOpen(false)
-    resolveRef.current?.(false)
-  }, [])
+    resolveDialog(false)
+  }, [resolveDialog])
 
   const handleConfirm = useCallback(() => {
     setOpen(false)
-    resolveRef.current?.(true)
-  }, [])
+    resolveDialog(true)
+  }, [resolveDialog])
 
   return (
     <ConfirmDialogContext.Provider value={confirm}>
       {props.children}
-      <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
         <AlertDialogContent title={options.title ?? 'Are you sure?'}>
           <AlertDialogHeader>
             <AlertDialogTitle>{options.title ?? 'Are you sure?'}</AlertDialogTitle>
@@ -64,11 +92,31 @@ export function ConfirmDialogProvider(props: PropsWithChildren) {
               <AlertDialogDescription>{options.description}</AlertDialogDescription>
             )}
           </AlertDialogHeader>
+          {options.details && options.details.length > 0 && (
+            <dl className="grid gap-2 rounded-md border bg-gray-50 p-3 text-sm dark:bg-gray-900/40">
+              {options.details.map((detail, index) => (
+                <div
+                  key={`${detail.label}-${index}`}
+                  className="grid gap-1 sm:grid-cols-[max-content_minmax(0,1fr)] sm:gap-4"
+                >
+                  <dt className="text-gray-600 dark:text-gray-400">{detail.label}</dt>
+                  <dd
+                    className={cn(
+                      'min-w-0 break-words font-medium text-gray-900 sm:text-right dark:text-gray-100',
+                      detail.tone === 'danger' && 'text-red-700 dark:text-red-300',
+                    )}
+                  >
+                    {detail.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel onClick={handleCancel}>
               {options.cancelText ?? 'Cancel'}
             </AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirm}>
+            <AlertDialogAction onClick={handleConfirm} variant={options.confirmVariant}>
               {options.confirmText ?? 'Confirm'}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/server/api/routers/listings.ts
+++ b/src/server/api/routers/listings.ts
@@ -25,6 +25,7 @@ export const listingsRouter = createTRPCRouter({
   resetToPending: adminRouter.resetToPending,
   bulkApproveListing: adminRouter.bulkApprove,
   bulkRejectListing: adminRouter.bulkReject,
+  autoRejectRiskyListings: adminRouter.autoRejectRisky,
   getProcessed: adminRouter.getProcessed,
   overrideApprovalStatus: adminRouter.overrideStatus,
   delete: adminRouter.delete,

--- a/src/server/api/routers/listings.ts
+++ b/src/server/api/routers/listings.ts
@@ -25,6 +25,7 @@ export const listingsRouter = createTRPCRouter({
   resetToPending: adminRouter.resetToPending,
   bulkApproveListing: adminRouter.bulkApprove,
   bulkRejectListing: adminRouter.bulkReject,
+  autoRejectRiskyListingsPreview: adminRouter.autoRejectRiskyPreview,
   autoRejectRiskyListings: adminRouter.autoRejectRisky,
   getProcessed: adminRouter.getProcessed,
   overrideApprovalStatus: adminRouter.overrideStatus,

--- a/src/server/api/routers/listings/admin.test.ts
+++ b/src/server/api/routers/listings/admin.test.ts
@@ -16,6 +16,7 @@ const mockListVerifiedEmulatorIdsByUserId = vi.fn()
 const mockGetPendingListingRiskCandidates = vi.fn()
 const mockGetPendingListingsByIds = vi.fn()
 const mockGetPendingListings = vi.fn()
+const mockApplyTrustAction = vi.fn().mockResolvedValue(undefined)
 
 vi.mock('@/server/services/author-risk.service', async (importOriginal) => {
   const actual = await importOriginal<typeof AuthorRiskService>()
@@ -31,7 +32,7 @@ vi.mock('@/server/services/submission-risk.service', () => ({
 }))
 
 vi.mock('@/lib/trust/service', () => ({
-  applyTrustAction: vi.fn().mockResolvedValue(undefined),
+  applyTrustAction: (...args: unknown[]) => mockApplyTrustAction(...args),
 }))
 
 vi.mock('@/server/notifications/eventEmitter', () => ({
@@ -85,15 +86,15 @@ const LISTING_ID = '00000000-0000-4000-a000-000000000010'
 const LISTING_ID_B = '00000000-0000-4000-a000-000000000011'
 const LISTING_ID_C = '00000000-0000-4000-a000-000000000012'
 
-function createCaller() {
+function createCaller(overrides: { userId?: string; role?: Role } = {}) {
   return {
     caller: adminRouter.createCaller({
       session: {
         user: {
-          id: ADMIN_ID,
+          id: overrides.userId ?? ADMIN_ID,
           email: 'admin@test.com',
           name: 'Admin User',
-          role: Role.MODERATOR,
+          role: overrides.role ?? Role.MODERATOR,
           permissions: [],
           showNsfw: false,
         },
@@ -257,5 +258,168 @@ describe('listing admin pending approvals', () => {
     expect(mockGetPendingListingsByIds).not.toHaveBeenCalled()
     expect(result.listings).toHaveLength(0)
     expect(result.pagination.total).toBe(0)
+  })
+})
+
+describe('listing admin auto risk rejection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockComputeAuthorRiskProfiles.mockResolvedValue(new Map())
+    mockComputeSubmissionRiskProfiles.mockResolvedValue(new Map())
+    mockListVerifiedEmulatorIdsByUserId.mockResolvedValue([])
+    mockGetPendingListingRiskCandidates.mockResolvedValue([])
+  })
+
+  function setupPrisma() {
+    const tx = {
+      listing: {
+        findMany: vi.fn(),
+        update: vi.fn().mockResolvedValue({}),
+      },
+    }
+    const prismaMock = prisma as unknown as {
+      user: { findUnique: ReturnType<typeof vi.fn> }
+      listing: typeof tx.listing
+      $transaction: ReturnType<typeof vi.fn>
+    }
+
+    prismaMock.user = {
+      findUnique: vi.fn().mockResolvedValue({ id: ADMIN_ID }),
+    }
+    prismaMock.listing = tx.listing
+    prismaMock.$transaction = vi.fn(
+      async (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx),
+    )
+
+    return { tx, prismaMock }
+  }
+
+  it('rejects pending handheld reports matched by high submission risk or any author risk', async () => {
+    const { tx } = setupPrisma()
+    const highSubmissionListing = {
+      id: LISTING_ID,
+      authorId: CLEAN_AUTHOR_ID,
+      author: { userBans: [] },
+      customFieldValues: [],
+    }
+    const authorRiskListing = {
+      id: LISTING_ID_B,
+      authorId: AUTHOR_ID,
+      author: { userBans: [] },
+      customFieldValues: [],
+    }
+    const cleanListing = {
+      id: LISTING_ID_C,
+      authorId: CLEAN_AUTHOR_ID,
+      author: { userBans: [] },
+      customFieldValues: [],
+    }
+
+    mockGetPendingListingRiskCandidates.mockResolvedValueOnce([
+      highSubmissionListing,
+      authorRiskListing,
+      cleanListing,
+    ])
+    mockComputeAuthorRiskProfiles.mockResolvedValue(
+      new Map([
+        [CLEAN_AUTHOR_ID, { authorId: CLEAN_AUTHOR_ID, signals: [], highestSeverity: null }],
+        [
+          AUTHOR_ID,
+          {
+            authorId: AUTHOR_ID,
+            highestSeverity: 'low',
+            signals: [
+              {
+                type: RISK_SIGNAL_TYPES.NEW_AUTHOR,
+                severity: 'low',
+                label: 'New Author',
+                description: 'No previously approved listings',
+              },
+            ],
+          },
+        ],
+      ]),
+    )
+    mockComputeSubmissionRiskProfiles.mockResolvedValue(
+      new Map([
+        [
+          LISTING_ID,
+          {
+            listingId: LISTING_ID,
+            highestSeverity: 'high',
+            signals: [
+              {
+                type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                severity: 'high',
+                label: 'Placeholder Emulator Version',
+                description: 'Submitted emulator version resembles placeholder text.',
+              },
+            ],
+          },
+        ],
+        [LISTING_ID_B, { listingId: LISTING_ID_B, signals: [], highestSeverity: null }],
+        [LISTING_ID_C, { listingId: LISTING_ID_C, signals: [], highestSeverity: null }],
+      ]),
+    )
+    tx.listing.findMany.mockResolvedValueOnce([
+      { id: LISTING_ID, authorId: CLEAN_AUTHOR_ID, deviceId: 'device-1' },
+      { id: LISTING_ID_B, authorId: AUTHOR_ID, deviceId: 'device-2' },
+    ])
+
+    const { caller } = createCaller({ role: Role.ADMIN })
+
+    const result = await caller.autoRejectRisky()
+
+    expect(mockGetPendingListingRiskCandidates).toHaveBeenCalledWith({})
+    expect(tx.listing.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: [LISTING_ID, LISTING_ID_B] },
+        status: 'PENDING',
+      },
+      include: { author: { select: { id: true } } },
+    })
+    expect(tx.listing.update).toHaveBeenCalledWith({
+      where: { id: LISTING_ID },
+      data: expect.objectContaining({
+        status: 'REJECTED',
+        processedByUserId: ADMIN_ID,
+        processedNotes:
+          'Automatically rejected by review risk bulk action: submission risk high severity.',
+      }),
+    })
+    expect(tx.listing.update).toHaveBeenCalledWith({
+      where: { id: LISTING_ID_B },
+      data: expect.objectContaining({
+        status: 'REJECTED',
+        processedByUserId: ADMIN_ID,
+        processedNotes:
+          'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+      }),
+    })
+    expect(mockApplyTrustAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: AUTHOR_ID,
+        context: expect.objectContaining({
+          listingId: LISTING_ID_B,
+          reason:
+            'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+        }),
+      }),
+    )
+    expect(result).toMatchObject({
+      success: true,
+      rejectedCount: 2,
+      skippedCount: 0,
+    })
+  })
+
+  it('requires admin role for automatic risk rejection', async () => {
+    setupPrisma()
+
+    const { caller } = createCaller({ role: Role.MODERATOR })
+
+    await expect(caller.autoRejectRisky()).rejects.toThrow(/admin|insufficient/i)
+
+    expect(mockGetPendingListingRiskCandidates).not.toHaveBeenCalled()
   })
 })

--- a/src/server/api/routers/listings/admin.test.ts
+++ b/src/server/api/routers/listings/admin.test.ts
@@ -82,9 +82,11 @@ const { adminRouter } = await import('./admin')
 const ADMIN_ID = '00000000-0000-4000-a000-000000000001'
 const AUTHOR_ID = '00000000-0000-4000-a000-000000000002'
 const CLEAN_AUTHOR_ID = '00000000-0000-4000-a000-000000000003'
+const HIGH_RISK_AUTHOR_ID = '00000000-0000-4000-a000-000000000004'
 const LISTING_ID = '00000000-0000-4000-a000-000000000010'
 const LISTING_ID_B = '00000000-0000-4000-a000-000000000011'
 const LISTING_ID_C = '00000000-0000-4000-a000-000000000012'
+const LISTING_ID_D = '00000000-0000-4000-a000-000000000013'
 
 function createCaller(overrides: { userId?: string; role?: Role } = {}) {
   return {
@@ -294,31 +296,38 @@ describe('listing admin auto risk rejection', () => {
     return { tx, prismaMock }
   }
 
-  it('rejects pending handheld reports matched by high submission risk or any author risk', async () => {
+  it('rejects pending handheld reports with high author risk or high submission risk with author risk', async () => {
     const { tx } = setupPrisma()
-    const highSubmissionListing = {
+    const highSubmissionOnlyListing = {
       id: LISTING_ID,
       authorId: CLEAN_AUTHOR_ID,
       author: { userBans: [] },
       customFieldValues: [],
     }
-    const authorRiskListing = {
+    const authorRiskOnlyListing = {
       id: LISTING_ID_B,
       authorId: AUTHOR_ID,
       author: { userBans: [] },
       customFieldValues: [],
     }
-    const cleanListing = {
+    const matchingListing = {
       id: LISTING_ID_C,
-      authorId: CLEAN_AUTHOR_ID,
+      authorId: AUTHOR_ID,
+      author: { userBans: [] },
+      customFieldValues: [],
+    }
+    const highAuthorRiskOnlyListing = {
+      id: LISTING_ID_D,
+      authorId: HIGH_RISK_AUTHOR_ID,
       author: { userBans: [] },
       customFieldValues: [],
     }
 
     mockGetPendingListingRiskCandidates.mockResolvedValueOnce([
-      highSubmissionListing,
-      authorRiskListing,
-      cleanListing,
+      highSubmissionOnlyListing,
+      authorRiskOnlyListing,
+      matchingListing,
+      highAuthorRiskOnlyListing,
     ])
     mockComputeAuthorRiskProfiles.mockResolvedValue(
       new Map([
@@ -334,6 +343,21 @@ describe('listing admin auto risk rejection', () => {
                 severity: 'low',
                 label: 'New Author',
                 description: 'No previously approved listings',
+              },
+            ],
+          },
+        ],
+        [
+          HIGH_RISK_AUTHOR_ID,
+          {
+            authorId: HIGH_RISK_AUTHOR_ID,
+            highestSeverity: 'high',
+            signals: [
+              {
+                type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                severity: 'high',
+                label: 'Active Ban',
+                description: 'Banned for spam',
               },
             ],
           },
@@ -358,12 +382,26 @@ describe('listing admin auto risk rejection', () => {
           },
         ],
         [LISTING_ID_B, { listingId: LISTING_ID_B, signals: [], highestSeverity: null }],
-        [LISTING_ID_C, { listingId: LISTING_ID_C, signals: [], highestSeverity: null }],
+        [
+          LISTING_ID_C,
+          {
+            listingId: LISTING_ID_C,
+            highestSeverity: 'high',
+            signals: [
+              {
+                type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                severity: 'high',
+                label: 'Placeholder Emulator Version',
+                description: 'Submitted emulator version resembles placeholder text.',
+              },
+            ],
+          },
+        ],
       ]),
     )
     tx.listing.findMany.mockResolvedValueOnce([
-      { id: LISTING_ID, authorId: CLEAN_AUTHOR_ID, deviceId: 'device-1' },
-      { id: LISTING_ID_B, authorId: AUTHOR_ID, deviceId: 'device-2' },
+      { id: LISTING_ID_C, authorId: AUTHOR_ID, deviceId: 'device-3' },
+      { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID, deviceId: 'device-4' },
     ])
 
     const { caller } = createCaller({ role: Role.ADMIN })
@@ -373,36 +411,47 @@ describe('listing admin auto risk rejection', () => {
     expect(mockGetPendingListingRiskCandidates).toHaveBeenCalledWith({})
     expect(tx.listing.findMany).toHaveBeenCalledWith({
       where: {
-        id: { in: [LISTING_ID, LISTING_ID_B] },
+        id: { in: [LISTING_ID_C, LISTING_ID_D] },
         status: 'PENDING',
       },
       include: { author: { select: { id: true } } },
     })
+    expect(tx.listing.update).toHaveBeenCalledTimes(2)
     expect(tx.listing.update).toHaveBeenCalledWith({
-      where: { id: LISTING_ID },
+      where: { id: LISTING_ID_C },
       data: expect.objectContaining({
         status: 'REJECTED',
         processedByUserId: ADMIN_ID,
         processedNotes:
-          'Automatically rejected by review risk bulk action: submission risk high severity.',
+          'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
       }),
     })
     expect(tx.listing.update).toHaveBeenCalledWith({
-      where: { id: LISTING_ID_B },
+      where: { id: LISTING_ID_D },
       data: expect.objectContaining({
         status: 'REJECTED',
         processedByUserId: ADMIN_ID,
         processedNotes:
-          'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+          'Automatically rejected by review risk bulk action: author risk high severity (1 signal).',
       }),
     })
     expect(mockApplyTrustAction).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: AUTHOR_ID,
         context: expect.objectContaining({
-          listingId: LISTING_ID_B,
+          listingId: LISTING_ID_C,
           reason:
-            'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+            'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
+        }),
+      }),
+    )
+    expect(mockApplyTrustAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: HIGH_RISK_AUTHOR_ID,
+        context: expect.objectContaining({
+          listingId: LISTING_ID_D,
+          reason:
+            'Automatically rejected by review risk bulk action: author risk high severity (1 signal).',
         }),
       }),
     )
@@ -413,11 +462,106 @@ describe('listing admin auto risk rejection', () => {
     })
   })
 
+  it('returns the admin-only auto-reject preview count', async () => {
+    mockGetPendingListingRiskCandidates.mockResolvedValueOnce([
+      { id: LISTING_ID, authorId: AUTHOR_ID, author: { userBans: [] }, customFieldValues: [] },
+      {
+        id: LISTING_ID_B,
+        authorId: CLEAN_AUTHOR_ID,
+        author: { userBans: [] },
+        customFieldValues: [],
+      },
+      {
+        id: LISTING_ID_D,
+        authorId: HIGH_RISK_AUTHOR_ID,
+        author: { userBans: [] },
+        customFieldValues: [],
+      },
+    ])
+    mockComputeAuthorRiskProfiles.mockResolvedValue(
+      new Map([
+        [
+          AUTHOR_ID,
+          {
+            authorId: AUTHOR_ID,
+            highestSeverity: 'low',
+            signals: [
+              {
+                type: RISK_SIGNAL_TYPES.NEW_AUTHOR,
+                severity: 'low',
+                label: 'New Author',
+                description: 'No previously approved listings',
+              },
+            ],
+          },
+        ],
+        [
+          HIGH_RISK_AUTHOR_ID,
+          {
+            authorId: HIGH_RISK_AUTHOR_ID,
+            highestSeverity: 'high',
+            signals: [
+              {
+                type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                severity: 'high',
+                label: 'Active Ban',
+                description: 'Banned for spam',
+              },
+            ],
+          },
+        ],
+        [CLEAN_AUTHOR_ID, { authorId: CLEAN_AUTHOR_ID, signals: [], highestSeverity: null }],
+      ]),
+    )
+    mockComputeSubmissionRiskProfiles.mockResolvedValue(
+      new Map([
+        [
+          LISTING_ID,
+          {
+            listingId: LISTING_ID,
+            highestSeverity: 'high',
+            signals: [
+              {
+                type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                severity: 'high',
+                label: 'Placeholder Emulator Version',
+                description: 'Submitted emulator version resembles placeholder text.',
+              },
+            ],
+          },
+        ],
+        [
+          LISTING_ID_B,
+          {
+            listingId: LISTING_ID_B,
+            highestSeverity: 'high',
+            signals: [
+              {
+                type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                severity: 'high',
+                label: 'Placeholder Emulator Version',
+                description: 'Submitted emulator version resembles placeholder text.',
+              },
+            ],
+          },
+        ],
+      ]),
+    )
+
+    const { caller } = createCaller({ role: Role.ADMIN })
+
+    await expect(caller.autoRejectRiskyPreview()).resolves.toEqual({
+      eligibleCount: 2,
+      reviewRiskQueueCount: 3,
+    })
+  })
+
   it('requires admin role for automatic risk rejection', async () => {
     setupPrisma()
 
     const { caller } = createCaller({ role: Role.MODERATOR })
 
+    await expect(caller.autoRejectRiskyPreview()).rejects.toThrow(/admin|insufficient/i)
     await expect(caller.autoRejectRisky()).rejects.toThrow(/admin|insufficient/i)
 
     expect(mockGetPendingListingRiskCandidates).not.toHaveBeenCalled()

--- a/src/server/api/routers/listings/admin.test.ts
+++ b/src/server/api/routers/listings/admin.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { RISK_SIGNAL_TYPES } from '@/schemas/authorRisk'
 import { SUBMISSION_RISK_SIGNAL_TYPES } from '@/schemas/submissionRisk'
-import { Role } from '@orm/client'
+import { ApprovalStatus, Role } from '@orm/client'
 import type * as AuthorRiskService from '@/server/services/author-risk.service'
 
 vi.unmock('@/server/api/trpc')
@@ -276,7 +276,7 @@ describe('listing admin auto risk rejection', () => {
     const tx = {
       listing: {
         findMany: vi.fn(),
-        update: vi.fn().mockResolvedValue({}),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
     }
     const prismaMock = prisma as unknown as {
@@ -412,24 +412,24 @@ describe('listing admin auto risk rejection', () => {
     expect(tx.listing.findMany).toHaveBeenCalledWith({
       where: {
         id: { in: [LISTING_ID_C, LISTING_ID_D] },
-        status: 'PENDING',
+        status: ApprovalStatus.PENDING,
       },
-      include: { author: { select: { id: true } } },
+      select: { id: true, authorId: true, deviceId: true },
     })
-    expect(tx.listing.update).toHaveBeenCalledTimes(2)
-    expect(tx.listing.update).toHaveBeenCalledWith({
-      where: { id: LISTING_ID_C },
+    expect(tx.listing.updateMany).toHaveBeenCalledTimes(2)
+    expect(tx.listing.updateMany).toHaveBeenCalledWith({
+      where: { id: LISTING_ID_C, status: ApprovalStatus.PENDING },
       data: expect.objectContaining({
-        status: 'REJECTED',
+        status: ApprovalStatus.REJECTED,
         processedByUserId: ADMIN_ID,
         processedNotes:
           'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
       }),
     })
-    expect(tx.listing.update).toHaveBeenCalledWith({
-      where: { id: LISTING_ID_D },
+    expect(tx.listing.updateMany).toHaveBeenCalledWith({
+      where: { id: LISTING_ID_D, status: ApprovalStatus.PENDING },
       data: expect.objectContaining({
-        status: 'REJECTED',
+        status: ApprovalStatus.REJECTED,
         processedByUserId: ADMIN_ID,
         processedNotes:
           'Automatically rejected by review risk bulk action: author risk high severity (1 signal).',
@@ -460,6 +460,59 @@ describe('listing admin auto risk rejection', () => {
       rejectedCount: 2,
       skippedCount: 0,
     })
+  })
+
+  it('keeps handheld auto-rejection successful when trust action emission fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const { tx } = setupPrisma()
+
+    mockGetPendingListingRiskCandidates.mockResolvedValueOnce([
+      {
+        id: LISTING_ID_D,
+        authorId: HIGH_RISK_AUTHOR_ID,
+        author: { userBans: [] },
+        customFieldValues: [],
+      },
+    ])
+    mockComputeAuthorRiskProfiles.mockResolvedValue(
+      new Map([
+        [
+          HIGH_RISK_AUTHOR_ID,
+          {
+            authorId: HIGH_RISK_AUTHOR_ID,
+            highestSeverity: 'high',
+            signals: [
+              {
+                type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                severity: 'high',
+                label: 'Active Ban',
+                description: 'Banned for spam',
+              },
+            ],
+          },
+        ],
+      ]),
+    )
+    tx.listing.findMany.mockResolvedValueOnce([
+      { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID, deviceId: 'device-4' },
+    ])
+    mockApplyTrustAction.mockRejectedValueOnce(new Error('trust failed'))
+
+    const { caller } = createCaller({ role: Role.ADMIN })
+
+    await expect(caller.autoRejectRisky()).resolves.toMatchObject({
+      success: true,
+      rejectedCount: 1,
+      skippedCount: 0,
+    })
+    expect(consoleError).toHaveBeenCalledWith(
+      'Some trust actions failed during review-risk handheld auto-rejection:',
+      expect.arrayContaining([
+        expect.objectContaining({ status: 'rejected', reason: expect.any(Error) }),
+      ]),
+    )
+
+    consoleError.mockRestore()
   })
 
   it('returns the admin-only auto-reject preview count', async () => {

--- a/src/server/api/routers/listings/admin.ts
+++ b/src/server/api/routers/listings/admin.ts
@@ -32,11 +32,11 @@ import { invalidateListingSeo, invalidateListingsSeo } from '@/server/cache/inva
 import { notificationEventEmitter, NOTIFICATION_EVENTS } from '@/server/notifications/eventEmitter'
 import { ListingsRepository } from '@/server/repositories/listings.repository'
 import { PcListingsRepository } from '@/server/repositories/pc-listings.repository'
+import { autoRejectRiskyHandheldReports } from '@/server/services/review-risk-auto-reject.service'
 import {
   attachReviewRiskProfiles,
   computeReviewRiskProfiles,
   getAutoRejectableReviewRiskPreviewForCandidates,
-  getAutoRejectableReviewRiskItemsForCandidates,
   getRiskOnlyReviewPage,
 } from '@/server/services/review-risk.service'
 import {
@@ -843,7 +843,6 @@ export const adminRouter = createTRPCRouter({
   }),
 
   autoRejectRisky: adminProcedure.mutation(async ({ ctx }) => {
-    const repository = new ListingsRepository(ctx.prisma)
     const adminUserId = ctx.session.user.id
 
     const adminUserExists = await ctx.prisma.user.findUnique({
@@ -852,118 +851,10 @@ export const adminRouter = createTRPCRouter({
     })
     if (!adminUserExists) return ResourceError.user.notInDatabase(adminUserId)
 
-    const autoRejectItems = await getAutoRejectableReviewRiskItemsForCandidates({
+    return autoRejectRiskyHandheldReports({
       prisma: ctx.prisma,
-      loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+      adminUserId,
     })
-
-    if (autoRejectItems.length === 0) {
-      return {
-        success: true,
-        rejectedCount: 0,
-        skippedCount: 0,
-        message: 'No auto-rejectable review-risk handheld reports found.',
-      }
-    }
-
-    const processedNotesById = new Map(
-      autoRejectItems.map((item) => [item.id, item.processedNotes]),
-    )
-    const listingIds = autoRejectItems.map((item) => item.id)
-
-    const transactionResult = await ctx.prisma.$transaction(async (tx) => {
-      const listingsToReject = await tx.listing.findMany({
-        where: {
-          id: { in: listingIds },
-          status: ApprovalStatus.PENDING,
-        },
-        include: { author: { select: { id: true } } },
-      })
-
-      for (const listing of listingsToReject) {
-        await tx.listing.update({
-          where: { id: listing.id },
-          data: {
-            status: ApprovalStatus.REJECTED,
-            processedByUserId: adminUserId,
-            processedAt: new Date(),
-            processedNotes:
-              processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.',
-          },
-        })
-      }
-
-      return {
-        listingsToReject,
-        skippedCount: listingIds.length - listingsToReject.length,
-      }
-    })
-
-    const rejectedListingsWithAuthor = transactionResult.listingsToReject.filter(
-      (l): l is typeof l & { authorId: string } => l.authorId !== null,
-    )
-    await Promise.all(
-      rejectedListingsWithAuthor.map((listing) => {
-        const processedNotes =
-          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
-
-        return applyTrustAction({
-          userId: listing.authorId,
-          action: TrustAction.LISTING_REJECTED,
-          context: {
-            listingId: listing.id,
-            adminUserId,
-            reason: processedNotes,
-          },
-        })
-      }),
-    )
-
-    try {
-      const rejectedAt = new Date()
-
-      for (const listing of transactionResult.listingsToReject) {
-        const processedNotes =
-          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
-
-        try {
-          notificationEventEmitter.emitNotificationEvent({
-            eventType: NOTIFICATION_EVENTS.LISTING_REJECTED,
-            entityType: 'listing',
-            entityId: listing.id,
-            triggeredBy: adminUserId,
-            payload: {
-              listingId: listing.id,
-              rejectedBy: adminUserId,
-              rejectedAt,
-              rejectionReason: processedNotes,
-              bulk: true,
-            },
-          })
-        } catch (notificationError) {
-          console.error(`Failed to emit notification for listing ${listing.id}:`, notificationError)
-        }
-      }
-    } catch (error) {
-      console.error('Error emitting review-risk auto-rejection notifications:', error)
-    }
-
-    listingStatsCache.delete(LISTING_STATS_CACHE_KEY)
-    invalidateCatalogCompatibilityCacheForDevices(
-      transactionResult.listingsToReject.map((listing) => listing.deviceId),
-    )
-
-    const message =
-      transactionResult.skippedCount > 0
-        ? `Automatically rejected ${transactionResult.listingsToReject.length} review-risk handheld report(s). ${transactionResult.skippedCount} handheld report(s) were skipped because they were already processed.`
-        : `Automatically rejected ${transactionResult.listingsToReject.length} review-risk handheld report(s).`
-
-    return {
-      success: true,
-      rejectedCount: transactionResult.listingsToReject.length,
-      skippedCount: transactionResult.skippedCount,
-      message,
-    }
   }),
 
   stats: viewStatisticsProcedure.query(async ({ ctx }) => {

--- a/src/server/api/routers/listings/admin.ts
+++ b/src/server/api/routers/listings/admin.ts
@@ -35,6 +35,7 @@ import { PcListingsRepository } from '@/server/repositories/pc-listings.reposito
 import {
   attachReviewRiskProfiles,
   computeReviewRiskProfiles,
+  getAutoRejectableReviewRiskPreviewForCandidates,
   getAutoRejectableReviewRiskItemsForCandidates,
   getRiskOnlyReviewPage,
 } from '@/server/services/review-risk.service'
@@ -831,6 +832,15 @@ export const adminRouter = createTRPCRouter({
         message,
       }
     }),
+
+  autoRejectRiskyPreview: adminProcedure.query(async ({ ctx }) => {
+    const repository = new ListingsRepository(ctx.prisma)
+
+    return getAutoRejectableReviewRiskPreviewForCandidates({
+      prisma: ctx.prisma,
+      loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+    })
+  }),
 
   autoRejectRisky: adminProcedure.mutation(async ({ ctx }) => {
     const repository = new ListingsRepository(ctx.prisma)

--- a/src/server/api/routers/listings/admin.ts
+++ b/src/server/api/routers/listings/admin.ts
@@ -22,6 +22,7 @@ import {
   deleteAnyListingProcedure,
   moderatorProcedure,
   superAdminProcedure,
+  adminProcedure,
   developerProcedure,
   viewStatisticsProcedure,
   protectedProcedure,
@@ -34,6 +35,7 @@ import { PcListingsRepository } from '@/server/repositories/pc-listings.reposito
 import {
   attachReviewRiskProfiles,
   computeReviewRiskProfiles,
+  getAutoRejectableReviewRiskItemsForCandidates,
   getRiskOnlyReviewPage,
 } from '@/server/services/review-risk.service'
 import {
@@ -829,6 +831,130 @@ export const adminRouter = createTRPCRouter({
         message,
       }
     }),
+
+  autoRejectRisky: adminProcedure.mutation(async ({ ctx }) => {
+    const repository = new ListingsRepository(ctx.prisma)
+    const adminUserId = ctx.session.user.id
+
+    const adminUserExists = await ctx.prisma.user.findUnique({
+      where: { id: adminUserId },
+      select: { id: true },
+    })
+    if (!adminUserExists) return ResourceError.user.notInDatabase(adminUserId)
+
+    const autoRejectItems = await getAutoRejectableReviewRiskItemsForCandidates({
+      prisma: ctx.prisma,
+      loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+    })
+
+    if (autoRejectItems.length === 0) {
+      return {
+        success: true,
+        rejectedCount: 0,
+        skippedCount: 0,
+        message: 'No auto-rejectable review-risk handheld reports found.',
+      }
+    }
+
+    const processedNotesById = new Map(
+      autoRejectItems.map((item) => [item.id, item.processedNotes]),
+    )
+    const listingIds = autoRejectItems.map((item) => item.id)
+
+    const transactionResult = await ctx.prisma.$transaction(async (tx) => {
+      const listingsToReject = await tx.listing.findMany({
+        where: {
+          id: { in: listingIds },
+          status: ApprovalStatus.PENDING,
+        },
+        include: { author: { select: { id: true } } },
+      })
+
+      for (const listing of listingsToReject) {
+        await tx.listing.update({
+          where: { id: listing.id },
+          data: {
+            status: ApprovalStatus.REJECTED,
+            processedByUserId: adminUserId,
+            processedAt: new Date(),
+            processedNotes:
+              processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.',
+          },
+        })
+      }
+
+      return {
+        listingsToReject,
+        skippedCount: listingIds.length - listingsToReject.length,
+      }
+    })
+
+    const rejectedListingsWithAuthor = transactionResult.listingsToReject.filter(
+      (l): l is typeof l & { authorId: string } => l.authorId !== null,
+    )
+    await Promise.all(
+      rejectedListingsWithAuthor.map((listing) => {
+        const processedNotes =
+          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
+
+        return applyTrustAction({
+          userId: listing.authorId,
+          action: TrustAction.LISTING_REJECTED,
+          context: {
+            listingId: listing.id,
+            adminUserId,
+            reason: processedNotes,
+          },
+        })
+      }),
+    )
+
+    try {
+      const rejectedAt = new Date()
+
+      for (const listing of transactionResult.listingsToReject) {
+        const processedNotes =
+          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
+
+        try {
+          notificationEventEmitter.emitNotificationEvent({
+            eventType: NOTIFICATION_EVENTS.LISTING_REJECTED,
+            entityType: 'listing',
+            entityId: listing.id,
+            triggeredBy: adminUserId,
+            payload: {
+              listingId: listing.id,
+              rejectedBy: adminUserId,
+              rejectedAt,
+              rejectionReason: processedNotes,
+              bulk: true,
+            },
+          })
+        } catch (notificationError) {
+          console.error(`Failed to emit notification for listing ${listing.id}:`, notificationError)
+        }
+      }
+    } catch (error) {
+      console.error('Error emitting review-risk auto-rejection notifications:', error)
+    }
+
+    listingStatsCache.delete(LISTING_STATS_CACHE_KEY)
+    invalidateCatalogCompatibilityCacheForDevices(
+      transactionResult.listingsToReject.map((listing) => listing.deviceId),
+    )
+
+    const message =
+      transactionResult.skippedCount > 0
+        ? `Automatically rejected ${transactionResult.listingsToReject.length} review-risk handheld report(s). ${transactionResult.skippedCount} handheld report(s) were skipped because they were already processed.`
+        : `Automatically rejected ${transactionResult.listingsToReject.length} review-risk handheld report(s).`
+
+    return {
+      success: true,
+      rejectedCount: transactionResult.listingsToReject.length,
+      skippedCount: transactionResult.skippedCount,
+      message,
+    }
+  }),
 
   stats: viewStatisticsProcedure.query(async ({ ctx }) => {
     const [pending, approved, rejected] = await Promise.all([

--- a/src/server/api/routers/pcListings.test.ts
+++ b/src/server/api/routers/pcListings.test.ts
@@ -196,6 +196,9 @@ function createMockPrisma() {
       update: vi.fn(),
       updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
+    user: {
+      findUnique: vi.fn().mockResolvedValue({ id: ADMIN_ID }),
+    },
     userBan: {
       findMany: vi.fn().mockResolvedValue([]),
     },
@@ -1239,6 +1242,16 @@ describe('pcListings trust integration', () => {
       )
 
       consoleError.mockRestore()
+    })
+
+    it('fails automatic PC risk rejection when the admin user is missing from the database', async () => {
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+      prisma.user.findUnique.mockResolvedValueOnce(null)
+
+      await expect(caller.autoRejectRisky()).rejects.toThrow(
+        `User with ID ${ADMIN_ID} not found in database`,
+      )
+      expect(mockRepositoryGetPendingListingRiskCandidates).not.toHaveBeenCalled()
     })
 
     it('returns the admin-only PC auto-reject preview count', async () => {

--- a/src/server/api/routers/pcListings.test.ts
+++ b/src/server/api/routers/pcListings.test.ts
@@ -916,7 +916,7 @@ describe('pcListings trust integration', () => {
         authorId: '00000000-0000-4000-a000-000000000050',
       }
 
-      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.MODERATOR })
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
       prisma.pcListing.findMany.mockResolvedValue([listing1, listing2])
       prisma.pcListing.updateMany.mockResolvedValue({ count: 2 })
 
@@ -945,7 +945,7 @@ describe('pcListings trust integration', () => {
         authorId: '00000000-0000-4000-a000-000000000050',
       }
 
-      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.MODERATOR })
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
       prisma.pcListing.findMany.mockResolvedValue([listing1, listing2])
       prisma.pcListing.updateMany.mockResolvedValue({ count: 2 })
 
@@ -968,6 +968,134 @@ describe('pcListings trust integration', () => {
           reason: 'Spam',
         }),
       })
+    })
+  })
+
+  describe('autoRejectRisky', () => {
+    it('rejects pending PC reports matched by high submission risk or any author risk', async () => {
+      const highSubmissionListing = {
+        id: LISTING_ID,
+        authorId: CLEAN_AUTHOR_ID,
+        author: { userBans: [] },
+        customFieldValues: [],
+      }
+      const authorRiskListing = {
+        id: LISTING_ID_B,
+        authorId: AUTHOR_ID,
+        author: { userBans: [] },
+        customFieldValues: [],
+      }
+      const cleanListing = {
+        id: LISTING_ID_C,
+        authorId: CLEAN_AUTHOR_ID,
+        author: { userBans: [] },
+        customFieldValues: [],
+      }
+
+      mockRepositoryGetPendingListingRiskCandidates.mockResolvedValueOnce([
+        highSubmissionListing,
+        authorRiskListing,
+        cleanListing,
+      ])
+      mockComputeAuthorRiskProfiles.mockResolvedValue(
+        new Map([
+          [CLEAN_AUTHOR_ID, { authorId: CLEAN_AUTHOR_ID, signals: [], highestSeverity: null }],
+          [
+            AUTHOR_ID,
+            {
+              authorId: AUTHOR_ID,
+              highestSeverity: 'low',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.NEW_AUTHOR,
+                  severity: 'low',
+                  label: 'New Author',
+                  description: 'No previously approved listings',
+                },
+              ],
+            },
+          ],
+        ]),
+      )
+      mockComputeSubmissionRiskProfiles.mockResolvedValue(
+        new Map([
+          [
+            LISTING_ID,
+            {
+              listingId: LISTING_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                  severity: 'high',
+                  label: 'Placeholder Emulator Version',
+                  description: 'Submitted emulator version resembles placeholder text.',
+                },
+              ],
+            },
+          ],
+          [LISTING_ID_B, { listingId: LISTING_ID_B, signals: [], highestSeverity: null }],
+          [LISTING_ID_C, { listingId: LISTING_ID_C, signals: [], highestSeverity: null }],
+        ]),
+      )
+
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+      prisma.pcListing.findMany.mockResolvedValueOnce([
+        { id: LISTING_ID, authorId: CLEAN_AUTHOR_ID },
+        { id: LISTING_ID_B, authorId: AUTHOR_ID },
+      ])
+      prisma.pcListing.update.mockResolvedValue({})
+
+      const result = await caller.autoRejectRisky()
+
+      expect(mockRepositoryGetPendingListingRiskCandidates).toHaveBeenCalledWith({})
+      expect(prisma.pcListing.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: [LISTING_ID, LISTING_ID_B] },
+          status: 'PENDING',
+        },
+        select: { id: true, authorId: true },
+      })
+      expect(prisma.pcListing.update).toHaveBeenCalledWith({
+        where: { id: LISTING_ID },
+        data: expect.objectContaining({
+          status: 'REJECTED',
+          processedByUserId: ADMIN_ID,
+          processedNotes:
+            'Automatically rejected by review risk bulk action: submission risk high severity.',
+        }),
+      })
+      expect(prisma.pcListing.update).toHaveBeenCalledWith({
+        where: { id: LISTING_ID_B },
+        data: expect.objectContaining({
+          status: 'REJECTED',
+          processedByUserId: ADMIN_ID,
+          processedNotes:
+            'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+        }),
+      })
+      expect(mockApplyTrustAction).toHaveBeenCalledWith({
+        userId: AUTHOR_ID,
+        action: TrustAction.LISTING_REJECTED,
+        context: expect.objectContaining({
+          pcListingId: LISTING_ID_B,
+          reason:
+            'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+        }),
+      })
+      expect(result).toMatchObject({
+        success: true,
+        rejectedCount: 2,
+        skippedCount: 0,
+      })
+    })
+
+    it('requires admin role for automatic PC risk rejection', async () => {
+      const { caller } = createCaller({ userId: ADMIN_ID, role: Role.MODERATOR })
+
+      await expect(caller.autoRejectRisky()).rejects.toThrow(/admin|insufficient/i)
+
+      expect(mockRepositoryGetPendingListingRiskCandidates).not.toHaveBeenCalled()
     })
   })
 

--- a/src/server/api/routers/pcListings.test.ts
+++ b/src/server/api/routers/pcListings.test.ts
@@ -157,9 +157,11 @@ const USER_ID = '00000000-0000-4000-a000-000000000001'
 const AUTHOR_ID = '00000000-0000-4000-a000-000000000002'
 const ADMIN_ID = '00000000-0000-4000-a000-000000000003'
 const CLEAN_AUTHOR_ID = '00000000-0000-4000-a000-000000000004'
+const HIGH_RISK_AUTHOR_ID = '00000000-0000-4000-a000-000000000005'
 const LISTING_ID = '00000000-0000-4000-a000-000000000010'
 const LISTING_ID_B = '00000000-0000-4000-a000-000000000011'
 const LISTING_ID_C = '00000000-0000-4000-a000-000000000012'
+const LISTING_ID_D = '00000000-0000-4000-a000-000000000013'
 const COMMENT_ID = '00000000-0000-4000-a000-000000000020'
 
 function createMockPrisma() {
@@ -916,7 +918,7 @@ describe('pcListings trust integration', () => {
         authorId: '00000000-0000-4000-a000-000000000050',
       }
 
-      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.MODERATOR })
       prisma.pcListing.findMany.mockResolvedValue([listing1, listing2])
       prisma.pcListing.updateMany.mockResolvedValue({ count: 2 })
 
@@ -945,7 +947,7 @@ describe('pcListings trust integration', () => {
         authorId: '00000000-0000-4000-a000-000000000050',
       }
 
-      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.MODERATOR })
       prisma.pcListing.findMany.mockResolvedValue([listing1, listing2])
       prisma.pcListing.updateMany.mockResolvedValue({ count: 2 })
 
@@ -972,30 +974,37 @@ describe('pcListings trust integration', () => {
   })
 
   describe('autoRejectRisky', () => {
-    it('rejects pending PC reports matched by high submission risk or any author risk', async () => {
-      const highSubmissionListing = {
+    it('rejects pending PC reports with high author risk or high submission risk with author risk', async () => {
+      const highSubmissionOnlyListing = {
         id: LISTING_ID,
         authorId: CLEAN_AUTHOR_ID,
         author: { userBans: [] },
         customFieldValues: [],
       }
-      const authorRiskListing = {
+      const authorRiskOnlyListing = {
         id: LISTING_ID_B,
         authorId: AUTHOR_ID,
         author: { userBans: [] },
         customFieldValues: [],
       }
-      const cleanListing = {
+      const matchingListing = {
         id: LISTING_ID_C,
-        authorId: CLEAN_AUTHOR_ID,
+        authorId: AUTHOR_ID,
+        author: { userBans: [] },
+        customFieldValues: [],
+      }
+      const highAuthorRiskOnlyListing = {
+        id: LISTING_ID_D,
+        authorId: HIGH_RISK_AUTHOR_ID,
         author: { userBans: [] },
         customFieldValues: [],
       }
 
       mockRepositoryGetPendingListingRiskCandidates.mockResolvedValueOnce([
-        highSubmissionListing,
-        authorRiskListing,
-        cleanListing,
+        highSubmissionOnlyListing,
+        authorRiskOnlyListing,
+        matchingListing,
+        highAuthorRiskOnlyListing,
       ])
       mockComputeAuthorRiskProfiles.mockResolvedValue(
         new Map([
@@ -1011,6 +1020,21 @@ describe('pcListings trust integration', () => {
                   severity: 'low',
                   label: 'New Author',
                   description: 'No previously approved listings',
+                },
+              ],
+            },
+          ],
+          [
+            HIGH_RISK_AUTHOR_ID,
+            {
+              authorId: HIGH_RISK_AUTHOR_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                  severity: 'high',
+                  label: 'Active Ban',
+                  description: 'Banned for spam',
                 },
               ],
             },
@@ -1035,14 +1059,28 @@ describe('pcListings trust integration', () => {
             },
           ],
           [LISTING_ID_B, { listingId: LISTING_ID_B, signals: [], highestSeverity: null }],
-          [LISTING_ID_C, { listingId: LISTING_ID_C, signals: [], highestSeverity: null }],
+          [
+            LISTING_ID_C,
+            {
+              listingId: LISTING_ID_C,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                  severity: 'high',
+                  label: 'Placeholder Emulator Version',
+                  description: 'Submitted emulator version resembles placeholder text.',
+                },
+              ],
+            },
+          ],
         ]),
       )
 
       const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
       prisma.pcListing.findMany.mockResolvedValueOnce([
-        { id: LISTING_ID, authorId: CLEAN_AUTHOR_ID },
-        { id: LISTING_ID_B, authorId: AUTHOR_ID },
+        { id: LISTING_ID_C, authorId: AUTHOR_ID },
+        { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID },
       ])
       prisma.pcListing.update.mockResolvedValue({})
 
@@ -1051,36 +1089,46 @@ describe('pcListings trust integration', () => {
       expect(mockRepositoryGetPendingListingRiskCandidates).toHaveBeenCalledWith({})
       expect(prisma.pcListing.findMany).toHaveBeenCalledWith({
         where: {
-          id: { in: [LISTING_ID, LISTING_ID_B] },
+          id: { in: [LISTING_ID_C, LISTING_ID_D] },
           status: 'PENDING',
         },
         select: { id: true, authorId: true },
       })
+      expect(prisma.pcListing.update).toHaveBeenCalledTimes(2)
       expect(prisma.pcListing.update).toHaveBeenCalledWith({
-        where: { id: LISTING_ID },
+        where: { id: LISTING_ID_C },
         data: expect.objectContaining({
           status: 'REJECTED',
           processedByUserId: ADMIN_ID,
           processedNotes:
-            'Automatically rejected by review risk bulk action: submission risk high severity.',
+            'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
         }),
       })
       expect(prisma.pcListing.update).toHaveBeenCalledWith({
-        where: { id: LISTING_ID_B },
+        where: { id: LISTING_ID_D },
         data: expect.objectContaining({
           status: 'REJECTED',
           processedByUserId: ADMIN_ID,
           processedNotes:
-            'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+            'Automatically rejected by review risk bulk action: author risk high severity (1 signal).',
         }),
       })
       expect(mockApplyTrustAction).toHaveBeenCalledWith({
         userId: AUTHOR_ID,
         action: TrustAction.LISTING_REJECTED,
         context: expect.objectContaining({
-          pcListingId: LISTING_ID_B,
+          pcListingId: LISTING_ID_C,
           reason:
-            'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+            'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
+        }),
+      })
+      expect(mockApplyTrustAction).toHaveBeenCalledWith({
+        userId: HIGH_RISK_AUTHOR_ID,
+        action: TrustAction.LISTING_REJECTED,
+        context: expect.objectContaining({
+          pcListingId: LISTING_ID_D,
+          reason:
+            'Automatically rejected by review risk bulk action: author risk high severity (1 signal).',
         }),
       })
       expect(result).toMatchObject({
@@ -1090,9 +1138,157 @@ describe('pcListings trust integration', () => {
       })
     })
 
+    it('returns the admin-only PC auto-reject preview count', async () => {
+      mockRepositoryGetPendingListingRiskCandidates.mockResolvedValueOnce([
+        { id: LISTING_ID, authorId: AUTHOR_ID, author: { userBans: [] }, customFieldValues: [] },
+        {
+          id: LISTING_ID_B,
+          authorId: CLEAN_AUTHOR_ID,
+          author: { userBans: [] },
+          customFieldValues: [],
+        },
+        {
+          id: LISTING_ID_D,
+          authorId: HIGH_RISK_AUTHOR_ID,
+          author: { userBans: [] },
+          customFieldValues: [],
+        },
+      ])
+      mockComputeAuthorRiskProfiles.mockResolvedValue(
+        new Map([
+          [
+            AUTHOR_ID,
+            {
+              authorId: AUTHOR_ID,
+              highestSeverity: 'low',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.NEW_AUTHOR,
+                  severity: 'low',
+                  label: 'New Author',
+                  description: 'No previously approved listings',
+                },
+              ],
+            },
+          ],
+          [CLEAN_AUTHOR_ID, { authorId: CLEAN_AUTHOR_ID, signals: [], highestSeverity: null }],
+          [
+            HIGH_RISK_AUTHOR_ID,
+            {
+              authorId: HIGH_RISK_AUTHOR_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                  severity: 'high',
+                  label: 'Active Ban',
+                  description: 'Banned for spam',
+                },
+              ],
+            },
+          ],
+        ]),
+      )
+      mockComputeSubmissionRiskProfiles.mockResolvedValue(
+        new Map([
+          [
+            LISTING_ID,
+            {
+              listingId: LISTING_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                  severity: 'high',
+                  label: 'Placeholder Emulator Version',
+                  description: 'Submitted emulator version resembles placeholder text.',
+                },
+              ],
+            },
+          ],
+          [
+            LISTING_ID_B,
+            {
+              listingId: LISTING_ID_B,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                  severity: 'high',
+                  label: 'Placeholder Emulator Version',
+                  description: 'Submitted emulator version resembles placeholder text.',
+                },
+              ],
+            },
+          ],
+        ]),
+      )
+
+      const { caller } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+
+      await expect(caller.autoRejectRiskyPreview()).resolves.toEqual({
+        eligibleCount: 2,
+        reviewRiskQueueCount: 3,
+      })
+    })
+
+    it('keeps automatic PC risk rejection successful when notification emission fails', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      mockRepositoryGetPendingListingRiskCandidates.mockResolvedValueOnce([
+        {
+          id: LISTING_ID_D,
+          authorId: HIGH_RISK_AUTHOR_ID,
+          author: { userBans: [] },
+          customFieldValues: [],
+        },
+      ])
+      mockComputeAuthorRiskProfiles.mockResolvedValue(
+        new Map([
+          [
+            HIGH_RISK_AUTHOR_ID,
+            {
+              authorId: HIGH_RISK_AUTHOR_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                  severity: 'high',
+                  label: 'Active Ban',
+                  description: 'Banned for spam',
+                },
+              ],
+            },
+          ],
+        ]),
+      )
+      mockComputeSubmissionRiskProfiles.mockResolvedValue(new Map())
+      mockEmitNotificationEvent.mockImplementationOnce(() => {
+        throw new Error('notification failed')
+      })
+
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+      prisma.pcListing.findMany.mockResolvedValueOnce([
+        { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID },
+      ])
+      prisma.pcListing.update.mockResolvedValue({})
+
+      await expect(caller.autoRejectRisky()).resolves.toMatchObject({
+        success: true,
+        rejectedCount: 1,
+        skippedCount: 0,
+      })
+      expect(consoleError).toHaveBeenCalledWith(
+        `Failed to emit notification for PC listing ${LISTING_ID_D}:`,
+        expect.any(Error),
+      )
+
+      consoleError.mockRestore()
+    })
+
     it('requires admin role for automatic PC risk rejection', async () => {
       const { caller } = createCaller({ userId: ADMIN_ID, role: Role.MODERATOR })
 
+      await expect(caller.autoRejectRiskyPreview()).rejects.toThrow(/admin|insufficient/i)
       await expect(caller.autoRejectRisky()).rejects.toThrow(/admin|insufficient/i)
 
       expect(mockRepositoryGetPendingListingRiskCandidates).not.toHaveBeenCalled()

--- a/src/server/api/routers/pcListings.test.ts
+++ b/src/server/api/routers/pcListings.test.ts
@@ -1082,7 +1082,7 @@ describe('pcListings trust integration', () => {
         { id: LISTING_ID_C, authorId: AUTHOR_ID },
         { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID },
       ])
-      prisma.pcListing.update.mockResolvedValue({})
+      prisma.pcListing.updateMany.mockResolvedValue({ count: 1 })
 
       const result = await caller.autoRejectRisky()
 
@@ -1090,24 +1090,24 @@ describe('pcListings trust integration', () => {
       expect(prisma.pcListing.findMany).toHaveBeenCalledWith({
         where: {
           id: { in: [LISTING_ID_C, LISTING_ID_D] },
-          status: 'PENDING',
+          status: ApprovalStatus.PENDING,
         },
         select: { id: true, authorId: true },
       })
-      expect(prisma.pcListing.update).toHaveBeenCalledTimes(2)
-      expect(prisma.pcListing.update).toHaveBeenCalledWith({
-        where: { id: LISTING_ID_C },
+      expect(prisma.pcListing.updateMany).toHaveBeenCalledTimes(2)
+      expect(prisma.pcListing.updateMany).toHaveBeenCalledWith({
+        where: { id: LISTING_ID_C, status: ApprovalStatus.PENDING },
         data: expect.objectContaining({
-          status: 'REJECTED',
+          status: ApprovalStatus.REJECTED,
           processedByUserId: ADMIN_ID,
           processedNotes:
             'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
         }),
       })
-      expect(prisma.pcListing.update).toHaveBeenCalledWith({
-        where: { id: LISTING_ID_D },
+      expect(prisma.pcListing.updateMany).toHaveBeenCalledWith({
+        where: { id: LISTING_ID_D, status: ApprovalStatus.PENDING },
         data: expect.objectContaining({
-          status: 'REJECTED',
+          status: ApprovalStatus.REJECTED,
           processedByUserId: ADMIN_ID,
           processedNotes:
             'Automatically rejected by review risk bulk action: author risk high severity (1 signal).',
@@ -1136,6 +1136,109 @@ describe('pcListings trust integration', () => {
         rejectedCount: 2,
         skippedCount: 0,
       })
+    })
+
+    it('skips automatic PC risk rejection if a report is no longer pending at update time', async () => {
+      mockRepositoryGetPendingListingRiskCandidates.mockResolvedValueOnce([
+        {
+          id: LISTING_ID_D,
+          authorId: HIGH_RISK_AUTHOR_ID,
+          author: { userBans: [] },
+          customFieldValues: [],
+        },
+      ])
+      mockComputeAuthorRiskProfiles.mockResolvedValue(
+        new Map([
+          [
+            HIGH_RISK_AUTHOR_ID,
+            {
+              authorId: HIGH_RISK_AUTHOR_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                  severity: 'high',
+                  label: 'Active Ban',
+                  description: 'Banned for spam',
+                },
+              ],
+            },
+          ],
+        ]),
+      )
+
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+      prisma.pcListing.findMany.mockResolvedValueOnce([
+        { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID },
+      ])
+      prisma.pcListing.updateMany.mockResolvedValueOnce({ count: 0 })
+
+      await expect(caller.autoRejectRisky()).resolves.toMatchObject({
+        success: true,
+        rejectedCount: 0,
+        skippedCount: 1,
+      })
+      expect(prisma.pcListing.updateMany).toHaveBeenCalledWith({
+        where: { id: LISTING_ID_D, status: ApprovalStatus.PENDING },
+        data: expect.objectContaining({
+          status: ApprovalStatus.REJECTED,
+          processedByUserId: ADMIN_ID,
+        }),
+      })
+      expect(mockApplyTrustAction).not.toHaveBeenCalled()
+      expect(mockEmitNotificationEvent).not.toHaveBeenCalled()
+    })
+
+    it('keeps automatic PC risk rejection successful when trust action emission fails', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      mockRepositoryGetPendingListingRiskCandidates.mockResolvedValueOnce([
+        {
+          id: LISTING_ID_D,
+          authorId: HIGH_RISK_AUTHOR_ID,
+          author: { userBans: [] },
+          customFieldValues: [],
+        },
+      ])
+      mockComputeAuthorRiskProfiles.mockResolvedValue(
+        new Map([
+          [
+            HIGH_RISK_AUTHOR_ID,
+            {
+              authorId: HIGH_RISK_AUTHOR_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                  severity: 'high',
+                  label: 'Active Ban',
+                  description: 'Banned for spam',
+                },
+              ],
+            },
+          ],
+        ]),
+      )
+      mockApplyTrustAction.mockRejectedValueOnce(new Error('trust failed'))
+
+      const { caller, prisma } = createCaller({ userId: ADMIN_ID, role: Role.ADMIN })
+      prisma.pcListing.findMany.mockResolvedValueOnce([
+        { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID },
+      ])
+      prisma.pcListing.updateMany.mockResolvedValue({ count: 1 })
+
+      await expect(caller.autoRejectRisky()).resolves.toMatchObject({
+        success: true,
+        rejectedCount: 1,
+        skippedCount: 0,
+      })
+      expect(consoleError).toHaveBeenCalledWith(
+        'Some trust actions failed during review-risk PC auto-rejection:',
+        expect.arrayContaining([
+          expect.objectContaining({ status: 'rejected', reason: expect.any(Error) }),
+        ]),
+      )
+
+      consoleError.mockRestore()
     })
 
     it('returns the admin-only PC auto-reject preview count', async () => {
@@ -1270,7 +1373,7 @@ describe('pcListings trust integration', () => {
       prisma.pcListing.findMany.mockResolvedValueOnce([
         { id: LISTING_ID_D, authorId: HIGH_RISK_AUTHOR_ID },
       ])
-      prisma.pcListing.update.mockResolvedValue({})
+      prisma.pcListing.updateMany.mockResolvedValue({ count: 1 })
 
       await expect(caller.autoRejectRisky()).resolves.toMatchObject({
         success: true,

--- a/src/server/api/routers/pcListings.ts
+++ b/src/server/api/routers/pcListings.ts
@@ -64,12 +64,12 @@ import { NOTIFICATION_EVENTS, notificationEventEmitter } from '@/server/notifica
 import { PcListingsRepository } from '@/server/repositories/pc-listings.repository'
 import { UserPcPresetsRepository } from '@/server/repositories/user-pc-presets.repository'
 import { logAudit } from '@/server/services/audit.service'
+import { autoRejectRiskyPcReports } from '@/server/services/review-risk-auto-reject.service'
 import {
   attachReviewRiskProfiles,
   attachReviewRiskProfileForViewer,
   computeReviewRiskProfiles,
   getAutoRejectableReviewRiskPreviewForCandidates,
-  getAutoRejectableReviewRiskItemsForCandidates,
   getRiskOnlyReviewPage,
 } from '@/server/services/review-risk.service'
 import { listingStatsCache } from '@/server/utils/cache'
@@ -891,120 +891,10 @@ export const pcListingsRouter = createTRPCRouter({
   }),
 
   autoRejectRisky: adminProcedure.mutation(async ({ ctx }) => {
-    const repository = new PcListingsRepository(ctx.prisma)
-
-    const autoRejectItems = await getAutoRejectableReviewRiskItemsForCandidates({
+    return autoRejectRiskyPcReports({
       prisma: ctx.prisma,
-      loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+      adminUserId: ctx.session.user.id,
     })
-
-    if (autoRejectItems.length === 0) {
-      return {
-        success: true,
-        rejectedCount: 0,
-        skippedCount: 0,
-        message: 'No auto-rejectable review-risk PC reports found.',
-      }
-    }
-
-    const processedNotesById = new Map(
-      autoRejectItems.map((item) => [item.id, item.processedNotes]),
-    )
-    const pcListingIds = autoRejectItems.map((item) => item.id)
-
-    const transactionResult = await ctx.prisma.$transaction(async (tx) => {
-      const pendingListings = await tx.pcListing.findMany({
-        where: {
-          id: { in: pcListingIds },
-          status: ApprovalStatus.PENDING,
-        },
-        select: { id: true, authorId: true },
-      })
-
-      for (const listing of pendingListings) {
-        await tx.pcListing.update({
-          where: { id: listing.id },
-          data: {
-            status: ApprovalStatus.REJECTED,
-            processedAt: new Date(),
-            processedByUserId: ctx.session.user.id,
-            processedNotes:
-              processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.',
-          },
-        })
-      }
-
-      return {
-        pendingListings,
-        skippedCount: pcListingIds.length - pendingListings.length,
-      }
-    })
-
-    const listingsWithAuthor = transactionResult.pendingListings.filter(
-      (l): l is typeof l & { authorId: string } => l.authorId !== null,
-    )
-    await Promise.all(
-      listingsWithAuthor.map((listing) => {
-        const processedNotes =
-          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
-
-        return applyTrustAction({
-          userId: listing.authorId,
-          action: TrustAction.LISTING_REJECTED,
-          context: {
-            pcListingId: listing.id,
-            adminUserId: ctx.session.user.id,
-            reason: processedNotes,
-          },
-        })
-      }),
-    )
-
-    listingStatsCache.delete('pc-listing-stats')
-
-    try {
-      const rejectedAt = new Date()
-
-      for (const listing of transactionResult.pendingListings) {
-        const processedNotes =
-          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
-
-        try {
-          notificationEventEmitter.emitNotificationEvent({
-            eventType: NOTIFICATION_EVENTS.PC_LISTING_REJECTED,
-            entityType: 'pcListing',
-            entityId: listing.id,
-            triggeredBy: ctx.session.user.id,
-            payload: {
-              pcListingId: listing.id,
-              rejectedBy: ctx.session.user.id,
-              rejectedAt,
-              rejectionReason: processedNotes,
-              bulk: true,
-            },
-          })
-        } catch (notificationError) {
-          console.error(
-            `Failed to emit notification for PC listing ${listing.id}:`,
-            notificationError,
-          )
-        }
-      }
-    } catch (error) {
-      console.error('Error emitting review-risk PC auto-rejection notifications:', error)
-    }
-
-    const message =
-      transactionResult.skippedCount > 0
-        ? `Automatically rejected ${transactionResult.pendingListings.length} review-risk PC report(s). ${transactionResult.skippedCount} PC report(s) were skipped because they were already processed.`
-        : `Automatically rejected ${transactionResult.pendingListings.length} review-risk PC report(s).`
-
-    return {
-      success: true,
-      rejectedCount: transactionResult.pendingListings.length,
-      skippedCount: transactionResult.skippedCount,
-      message,
-    }
   }),
 
   getAll: permissionProcedure(PERMISSIONS.APPROVE_LISTINGS)

--- a/src/server/api/routers/pcListings.ts
+++ b/src/server/api/routers/pcListings.ts
@@ -891,9 +891,17 @@ export const pcListingsRouter = createTRPCRouter({
   }),
 
   autoRejectRisky: adminProcedure.mutation(async ({ ctx }) => {
+    const adminUserId = ctx.session.user.id
+
+    const adminUserExists = await ctx.prisma.user.findUnique({
+      where: { id: adminUserId },
+      select: { id: true },
+    })
+    if (!adminUserExists) return ResourceError.user.notInDatabase(adminUserId)
+
     return autoRejectRiskyPcReports({
       prisma: ctx.prisma,
-      adminUserId: ctx.session.user.id,
+      adminUserId,
     })
   }),
 

--- a/src/server/api/routers/pcListings.ts
+++ b/src/server/api/routers/pcListings.ts
@@ -40,6 +40,7 @@ import {
 import {
   createListingProcedure,
   createTRPCRouter,
+  adminProcedure,
   moderatorProcedure,
   permissionProcedure,
   protectedProcedure,
@@ -67,6 +68,7 @@ import {
   attachReviewRiskProfiles,
   attachReviewRiskProfileForViewer,
   computeReviewRiskProfiles,
+  getAutoRejectableReviewRiskItemsForCandidates,
   getRiskOnlyReviewPage,
 } from '@/server/services/review-risk.service'
 import { listingStatsCache } from '@/server/utils/cache'
@@ -877,6 +879,110 @@ export const pcListingsRouter = createTRPCRouter({
 
       return { count: result.count }
     }),
+
+  autoRejectRisky: adminProcedure.mutation(async ({ ctx }) => {
+    const repository = new PcListingsRepository(ctx.prisma)
+
+    const autoRejectItems = await getAutoRejectableReviewRiskItemsForCandidates({
+      prisma: ctx.prisma,
+      loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+    })
+
+    if (autoRejectItems.length === 0) {
+      return {
+        success: true,
+        rejectedCount: 0,
+        skippedCount: 0,
+        message: 'No auto-rejectable review-risk PC reports found.',
+      }
+    }
+
+    const processedNotesById = new Map(
+      autoRejectItems.map((item) => [item.id, item.processedNotes]),
+    )
+    const pcListingIds = autoRejectItems.map((item) => item.id)
+
+    const transactionResult = await ctx.prisma.$transaction(async (tx) => {
+      const pendingListings = await tx.pcListing.findMany({
+        where: {
+          id: { in: pcListingIds },
+          status: ApprovalStatus.PENDING,
+        },
+        select: { id: true, authorId: true },
+      })
+
+      for (const listing of pendingListings) {
+        await tx.pcListing.update({
+          where: { id: listing.id },
+          data: {
+            status: ApprovalStatus.REJECTED,
+            processedAt: new Date(),
+            processedByUserId: ctx.session.user.id,
+            processedNotes:
+              processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.',
+          },
+        })
+      }
+
+      return {
+        pendingListings,
+        skippedCount: pcListingIds.length - pendingListings.length,
+      }
+    })
+
+    const listingsWithAuthor = transactionResult.pendingListings.filter(
+      (l): l is typeof l & { authorId: string } => l.authorId !== null,
+    )
+    await Promise.all(
+      listingsWithAuthor.map((listing) => {
+        const processedNotes =
+          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
+
+        return applyTrustAction({
+          userId: listing.authorId,
+          action: TrustAction.LISTING_REJECTED,
+          context: {
+            pcListingId: listing.id,
+            adminUserId: ctx.session.user.id,
+            reason: processedNotes,
+          },
+        })
+      }),
+    )
+
+    listingStatsCache.delete('pc-listing-stats')
+
+    for (const listing of transactionResult.pendingListings) {
+      const processedNotes =
+        processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
+
+      notificationEventEmitter.emitNotificationEvent({
+        eventType: NOTIFICATION_EVENTS.PC_LISTING_REJECTED,
+        entityType: 'pcListing',
+        entityId: listing.id,
+        triggeredBy: ctx.session.user.id,
+        payload: {
+          pcListingId: listing.id,
+          rejectedBy: ctx.session.user.id,
+          rejectedAt: new Date(),
+          rejectionReason: processedNotes,
+          bulk: true,
+        },
+      })
+    }
+
+    const message =
+      transactionResult.skippedCount > 0
+        ? `Automatically rejected ${transactionResult.pendingListings.length} review-risk PC report(s). ${transactionResult.skippedCount} PC report(s) were skipped because they were already processed.`
+        : `Automatically rejected ${transactionResult.pendingListings.length} review-risk PC report(s).`
+
+    return {
+      success: true,
+      rejectedCount: transactionResult.pendingListings.length,
+      skippedCount: transactionResult.skippedCount,
+      message,
+    }
+  }),
 
   getAll: permissionProcedure(PERMISSIONS.APPROVE_LISTINGS)
     .input(GetAllPcListingsAdminSchema)

--- a/src/server/api/routers/pcListings.ts
+++ b/src/server/api/routers/pcListings.ts
@@ -68,6 +68,7 @@ import {
   attachReviewRiskProfiles,
   attachReviewRiskProfileForViewer,
   computeReviewRiskProfiles,
+  getAutoRejectableReviewRiskPreviewForCandidates,
   getAutoRejectableReviewRiskItemsForCandidates,
   getRiskOnlyReviewPage,
 } from '@/server/services/review-risk.service'
@@ -880,6 +881,15 @@ export const pcListingsRouter = createTRPCRouter({
       return { count: result.count }
     }),
 
+  autoRejectRiskyPreview: adminProcedure.query(async ({ ctx }) => {
+    const repository = new PcListingsRepository(ctx.prisma)
+
+    return getAutoRejectableReviewRiskPreviewForCandidates({
+      prisma: ctx.prisma,
+      loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+    })
+  }),
+
   autoRejectRisky: adminProcedure.mutation(async ({ ctx }) => {
     const repository = new PcListingsRepository(ctx.prisma)
 
@@ -952,23 +962,36 @@ export const pcListingsRouter = createTRPCRouter({
 
     listingStatsCache.delete('pc-listing-stats')
 
-    for (const listing of transactionResult.pendingListings) {
-      const processedNotes =
-        processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
+    try {
+      const rejectedAt = new Date()
 
-      notificationEventEmitter.emitNotificationEvent({
-        eventType: NOTIFICATION_EVENTS.PC_LISTING_REJECTED,
-        entityType: 'pcListing',
-        entityId: listing.id,
-        triggeredBy: ctx.session.user.id,
-        payload: {
-          pcListingId: listing.id,
-          rejectedBy: ctx.session.user.id,
-          rejectedAt: new Date(),
-          rejectionReason: processedNotes,
-          bulk: true,
-        },
-      })
+      for (const listing of transactionResult.pendingListings) {
+        const processedNotes =
+          processedNotesById.get(listing.id) ?? 'Automatically rejected by review risk.'
+
+        try {
+          notificationEventEmitter.emitNotificationEvent({
+            eventType: NOTIFICATION_EVENTS.PC_LISTING_REJECTED,
+            entityType: 'pcListing',
+            entityId: listing.id,
+            triggeredBy: ctx.session.user.id,
+            payload: {
+              pcListingId: listing.id,
+              rejectedBy: ctx.session.user.id,
+              rejectedAt,
+              rejectionReason: processedNotes,
+              bulk: true,
+            },
+          })
+        } catch (notificationError) {
+          console.error(
+            `Failed to emit notification for PC listing ${listing.id}:`,
+            notificationError,
+          )
+        }
+      }
+    } catch (error) {
+      console.error('Error emitting review-risk PC auto-rejection notifications:', error)
     }
 
     const message =

--- a/src/server/services/review-risk-auto-reject.service.ts
+++ b/src/server/services/review-risk-auto-reject.service.ts
@@ -1,0 +1,294 @@
+import { applyTrustAction } from '@/lib/trust/service'
+import { NOTIFICATION_EVENTS, notificationEventEmitter } from '@/server/notifications/eventEmitter'
+import { ListingsRepository } from '@/server/repositories/listings.repository'
+import { PcListingsRepository } from '@/server/repositories/pc-listings.repository'
+import {
+  getAutoRejectableReviewRiskItemsForCandidates,
+  type AutoRejectReviewRiskItem,
+} from '@/server/services/review-risk.service'
+import {
+  invalidateCatalogCompatibilityCacheForDevices,
+  listingStatsCache,
+} from '@/server/utils/cache/instances'
+import { ApprovalStatus, TrustAction, type PrismaClient } from '@orm/client'
+
+const AUTO_REJECT_FALLBACK_NOTE = 'Automatically rejected by review risk.'
+const HANDHELD_STATS_CACHE_KEY = 'listing-stats'
+const PC_STATS_CACHE_KEY = 'pc-listing-stats'
+
+export interface ReviewRiskAutoRejectResult {
+  success: true
+  rejectedCount: number
+  skippedCount: number
+  message: string
+}
+
+interface RejectedHandheldListing {
+  id: string
+  authorId: string | null
+  deviceId: string
+}
+
+interface RejectedPcListing {
+  id: string
+  authorId: string | null
+}
+
+function createProcessedNotesMap(items: readonly AutoRejectReviewRiskItem[]): Map<string, string> {
+  return new Map(items.map((item) => [item.id, item.processedNotes]))
+}
+
+function getProcessedNotes(processedNotesById: Map<string, string>, listingId: string): string {
+  return processedNotesById.get(listingId) ?? AUTO_REJECT_FALLBACK_NOTE
+}
+
+function buildMessage(params: {
+  rejectedCount: number
+  skippedCount: number
+  reportLabel: 'handheld' | 'PC'
+}): string {
+  const base = `Automatically rejected ${params.rejectedCount} review-risk ${params.reportLabel} report(s).`
+
+  if (params.skippedCount === 0) return base
+
+  return `${base} ${params.skippedCount} ${params.reportLabel} report(s) were skipped because they were already processed.`
+}
+
+function logTrustFailures(context: string, results: readonly PromiseSettledResult<unknown>[]) {
+  const failures = results.filter((result): result is PromiseRejectedResult => {
+    return result.status === 'rejected'
+  })
+
+  if (failures.length === 0) return
+
+  console.error(context, failures)
+}
+
+export async function autoRejectRiskyHandheldReports(params: {
+  prisma: PrismaClient
+  adminUserId: string
+}): Promise<ReviewRiskAutoRejectResult> {
+  const repository = new ListingsRepository(params.prisma)
+  const autoRejectItems = await getAutoRejectableReviewRiskItemsForCandidates({
+    prisma: params.prisma,
+    loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+  })
+
+  if (autoRejectItems.length === 0) {
+    return {
+      success: true,
+      rejectedCount: 0,
+      skippedCount: 0,
+      message: 'No auto-rejectable review-risk handheld reports found.',
+    }
+  }
+
+  const processedNotesById = createProcessedNotesMap(autoRejectItems)
+  const listingIds = autoRejectItems.map((item) => item.id)
+
+  const transactionResult = await params.prisma.$transaction(async (tx) => {
+    const pendingListings = await tx.listing.findMany({
+      where: {
+        id: { in: listingIds },
+        status: ApprovalStatus.PENDING,
+      },
+      select: { id: true, authorId: true, deviceId: true },
+    })
+
+    const rejectedListings: RejectedHandheldListing[] = []
+    let skippedCount = listingIds.length - pendingListings.length
+    const processedAt = new Date()
+
+    for (const listing of pendingListings) {
+      const { count } = await tx.listing.updateMany({
+        where: { id: listing.id, status: ApprovalStatus.PENDING },
+        data: {
+          status: ApprovalStatus.REJECTED,
+          processedByUserId: params.adminUserId,
+          processedAt,
+          processedNotes: getProcessedNotes(processedNotesById, listing.id),
+        },
+      })
+
+      if (count === 1) {
+        rejectedListings.push(listing)
+      } else {
+        skippedCount += 1
+      }
+    }
+
+    return { rejectedListings, skippedCount }
+  })
+
+  const trustActionResults = await Promise.allSettled(
+    transactionResult.rejectedListings
+      .filter((listing): listing is RejectedHandheldListing & { authorId: string } => {
+        return listing.authorId !== null
+      })
+      .map((listing) =>
+        applyTrustAction({
+          userId: listing.authorId,
+          action: TrustAction.LISTING_REJECTED,
+          context: {
+            listingId: listing.id,
+            adminUserId: params.adminUserId,
+            reason: getProcessedNotes(processedNotesById, listing.id),
+          },
+        }),
+      ),
+  )
+  logTrustFailures(
+    'Some trust actions failed during review-risk handheld auto-rejection:',
+    trustActionResults,
+  )
+
+  const rejectedAt = new Date()
+  for (const listing of transactionResult.rejectedListings) {
+    try {
+      notificationEventEmitter.emitNotificationEvent({
+        eventType: NOTIFICATION_EVENTS.LISTING_REJECTED,
+        entityType: 'listing',
+        entityId: listing.id,
+        triggeredBy: params.adminUserId,
+        payload: {
+          listingId: listing.id,
+          rejectedBy: params.adminUserId,
+          rejectedAt,
+          rejectionReason: getProcessedNotes(processedNotesById, listing.id),
+          bulk: true,
+        },
+      })
+    } catch (notificationError) {
+      console.error(`Failed to emit notification for listing ${listing.id}:`, notificationError)
+    }
+  }
+
+  listingStatsCache.delete(HANDHELD_STATS_CACHE_KEY)
+  invalidateCatalogCompatibilityCacheForDevices(
+    transactionResult.rejectedListings.map((listing) => listing.deviceId),
+  )
+
+  return {
+    success: true,
+    rejectedCount: transactionResult.rejectedListings.length,
+    skippedCount: transactionResult.skippedCount,
+    message: buildMessage({
+      rejectedCount: transactionResult.rejectedListings.length,
+      skippedCount: transactionResult.skippedCount,
+      reportLabel: 'handheld',
+    }),
+  }
+}
+
+export async function autoRejectRiskyPcReports(params: {
+  prisma: PrismaClient
+  adminUserId: string
+}): Promise<ReviewRiskAutoRejectResult> {
+  const repository = new PcListingsRepository(params.prisma)
+  const autoRejectItems = await getAutoRejectableReviewRiskItemsForCandidates({
+    prisma: params.prisma,
+    loadCandidates: () => repository.getPendingListingRiskCandidates({}),
+  })
+
+  if (autoRejectItems.length === 0) {
+    return {
+      success: true,
+      rejectedCount: 0,
+      skippedCount: 0,
+      message: 'No auto-rejectable review-risk PC reports found.',
+    }
+  }
+
+  const processedNotesById = createProcessedNotesMap(autoRejectItems)
+  const pcListingIds = autoRejectItems.map((item) => item.id)
+
+  const transactionResult = await params.prisma.$transaction(async (tx) => {
+    const pendingListings = await tx.pcListing.findMany({
+      where: {
+        id: { in: pcListingIds },
+        status: ApprovalStatus.PENDING,
+      },
+      select: { id: true, authorId: true },
+    })
+
+    const rejectedListings: RejectedPcListing[] = []
+    let skippedCount = pcListingIds.length - pendingListings.length
+    const processedAt = new Date()
+
+    for (const listing of pendingListings) {
+      const { count } = await tx.pcListing.updateMany({
+        where: { id: listing.id, status: ApprovalStatus.PENDING },
+        data: {
+          status: ApprovalStatus.REJECTED,
+          processedAt,
+          processedByUserId: params.adminUserId,
+          processedNotes: getProcessedNotes(processedNotesById, listing.id),
+        },
+      })
+
+      if (count === 1) {
+        rejectedListings.push(listing)
+      } else {
+        skippedCount += 1
+      }
+    }
+
+    return { rejectedListings, skippedCount }
+  })
+
+  const trustActionResults = await Promise.allSettled(
+    transactionResult.rejectedListings
+      .filter((listing): listing is RejectedPcListing & { authorId: string } => {
+        return listing.authorId !== null
+      })
+      .map((listing) =>
+        applyTrustAction({
+          userId: listing.authorId,
+          action: TrustAction.LISTING_REJECTED,
+          context: {
+            pcListingId: listing.id,
+            adminUserId: params.adminUserId,
+            reason: getProcessedNotes(processedNotesById, listing.id),
+          },
+        }),
+      ),
+  )
+  logTrustFailures(
+    'Some trust actions failed during review-risk PC auto-rejection:',
+    trustActionResults,
+  )
+
+  listingStatsCache.delete(PC_STATS_CACHE_KEY)
+
+  const rejectedAt = new Date()
+  for (const listing of transactionResult.rejectedListings) {
+    try {
+      notificationEventEmitter.emitNotificationEvent({
+        eventType: NOTIFICATION_EVENTS.PC_LISTING_REJECTED,
+        entityType: 'pcListing',
+        entityId: listing.id,
+        triggeredBy: params.adminUserId,
+        payload: {
+          pcListingId: listing.id,
+          rejectedBy: params.adminUserId,
+          rejectedAt,
+          rejectionReason: getProcessedNotes(processedNotesById, listing.id),
+          bulk: true,
+        },
+      })
+    } catch (notificationError) {
+      console.error(`Failed to emit notification for PC listing ${listing.id}:`, notificationError)
+    }
+  }
+
+  return {
+    success: true,
+    rejectedCount: transactionResult.rejectedListings.length,
+    skippedCount: transactionResult.skippedCount,
+    message: buildMessage({
+      rejectedCount: transactionResult.rejectedListings.length,
+      skippedCount: transactionResult.skippedCount,
+      reportLabel: 'PC',
+    }),
+  }
+}

--- a/src/server/services/review-risk.service.test.ts
+++ b/src/server/services/review-risk.service.test.ts
@@ -6,6 +6,7 @@ import {
   attachHiddenReviewRiskProfiles,
   attachReviewRiskProfiles,
   canViewReviewRiskProfiles,
+  getAutoRejectableReviewRiskPreview,
   getAutoRejectableReviewRiskItems,
   getActiveAuthorBansForReviewRisk,
   getRiskyReviewItemIds,
@@ -13,9 +14,12 @@ import {
 
 const AUTHOR_ID = '00000000-0000-4000-a000-000000000001'
 const CLEAN_AUTHOR_ID = '00000000-0000-4000-a000-000000000002'
+const HIGH_RISK_AUTHOR_ID = '00000000-0000-4000-a000-000000000003'
 const LISTING_ID = '00000000-0000-4000-a000-000000000010'
 const CLEAN_LISTING_ID = '00000000-0000-4000-a000-000000000011'
 const MEDIUM_SUBMISSION_LISTING_ID = '00000000-0000-4000-a000-000000000012'
+const HIGH_SUBMISSION_ONLY_LISTING_ID = '00000000-0000-4000-a000-000000000013'
+const HIGH_AUTHOR_ONLY_LISTING_ID = '00000000-0000-4000-a000-000000000014'
 
 const authorRiskProfile: AuthorRiskProfile = {
   authorId: AUTHOR_ID,
@@ -59,11 +63,17 @@ describe('review risk helpers', () => {
     expect(riskCandidateIds).toEqual([LISTING_ID])
   })
 
-  it('returns auto-reject items for high submission risk and any author risk', () => {
+  it('returns auto-reject items for high author risk or high submission risk with author risk', () => {
     const autoRejectItems = getAutoRejectableReviewRiskItems(
       [
         { id: LISTING_ID, authorId: AUTHOR_ID, customFieldValues: [] },
-        { id: CLEAN_LISTING_ID, authorId: AUTHOR_ID, customFieldValues: [] },
+        { id: CLEAN_LISTING_ID, authorId: CLEAN_AUTHOR_ID, customFieldValues: [] },
+        { id: HIGH_AUTHOR_ONLY_LISTING_ID, authorId: HIGH_RISK_AUTHOR_ID, customFieldValues: [] },
+        {
+          id: HIGH_SUBMISSION_ONLY_LISTING_ID,
+          authorId: CLEAN_AUTHOR_ID,
+          customFieldValues: [],
+        },
         { id: MEDIUM_SUBMISSION_LISTING_ID, authorId: CLEAN_AUTHOR_ID, customFieldValues: [] },
       ],
       {
@@ -74,6 +84,21 @@ describe('review risk helpers', () => {
               authorId: CLEAN_AUTHOR_ID,
               highestSeverity: null,
               signals: [],
+            },
+          ],
+          [
+            HIGH_RISK_AUTHOR_ID,
+            {
+              authorId: HIGH_RISK_AUTHOR_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.ACTIVE_BAN,
+                  severity: 'high',
+                  label: 'Active Ban',
+                  description: 'Banned for spam',
+                },
+              ],
             },
           ],
           [
@@ -94,6 +119,21 @@ describe('review risk helpers', () => {
         ]),
         submissionRiskProfiles: new Map([
           [LISTING_ID, submissionRiskProfile],
+          [
+            HIGH_SUBMISSION_ONLY_LISTING_ID,
+            {
+              listingId: HIGH_SUBMISSION_ONLY_LISTING_ID,
+              highestSeverity: 'high',
+              signals: [
+                {
+                  type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                  severity: 'high',
+                  label: 'Placeholder Emulator Version',
+                  description: 'Submitted emulator version resembles placeholder text.',
+                },
+              ],
+            },
+          ],
           [
             MEDIUM_SUBMISSION_LISTING_ID,
             {
@@ -120,9 +160,9 @@ describe('review risk helpers', () => {
           'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
       },
       {
-        id: CLEAN_LISTING_ID,
+        id: HIGH_AUTHOR_ONLY_LISTING_ID,
         processedNotes:
-          'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+          'Automatically rejected by review risk bulk action: author risk high severity (1 signal).',
       },
     ])
   })
@@ -162,6 +202,53 @@ describe('review risk helpers', () => {
     )
 
     expect(autoRejectItems).toEqual([])
+  })
+
+  it('excludes malformed high author risk profiles without signals', () => {
+    const autoRejectItems = getAutoRejectableReviewRiskItems(
+      [{ id: HIGH_AUTHOR_ONLY_LISTING_ID, authorId: HIGH_RISK_AUTHOR_ID, customFieldValues: [] }],
+      {
+        authorRiskProfiles: new Map([
+          [
+            HIGH_RISK_AUTHOR_ID,
+            {
+              authorId: HIGH_RISK_AUTHOR_ID,
+              highestSeverity: 'high',
+              signals: [],
+            },
+          ],
+        ]),
+        submissionRiskProfiles: new Map(),
+      },
+    )
+
+    expect(autoRejectItems).toEqual([])
+  })
+
+  it('returns the auto-reject preview count from the shared predicate', () => {
+    const preview = getAutoRejectableReviewRiskPreview(
+      [
+        { id: LISTING_ID, authorId: AUTHOR_ID, customFieldValues: [] },
+        { id: CLEAN_LISTING_ID, authorId: CLEAN_AUTHOR_ID, customFieldValues: [] },
+        { id: HIGH_SUBMISSION_ONLY_LISTING_ID, authorId: CLEAN_AUTHOR_ID, customFieldValues: [] },
+        { id: HIGH_AUTHOR_ONLY_LISTING_ID, authorId: HIGH_RISK_AUTHOR_ID, customFieldValues: [] },
+      ],
+      {
+        authorRiskProfiles: new Map([
+          [AUTHOR_ID, authorRiskProfile],
+          [HIGH_RISK_AUTHOR_ID, { ...authorRiskProfile, authorId: HIGH_RISK_AUTHOR_ID }],
+        ]),
+        submissionRiskProfiles: new Map([
+          [LISTING_ID, submissionRiskProfile],
+          [
+            HIGH_SUBMISSION_ONLY_LISTING_ID,
+            { ...submissionRiskProfile, listingId: HIGH_SUBMISSION_ONLY_LISTING_ID },
+          ],
+        ]),
+      },
+    )
+
+    expect(preview).toEqual({ eligibleCount: 2, reviewRiskQueueCount: 3 })
   })
 
   it('attaches empty profiles when no risk profile exists for a listing', () => {

--- a/src/server/services/review-risk.service.test.ts
+++ b/src/server/services/review-risk.service.test.ts
@@ -6,6 +6,7 @@ import {
   attachHiddenReviewRiskProfiles,
   attachReviewRiskProfiles,
   canViewReviewRiskProfiles,
+  getAutoRejectableReviewRiskItems,
   getActiveAuthorBansForReviewRisk,
   getRiskyReviewItemIds,
 } from './review-risk.service'
@@ -14,6 +15,7 @@ const AUTHOR_ID = '00000000-0000-4000-a000-000000000001'
 const CLEAN_AUTHOR_ID = '00000000-0000-4000-a000-000000000002'
 const LISTING_ID = '00000000-0000-4000-a000-000000000010'
 const CLEAN_LISTING_ID = '00000000-0000-4000-a000-000000000011'
+const MEDIUM_SUBMISSION_LISTING_ID = '00000000-0000-4000-a000-000000000012'
 
 const authorRiskProfile: AuthorRiskProfile = {
   authorId: AUTHOR_ID,
@@ -55,6 +57,111 @@ describe('review risk helpers', () => {
     )
 
     expect(riskCandidateIds).toEqual([LISTING_ID])
+  })
+
+  it('returns auto-reject items for high submission risk and any author risk', () => {
+    const autoRejectItems = getAutoRejectableReviewRiskItems(
+      [
+        { id: LISTING_ID, authorId: AUTHOR_ID, customFieldValues: [] },
+        { id: CLEAN_LISTING_ID, authorId: AUTHOR_ID, customFieldValues: [] },
+        { id: MEDIUM_SUBMISSION_LISTING_ID, authorId: CLEAN_AUTHOR_ID, customFieldValues: [] },
+      ],
+      {
+        authorRiskProfiles: new Map([
+          [
+            CLEAN_AUTHOR_ID,
+            {
+              authorId: CLEAN_AUTHOR_ID,
+              highestSeverity: null,
+              signals: [],
+            },
+          ],
+          [
+            AUTHOR_ID,
+            {
+              authorId: AUTHOR_ID,
+              highestSeverity: 'low',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.NEW_AUTHOR,
+                  severity: 'low',
+                  label: 'New Author',
+                  description: 'No previously approved listings',
+                },
+              ],
+            },
+          ],
+        ]),
+        submissionRiskProfiles: new Map([
+          [LISTING_ID, submissionRiskProfile],
+          [
+            MEDIUM_SUBMISSION_LISTING_ID,
+            {
+              listingId: MEDIUM_SUBMISSION_LISTING_ID,
+              highestSeverity: 'medium',
+              signals: [
+                {
+                  type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                  severity: 'medium',
+                  label: 'Placeholder Emulator Version',
+                  description: 'Submitted emulator version resembles placeholder text.',
+                },
+              ],
+            },
+          ],
+        ]),
+      },
+    )
+
+    expect(autoRejectItems).toEqual([
+      {
+        id: LISTING_ID,
+        processedNotes:
+          'Automatically rejected by review risk bulk action: submission risk high severity; author risk low severity (1 signal).',
+      },
+      {
+        id: CLEAN_LISTING_ID,
+        processedNotes:
+          'Automatically rejected by review risk bulk action: author risk low severity (1 signal).',
+      },
+    ])
+  })
+
+  it('excludes submissions when only submission risk is below high severity', () => {
+    const autoRejectItems = getAutoRejectableReviewRiskItems(
+      [{ id: MEDIUM_SUBMISSION_LISTING_ID, authorId: CLEAN_AUTHOR_ID, customFieldValues: [] }],
+      {
+        authorRiskProfiles: new Map([
+          [
+            CLEAN_AUTHOR_ID,
+            {
+              authorId: CLEAN_AUTHOR_ID,
+              highestSeverity: null,
+              signals: [],
+            },
+          ],
+        ]),
+        submissionRiskProfiles: new Map([
+          [
+            MEDIUM_SUBMISSION_LISTING_ID,
+            {
+              listingId: MEDIUM_SUBMISSION_LISTING_ID,
+              highestSeverity: 'medium',
+              signals: [
+                {
+                  type: SUBMISSION_RISK_SIGNAL_TYPES.PLACEHOLDER_EMULATOR_VERSION,
+                  severity: 'medium',
+                  label: 'Placeholder Emulator Version',
+                  description: 'Submitted emulator version resembles placeholder text.',
+                },
+              ],
+            },
+          ],
+        ]),
+      },
+    )
+
+    expect(autoRejectItems).toEqual([])
   })
 
   it('attaches empty profiles when no risk profile exists for a listing', () => {

--- a/src/server/services/review-risk.service.test.ts
+++ b/src/server/services/review-risk.service.test.ts
@@ -225,6 +225,43 @@ describe('review risk helpers', () => {
     expect(autoRejectItems).toEqual([])
   })
 
+  it('excludes malformed high submission risk profiles without signals', () => {
+    const autoRejectItems = getAutoRejectableReviewRiskItems(
+      [{ id: LISTING_ID, authorId: AUTHOR_ID, customFieldValues: [] }],
+      {
+        authorRiskProfiles: new Map([
+          [
+            AUTHOR_ID,
+            {
+              authorId: AUTHOR_ID,
+              highestSeverity: 'low',
+              signals: [
+                {
+                  type: RISK_SIGNAL_TYPES.NEW_AUTHOR,
+                  severity: 'low',
+                  label: 'New Author',
+                  description: 'No previously approved listings',
+                },
+              ],
+            },
+          ],
+        ]),
+        submissionRiskProfiles: new Map([
+          [
+            LISTING_ID,
+            {
+              listingId: LISTING_ID,
+              highestSeverity: 'high',
+              signals: [],
+            },
+          ],
+        ]),
+      },
+    )
+
+    expect(autoRejectItems).toEqual([])
+  })
+
   it('returns the auto-reject preview count from the shared predicate', () => {
     const preview = getAutoRejectableReviewRiskPreview(
       [

--- a/src/server/services/review-risk.service.ts
+++ b/src/server/services/review-risk.service.ts
@@ -44,6 +44,11 @@ export interface AutoRejectReviewRiskItem {
   processedNotes: string
 }
 
+export interface AutoRejectReviewRiskPreview {
+  eligibleCount: number
+  reviewRiskQueueCount: number
+}
+
 interface ActiveAuthorBansPrismaClient {
   userBan: {
     findMany: (args: {
@@ -84,12 +89,28 @@ function hasRiskSignals(candidate: ReviewRiskCandidate, profiles: ReviewRiskProf
   return Boolean(submissionRiskProfile && submissionRiskProfile.signals.length > 0)
 }
 
-function hasAutoRejectableAuthorRisk(profile: AuthorRiskProfile | undefined): boolean {
+function hasAuthorRiskSignals(profile: AuthorRiskProfile | undefined): boolean {
   return Boolean(profile && profile.signals.length > 0)
 }
 
-function hasAutoRejectableSubmissionRisk(profile: SubmissionRiskProfile | undefined): boolean {
+function hasHighAuthorRisk(profile: AuthorRiskProfile | undefined): boolean {
+  return Boolean(profile && profile.highestSeverity === 'high' && profile.signals.length > 0)
+}
+
+function hasHighSubmissionRisk(profile: SubmissionRiskProfile | undefined): boolean {
   return profile?.highestSeverity === 'high'
+}
+
+function isAutoRejectableReviewRisk(params: {
+  authorRiskProfile: AuthorRiskProfile | undefined
+  submissionRiskProfile: SubmissionRiskProfile | undefined
+}): boolean {
+  if (hasHighAuthorRisk(params.authorRiskProfile)) return true
+
+  return (
+    hasHighSubmissionRisk(params.submissionRiskProfile) &&
+    hasAuthorRiskSignals(params.authorRiskProfile)
+  )
 }
 
 function formatSignalCount(signalCount: number): string {
@@ -102,7 +123,7 @@ function buildAutoRejectProcessedNotes(params: {
 }): string {
   const reasons: string[] = []
 
-  if (hasAutoRejectableSubmissionRisk(params.submissionRiskProfile)) {
+  if (hasHighSubmissionRisk(params.submissionRiskProfile)) {
     reasons.push('submission risk high severity')
   }
 
@@ -153,8 +174,10 @@ export function getAutoRejectableReviewRiskItems<TCandidate extends ReviewRiskCa
     const submissionRiskProfile = profiles.submissionRiskProfiles.get(candidate.id)
 
     if (
-      !hasAutoRejectableAuthorRisk(authorRiskProfile) &&
-      !hasAutoRejectableSubmissionRisk(submissionRiskProfile)
+      !isAutoRejectableReviewRisk({
+        authorRiskProfile,
+        submissionRiskProfile,
+      })
     ) {
       return []
     }
@@ -171,6 +194,16 @@ export function getAutoRejectableReviewRiskItems<TCandidate extends ReviewRiskCa
   })
 }
 
+export function getAutoRejectableReviewRiskPreview<TCandidate extends ReviewRiskCandidate>(
+  candidates: readonly TCandidate[],
+  profiles: ReviewRiskProfiles,
+): AutoRejectReviewRiskPreview {
+  return {
+    eligibleCount: getAutoRejectableReviewRiskItems(candidates, profiles).length,
+    reviewRiskQueueCount: getRiskyReviewItemIds(candidates, profiles).length,
+  }
+}
+
 export async function getAutoRejectableReviewRiskItemsForCandidates<
   TCandidate extends ReviewRiskCandidate,
 >(params: {
@@ -181,6 +214,18 @@ export async function getAutoRejectableReviewRiskItemsForCandidates<
   const profiles = await computeReviewRiskProfiles(params.prisma, candidates)
 
   return getAutoRejectableReviewRiskItems(candidates, profiles)
+}
+
+export async function getAutoRejectableReviewRiskPreviewForCandidates<
+  TCandidate extends ReviewRiskCandidate,
+>(params: {
+  prisma: RiskPrismaClient
+  loadCandidates: () => Promise<readonly TCandidate[]>
+}): Promise<AutoRejectReviewRiskPreview> {
+  const candidates = await params.loadCandidates()
+  const profiles = await computeReviewRiskProfiles(params.prisma, candidates)
+
+  return getAutoRejectableReviewRiskPreview(candidates, profiles)
 }
 
 export function attachReviewRiskProfiles<TListing extends { id: string; authorId: string }>(

--- a/src/server/services/review-risk.service.ts
+++ b/src/server/services/review-risk.service.ts
@@ -98,7 +98,7 @@ function hasHighAuthorRisk(profile: AuthorRiskProfile | undefined): boolean {
 }
 
 function hasHighSubmissionRisk(profile: SubmissionRiskProfile | undefined): boolean {
-  return profile?.highestSeverity === 'high'
+  return Boolean(profile && profile.highestSeverity === 'high' && profile.signals.length > 0)
 }
 
 function isAutoRejectableReviewRisk(params: {

--- a/src/server/services/review-risk.service.ts
+++ b/src/server/services/review-risk.service.ts
@@ -39,6 +39,11 @@ interface RiskOnlyReviewPage<TListing extends { id: string; authorId: string }> 
   total: number
 }
 
+export interface AutoRejectReviewRiskItem {
+  id: string
+  processedNotes: string
+}
+
 interface ActiveAuthorBansPrismaClient {
   userBan: {
     findMany: (args: {
@@ -79,6 +84,38 @@ function hasRiskSignals(candidate: ReviewRiskCandidate, profiles: ReviewRiskProf
   return Boolean(submissionRiskProfile && submissionRiskProfile.signals.length > 0)
 }
 
+function hasAutoRejectableAuthorRisk(profile: AuthorRiskProfile | undefined): boolean {
+  return Boolean(profile && profile.signals.length > 0)
+}
+
+function hasAutoRejectableSubmissionRisk(profile: SubmissionRiskProfile | undefined): boolean {
+  return profile?.highestSeverity === 'high'
+}
+
+function formatSignalCount(signalCount: number): string {
+  return `${signalCount} signal${signalCount === 1 ? '' : 's'}`
+}
+
+function buildAutoRejectProcessedNotes(params: {
+  authorRiskProfile: AuthorRiskProfile | undefined
+  submissionRiskProfile: SubmissionRiskProfile | undefined
+}): string {
+  const reasons: string[] = []
+
+  if (hasAutoRejectableSubmissionRisk(params.submissionRiskProfile)) {
+    reasons.push('submission risk high severity')
+  }
+
+  const authorRiskProfile = params.authorRiskProfile
+  if (authorRiskProfile && authorRiskProfile.signals.length > 0) {
+    const signalCount = authorRiskProfile.signals.length
+    const severity = authorRiskProfile.highestSeverity ?? 'unknown'
+    reasons.push(`author risk ${severity} severity (${formatSignalCount(signalCount)})`)
+  }
+
+  return `Automatically rejected by review risk bulk action: ${reasons.join('; ')}.`
+}
+
 export async function computeReviewRiskProfiles<TCandidate extends ReviewRiskCandidate>(
   prisma: RiskPrismaClient,
   candidates: readonly TCandidate[],
@@ -105,6 +142,45 @@ export function getRiskyReviewItemIds<TCandidate extends ReviewRiskCandidate>(
   return candidates
     .filter((candidate) => hasRiskSignals(candidate, profiles))
     .map((candidate) => candidate.id)
+}
+
+export function getAutoRejectableReviewRiskItems<TCandidate extends ReviewRiskCandidate>(
+  candidates: readonly TCandidate[],
+  profiles: ReviewRiskProfiles,
+): AutoRejectReviewRiskItem[] {
+  return candidates.flatMap((candidate) => {
+    const authorRiskProfile = profiles.authorRiskProfiles.get(candidate.authorId)
+    const submissionRiskProfile = profiles.submissionRiskProfiles.get(candidate.id)
+
+    if (
+      !hasAutoRejectableAuthorRisk(authorRiskProfile) &&
+      !hasAutoRejectableSubmissionRisk(submissionRiskProfile)
+    ) {
+      return []
+    }
+
+    return [
+      {
+        id: candidate.id,
+        processedNotes: buildAutoRejectProcessedNotes({
+          authorRiskProfile,
+          submissionRiskProfile,
+        }),
+      },
+    ]
+  })
+}
+
+export async function getAutoRejectableReviewRiskItemsForCandidates<
+  TCandidate extends ReviewRiskCandidate,
+>(params: {
+  prisma: RiskPrismaClient
+  loadCandidates: () => Promise<readonly TCandidate[]>
+}): Promise<AutoRejectReviewRiskItem[]> {
+  const candidates = await params.loadCandidates()
+  const profiles = await computeReviewRiskProfiles(params.prisma, candidates)
+
+  return getAutoRejectableReviewRiskItems(candidates, profiles)
 }
 
 export function attachReviewRiskProfiles<TListing extends { id: string; authorId: string }>(


### PR DESCRIPTION
## Description

Adds an admin-only bulk action to auto-reject pending handheld and PC compatibility reports that match review-risk rejection rules.

The auto-reject rule is:
- high author risk
- high submission risk only when the author has at least one author-risk signal

The rejection workflow now lives in the service layer for both handheld and PC reports. It generates per-report processed notes, guards against status races before updating, and keeps trust/notification side effects from failing the endpoint after reports have already been rejected.

No linked issue.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [x] Typecheck
- [x] Unit tests
- [ ] Manual testing

Ran:
- `pnpm types`
- `pnpm lint`
- `pnpm test`

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [x] Documentation changes are not needed for this change
- [x] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

The button only appears for admins while viewing the review-risk queue. The confirmation dialog shows the matching count and scope before running the bulk rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin auto-reject workflow for risky listings (handheld + PC) with preview counts, dynamic rule details, confirmation, and success/error toasts.
  * Confirmation dialog supports custom button variants and detailed breakdowns.

* **Bug Fixes**
  * Improved confirmation dismissal handling and reliable promise resolution.

* **Tests**
  * Added unit and integration tests covering the auto-reject UI, dialogs, routers, and services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->