### PR TITLE
Add comment submit shortcut

### DIFF
--- a/src/components/comments/GenericCommentForm.test.tsx
+++ b/src/components/comments/GenericCommentForm.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GenericCommentForm } from './GenericCommentForm'
+import type { ReactNode } from 'react'
+
+const testMocks = vi.hoisted(() => ({
+  useUser: vi.fn(() => ({ user: { id: 'user-1' } })),
+  submitWithHumanVerification: vi.fn(
+    async (callback: (humanVerificationToken: string) => Promise<void>) => {
+      await callback('verification-token')
+    },
+  ),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: testMocks.useUser,
+  SignInButton: (props: { children: ReactNode }) => props.children,
+}))
+
+vi.mock('@/features/human-verification/client', () => ({
+  useSubmitWithHumanVerification: () => testMocks.submitWithHumanVerification,
+}))
+
+vi.mock('@/lib/toast', () => ({
+  default: {
+    error: testMocks.toastError,
+    success: testMocks.toastSuccess,
+  },
+}))
+
+vi.mock('@/lib/dynamic-imports', async () => {
+  const actual = await vi.importActual<{ MarkdownEditor: unknown }>(
+    '@/components/ui/form/MarkdownEditor',
+  )
+
+  return { MarkdownEditor: actual.MarkdownEditor }
+})
+
+describe('GenericCommentForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ['Cmd+Enter', { metaKey: true }],
+    ['Ctrl+Enter', { ctrlKey: true }],
+  ])('submits comments with %s', async (_shortcut, keyModifiers) => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <GenericCommentForm
+        entityId="listing-1"
+        config={{ entityType: 'listing' }}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    const editor = screen.getByRole('textbox')
+    await user.type(editor, 'Runs well')
+
+    fireEvent.keyDown(editor, { key: 'Enter', ...keyModifiers })
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'Runs well',
+          humanVerificationToken: 'verification-token',
+        }),
+      )
+    })
+  })
+
+  it('does not submit when Enter is pressed without a modifier key', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <GenericCommentForm
+        entityId="listing-1"
+        config={{ entityType: 'listing' }}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    const editor = screen.getByRole('textbox')
+    await user.type(editor, 'Runs well')
+
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/comments/GenericCommentForm.test.tsx
+++ b/src/components/comments/GenericCommentForm.test.tsx
@@ -93,4 +93,23 @@ describe('GenericCommentForm', () => {
 
     expect(onSubmit).not.toHaveBeenCalled()
   })
+
+  it('uses the normal validation flow when the shortcut is pressed with empty content', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <GenericCommentForm
+        entityId="listing-1"
+        config={{ entityType: 'listing' }}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', metaKey: true })
+
+    await waitFor(() => {
+      expect(testMocks.toastError).toHaveBeenCalledWith('Please enter a comment')
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/comments/GenericCommentForm.tsx
+++ b/src/components/comments/GenericCommentForm.tsx
@@ -108,7 +108,7 @@ export function GenericCommentForm(props: GenericCommentFormProps) {
     if (ev.key !== 'Enter' || (!ev.metaKey && !ev.ctrlKey)) return
 
     ev.preventDefault()
-    if (isLoading || !content.trim() || content.length > maxLength) return
+    if (isLoading) return
 
     ev.currentTarget.form?.requestSubmit()
   }

--- a/src/components/comments/GenericCommentForm.tsx
+++ b/src/components/comments/GenericCommentForm.tsx
@@ -2,7 +2,7 @@
 
 import { useUser, SignInButton } from '@clerk/nextjs'
 import { Send, X } from 'lucide-react'
-import { useState, type FormEvent } from 'react'
+import { useState, type FormEvent, type KeyboardEvent } from 'react'
 import { Button } from '@/components/ui'
 import { useSubmitWithHumanVerification } from '@/features/human-verification/client'
 import { MarkdownEditor } from '@/lib/dynamic-imports'
@@ -104,6 +104,15 @@ export function GenericCommentForm(props: GenericCommentFormProps) {
     props.onCancel?.()
   }
 
+  const handleEditorKeyDown = (ev: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (ev.key !== 'Enter' || (!ev.metaKey && !ev.ctrlKey)) return
+
+    ev.preventDefault()
+    if (isLoading || !content.trim() || content.length > maxLength) return
+
+    ev.currentTarget.form?.requestSubmit()
+  }
+
   if (!user && props.config.showSignInPrompt !== false) {
     return (
       <div className="mb-2 text-center p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
@@ -146,6 +155,7 @@ export function GenericCommentForm(props: GenericCommentFormProps) {
           maxLength={maxLength}
           disabled={isLoading}
           className={cn(isReply && 'text-sm')}
+          onKeyDown={handleEditorKeyDown}
         />
 
         <div className="flex items-center justify-end">
@@ -163,7 +173,6 @@ export function GenericCommentForm(props: GenericCommentFormProps) {
               </Button>
             )}
 
-            {/*TODO: allow Cmd+Enter or Ctrl+Enter to submit*/}
             <Button
               type="submit"
               size="sm"
@@ -188,6 +197,7 @@ export function GenericCommentForm(props: GenericCommentFormProps) {
         rows={rows}
         maxLength={maxLength}
         className={cn(isReply && 'text-sm')}
+        onKeyDown={handleEditorKeyDown}
       />
       <div className="flex justify-end gap-2 mt-2 mb-8">
         {(!!props.editingComment || isReply) && props.onCancel && (
@@ -195,7 +205,6 @@ export function GenericCommentForm(props: GenericCommentFormProps) {
             Cancel
           </Button>
         )}
-        {/*TODO: allow Cmd+Enter or Ctrl+Enter to submit*/}
         <Button
           type="submit"
           variant="primary"

--- a/src/components/ui/form/MarkdownEditor.tsx
+++ b/src/components/ui/form/MarkdownEditor.tsx
@@ -25,6 +25,7 @@ import {
   type ComponentType,
   type TouchEvent as ReactTouchEvent,
   type MouseEvent as ReactMouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
 } from 'react'
 import { MarkdownRenderer } from '@/components/ui'
 import { cn } from '@/lib/utils'
@@ -42,6 +43,7 @@ interface Props {
   id?: string
   minHeight?: number
   maxHeight?: number
+  onKeyDown?: (ev: ReactKeyboardEvent<HTMLTextAreaElement>) => void
 }
 
 export function MarkdownEditor(props: Props) {
@@ -297,6 +299,7 @@ export function MarkdownEditor(props: Props) {
               id={props.id}
               value={props.value || ''}
               onChange={(e) => props.onChange(e.target.value)}
+              onKeyDown={props.onKeyDown}
               placeholder={props.placeholder || 'Write your comment...'}
               maxLength={props.maxLength}
               disabled={props.disabled}


### PR DESCRIPTION
## Description

Adds Cmd+Enter / Ctrl+Enter support to the comment editor so comments and replies can be submitted from the keyboard without skipping the existing submit flow.

The shortcut goes through the form submit path, so the existing validation, human verification, update/create handling, and toasts still run in one place.

Fixes #394

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [ ] Typecheck
- [x] Unit tests
- [ ] Manual testing

Ran:
- `./node_modules/.bin/vitest run src/components/comments/GenericCommentForm.test.tsx`
- `./node_modules/.bin/eslint src/components/comments/GenericCommentForm.tsx src/components/comments/GenericCommentForm.test.tsx src/components/ui/form/MarkdownEditor.tsx`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [x] Documentation changes are not needed for this change
- [ ] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

The lint command still reports the existing React Compiler warnings in `MarkdownEditor`, but exits successfully. This change does not move that toolbar component code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support for submitting comments (Cmd+Enter on macOS, Ctrl+Enter on Windows/Linux).

* **Tests**
  * Expanded test coverage to verify shortcut submission, empty-content validation, and that plain Enter does not trigger submit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->