### PR TITLE
Fix GPU view modal close button

### DIFF
--- a/src/app/admin/gpus/components/GpuViewModal.tsx
+++ b/src/app/admin/gpus/components/GpuViewModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Modal, InputPlaceholder } from '@/components/ui'
+import { Button, Modal, InputPlaceholder } from '@/components/ui'
 import { type RouterOutput } from '@/types/trpc'
 
 type GpuData = RouterOutput['gpus']['get']['gpus'][number]
@@ -31,14 +31,9 @@ function GpuViewModal(props: Props) {
         </div>
 
         <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-gray-700">
-          {/* TODO: Use the Button component? */}
-          <button
-            type="button"
-            onClick={props.onClose}
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
+          <Button variant="ghost" onClick={props.onClose}>
             Close
-          </button>
+          </Button>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## Description

Replaces the raw close button in the GPU view modal with the shared `Button` component so it matches the rest of the admin modal UI.

Fixes #407

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [ ] Typecheck
- [ ] Unit tests
- [ ] Manual testing

Ran:
- `./node_modules/.bin/eslint src/app/admin/gpus/components/GpuViewModal.tsx`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [x] Documentation changes are not needed for this change
- [ ] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

No behavior change intended here, just swapping to the shared button component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component consistency by standardizing UI component usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->