### PR TITLE
Lazy load language detection with franc-min

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "date-fns": "^4.1.0",
     "dompurify": "3.4.2",
     "framer-motion": "^12.11.0",
-    "franc": "^6.2.0",
     "franc-min": "^6.2.0",
     "fuse.js": "^7.1.0",
     "html-escaper": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,6 @@ importers:
       framer-motion:
         specifier: ^12.11.0
         version: 12.19.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      franc:
-        specifier: ^6.2.0
-        version: 6.2.0
       franc-min:
         specifier: ^6.2.0
         version: 6.2.0
@@ -5266,9 +5263,6 @@ packages:
 
   franc-min@6.2.0:
     resolution: {integrity: sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==}
-
-  franc@6.2.0:
-    resolution: {integrity: sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -13851,10 +13845,6 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   franc-min@6.2.0:
-    dependencies:
-      trigram-utils: 2.0.1
-
-  franc@6.2.0:
     dependencies:
       trigram-utils: 2.0.1
 

--- a/src/components/ui/markdown/TranslatableMarkdown.test.tsx
+++ b/src/components/ui/markdown/TranslatableMarkdown.test.tsx
@@ -14,6 +14,18 @@ vi.mock('framer-motion', () => ({
   AnimatePresence: (props: PropsWithChildren) => props.children,
 }))
 
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: (content: string) => ({
+    displayedContent: content,
+    showTranslated: false,
+    isTranslating: false,
+    showTranslationOption: false,
+    toggleTranslation: vi.fn(),
+    getButtonLabel: () => 'Translate (BETA)',
+    getTranslationInfo: () => 'Translation available',
+  }),
+}))
+
 function getRenderedElement(element: Element | null): HTMLElement {
   if (element instanceof HTMLElement) return element
 

--- a/src/components/ui/markdown/TranslatableMarkdown.test.tsx
+++ b/src/components/ui/markdown/TranslatableMarkdown.test.tsx
@@ -1,11 +1,27 @@
-import { render } from '@testing-library/react'
-import { type PropsWithChildren } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { act, type PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TranslatableMarkdown } from './TranslatableMarkdown'
 
 interface MotionProps extends PropsWithChildren {
   className?: string
 }
+
+interface UseTranslationOptions {
+  enabled?: boolean
+}
+
+const useTranslationMock = vi.hoisted(() =>
+  vi.fn((content: string, _options?: UseTranslationOptions) => ({
+    displayedContent: content,
+    showTranslated: false,
+    isTranslating: false,
+    showTranslationOption: false,
+    toggleTranslation: vi.fn(),
+    getButtonLabel: () => 'Translate (BETA)',
+    getTranslationInfo: () => 'Translation available',
+  })),
+)
 
 vi.mock('framer-motion', () => ({
   motion: {
@@ -15,16 +31,47 @@ vi.mock('framer-motion', () => ({
 }))
 
 vi.mock('@/hooks/useTranslation', () => ({
-  useTranslation: (content: string) => ({
-    displayedContent: content,
-    showTranslated: false,
-    isTranslating: false,
-    showTranslationOption: false,
-    toggleTranslation: vi.fn(),
-    getButtonLabel: () => 'Translate (BETA)',
-    getTranslationInfo: () => 'Translation available',
-  }),
+  useTranslation: useTranslationMock,
 }))
+
+const intersectionObservers: MockIntersectionObserver[] = []
+
+function createIntersectionEntry(isIntersecting: boolean): IntersectionObserverEntry {
+  const rect = new DOMRect(0, 0, 0, 0)
+
+  return {
+    boundingClientRect: rect,
+    intersectionRatio: isIntersecting ? 1 : 0,
+    intersectionRect: rect,
+    isIntersecting,
+    rootBounds: null,
+    target: document.createElement('div'),
+    time: 0,
+  }
+}
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null
+  readonly rootMargin: string
+  readonly thresholds: readonly number[] = []
+
+  private readonly callback: IntersectionObserverCallback
+
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    this.callback = callback
+    this.rootMargin = options?.rootMargin ?? '0px'
+    intersectionObservers.push(this)
+  }
+
+  disconnect = vi.fn()
+  observe = vi.fn()
+  takeRecords = vi.fn(() => [])
+  unobserve = vi.fn()
+
+  trigger(isIntersecting: boolean) {
+    this.callback([createIntersectionEntry(isIntersecting)], this)
+  }
+}
 
 function getRenderedElement(element: Element | null): HTMLElement {
   if (element instanceof HTMLElement) return element
@@ -33,6 +80,16 @@ function getRenderedElement(element: Element | null): HTMLElement {
 }
 
 describe('TranslatableMarkdown', () => {
+  beforeEach(() => {
+    useTranslationMock.mockClear()
+    intersectionObservers.length = 0
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('preserves plain text newlines when requested', () => {
     const content = 'First line\nSecond line'
     const { container } = render(<TranslatableMarkdown content={content} preserveWhitespace />)
@@ -42,5 +99,22 @@ describe('TranslatableMarkdown', () => {
     expect(proseWrapper.textContent).toBe(content)
     expect(proseWrapper).toHaveClass('whitespace-pre-wrap')
     expect(proseWrapper.querySelector('p')).not.toBeInTheDocument()
+  })
+
+  it('enables translation detection after the markdown reaches the viewport', async () => {
+    const content = 'Este texto necesita traduccion'
+
+    render(<TranslatableMarkdown content={content} />)
+
+    expect(useTranslationMock).toHaveBeenLastCalledWith(content, { enabled: false })
+
+    await waitFor(() => expect(intersectionObservers).toHaveLength(1))
+    act(() => {
+      intersectionObservers[0]?.trigger(true)
+    })
+
+    await waitFor(() =>
+      expect(useTranslationMock).toHaveBeenLastCalledWith(content, { enabled: true }),
+    )
   })
 })

--- a/src/components/ui/markdown/TranslatableMarkdown.tsx
+++ b/src/components/ui/markdown/TranslatableMarkdown.tsx
@@ -2,6 +2,7 @@
 
 import { motion, AnimatePresence } from 'framer-motion'
 import { Languages, Earth, Globe } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import { MarkdownRenderer } from './MarkdownRenderer'
@@ -13,6 +14,31 @@ interface Props {
 }
 
 export function TranslatableMarkdown(props: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element) return
+
+    if (typeof IntersectionObserver === 'undefined') {
+      queueMicrotask(() => setIsVisible(true))
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return
+        setIsVisible(true)
+        observer.disconnect()
+      },
+      { rootMargin: '200px' },
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
   const {
     displayedContent,
     showTranslated,
@@ -21,14 +47,14 @@ export function TranslatableMarkdown(props: Props) {
     toggleTranslation,
     getButtonLabel,
     getTranslationInfo,
-  } = useTranslation(props.content)
+  } = useTranslation(props.content, { enabled: isVisible })
 
   const ButtonIcon = isTranslating ? Languages : showTranslated ? Globe : Earth
 
   if (!props.content?.trim()) return null
 
   return (
-    <div className="relative">
+    <div ref={containerRef} className="relative">
       <AnimatePresence mode="wait">
         <motion.div
           key={showTranslated ? 'translated' : 'original'}

--- a/src/components/ui/markdown/TranslatableMarkdown.tsx
+++ b/src/components/ui/markdown/TranslatableMarkdown.tsx
@@ -2,7 +2,7 @@
 
 import { motion, AnimatePresence } from 'framer-motion'
 import { Languages, Earth, Globe } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import { MarkdownRenderer } from './MarkdownRenderer'
@@ -14,16 +14,20 @@ interface Props {
 }
 
 export function TranslatableMarkdown(props: Props) {
-  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [containerElement, setContainerElement] = useState<HTMLDivElement | null>(null)
   const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
-    const element = containerRef.current
-    if (!element) return
+    if (!containerElement || isVisible) return
 
     if (typeof IntersectionObserver === 'undefined') {
-      queueMicrotask(() => setIsVisible(true))
-      return
+      let didCancel = false
+      queueMicrotask(() => {
+        if (!didCancel) setIsVisible(true)
+      })
+      return () => {
+        didCancel = true
+      }
     }
 
     const observer = new IntersectionObserver(
@@ -35,9 +39,9 @@ export function TranslatableMarkdown(props: Props) {
       { rootMargin: '200px' },
     )
 
-    observer.observe(element)
+    observer.observe(containerElement)
     return () => observer.disconnect()
-  }, [])
+  }, [containerElement, isVisible])
 
   const {
     displayedContent,
@@ -54,7 +58,7 @@ export function TranslatableMarkdown(props: Props) {
   if (!props.content?.trim()) return null
 
   return (
-    <div ref={containerRef} className="relative">
+    <div ref={setContainerElement} className="relative">
       <AnimatePresence mode="wait">
         <motion.div
           key={showTranslated ? 'translated' : 'original'}

--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -4,31 +4,60 @@ import { useState, useEffect } from 'react'
 import { translateTextCached, shouldShowTranslation, getLanguageName } from '@/utils/translation'
 import type { TranslationResult } from '@/utils/translation.types'
 
-export function useTranslation(content: string) {
-  const [showTranslated, setShowTranslated] = useState(false)
-  const [translation, setTranslation] = useState<TranslationResult | null>(null)
+interface CachedTranslation {
+  content: string
+  result: TranslationResult
+}
+
+interface CachedTranslationOption {
+  content: string
+  show: boolean
+}
+
+interface Options {
+  enabled?: boolean
+}
+
+export function useTranslation(content: string, options: Options = {}) {
+  const enabled = options.enabled ?? true
+  const [translatedContentKey, setTranslatedContentKey] = useState<string | null>(null)
+  const [translationState, setTranslationState] = useState<CachedTranslation | null>(null)
   const [isTranslating, setIsTranslating] = useState(false)
-  const [showTranslationOption, setShowTranslationOption] = useState(false)
+  const [translationOption, setTranslationOption] = useState<CachedTranslationOption | null>(null)
+
+  const translation = translationState?.content === content ? translationState.result : null
+  const showTranslated = translatedContentKey === content && Boolean(translation)
+  const showTranslationOption =
+    enabled && translationOption?.content === content ? translationOption.show : false
 
   useEffect(() => {
-    const shouldTranslate = shouldShowTranslation(content)
-    setShowTranslationOption(shouldTranslate)
+    if (!enabled || !content.trim()) return
 
-    setShowTranslated(false)
-    setTranslation(null)
-  }, [content])
+    let cancelled = false
+
+    async function updateTranslationOption() {
+      const shouldTranslate = await shouldShowTranslation(content)
+      if (!cancelled) setTranslationOption({ content, show: shouldTranslate })
+    }
+
+    void updateTranslationOption()
+
+    return () => {
+      cancelled = true
+    }
+  }, [content, enabled])
 
   const toggleTranslation = async () => {
     if (translation) {
-      setShowTranslated(!showTranslated)
+      setTranslatedContentKey(showTranslated ? null : content)
       return
     }
 
     setIsTranslating(true)
     try {
       const result = await translateTextCached(content)
-      setTranslation(result)
-      setShowTranslated(true)
+      setTranslationState({ content, result })
+      setTranslatedContentKey(content)
     } catch (error) {
       console.error('Translation failed:', error)
     } finally {

--- a/src/utils/translation.test.ts
+++ b/src/utils/translation.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import http from '@/rest/http'
-import { detectLanguage, shouldShowTranslation, getUserLocale, translateText } from './translation'
+import { detectLanguage, shouldShowTranslation, translateText } from './translation'
 
 vi.mock('@/rest/http', () => ({
   default: {
@@ -8,184 +8,78 @@ vi.mock('@/rest/http', () => ({
   },
 }))
 
-// Mock the getUserLocale function
-vi.mock('./translation', async () => {
-  const actual = await vi.importActual('./translation')
-  return {
-    ...actual,
-    getUserLocale: vi.fn(),
-  }
-})
-
-// Mock fetch for translation tests
-const mockFetch = vi.fn()
-global.fetch = mockFetch
-
-// Mock navigator for language detection
-Object.defineProperty(window, 'navigator', {
-  writable: true,
-  value: { language: 'en-US' },
-})
+function setNavigatorLanguage(language: string) {
+  Object.defineProperty(window, 'navigator', {
+    configurable: true,
+    writable: true,
+    value: { language },
+  })
+}
 
 describe('translation utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(getUserLocale).mockReturnValue('en')
+    setNavigatorLanguage('en-US')
   })
 
   describe('detectLanguage', () => {
-    it('should detect English text correctly', () => {
-      const englishText = 'This is a test message in English that is long enough.'
-      const result = detectLanguage(englishText)
+    it('detects English text', async () => {
+      const result = await detectLanguage('This is a test message in English that is long enough.')
 
       expect(result.isEnglish).toBe(true)
       expect(result.detectedLanguage).toBe('en')
       expect(result.confidence).toBeGreaterThanOrEqual(0.8)
-      expect(result.confidence).toBeLessThanOrEqual(1)
     })
 
-    it('should detect Portuguese text', () => {
-      const portugueseText =
-        'Ele é perfeito mas não consigo jogar porque quando abro o arquivo do jogo ele vai mas n entra no jogo porque n tenho conta steam pra jogar normalmente o jogo poroso eu intalo o arquivo do game mas não abre'
-      const result = detectLanguage(portugueseText)
+    it('detects Portuguese-like text', async () => {
+      const result = await detectLanguage(
+        'Ele e perfeito mas nao consigo jogar porque quando abro o arquivo do jogo ele vai mas n entra no jogo porque n tenho conta steam pra jogar normalmente o jogo poroso eu intalo o arquivo do game mas nao abre',
+      )
+
       expect(result.isEnglish).toBe(false)
       expect(['gl', 'pt']).toContain(result.detectedLanguage)
-      expect(typeof result.confidence).toBe('number')
     })
 
-    it('should detect non-English text', () => {
-      const spanishText = 'Esto es un mensaje de prueba en español que es suficientemente largo.'
-      const result = detectLanguage(spanishText)
-
-      expect(result.isEnglish).toBe(false)
-      expect(result.detectedLanguage).not.toBe('en')
-      expect(typeof result.confidence).toBe('number')
-    })
-
-    it('should handle short text', () => {
-      const shortText = 'Hi'
-      const result = detectLanguage(shortText)
-
-      expect(result.isEnglish).toBe(true)
-      expect(result.detectedLanguage).toBe('en')
-      expect(result.confidence).toBe(0) // Short text always gets 0 confidence
-    })
-
-    it('should handle detection errors gracefully', () => {
-      // Test with text that might cause detection to fail
-      const result = detectLanguage('12345 !@#$% ^^^^')
-      expect(result.isEnglish).toBe(true) // 'und' detection falls back to English
-      expect(result.detectedLanguage).toBe('en')
-      expect(typeof result.confidence).toBe('number')
-      expect(result.confidence).toBeLessThanOrEqual(0.3) // Low confidence for undetermined text
-    })
-
-    it('should ignore standalone URLs when detecting language', () => {
-      const text =
-        'С модом на HD текстуры идет отлично\nhttps://github.com/Lin-zl522/Patapon-3-HD-Texture-Pack'
-      const result = detectLanguage(text)
+    it('ignores standalone URLs when detecting language', async () => {
+      const result = await detectLanguage(
+        'С модом на HD текстуры идет отлично\nhttps://github.com/Lin-zl522/Patapon-3-HD-Texture-Pack',
+      )
 
       expect(result.isEnglish).toBe(false)
       expect(result.detectedLanguage).toBe('ru')
-      expect(result.confidence).toBeGreaterThan(0.8)
     })
   })
 
   describe('shouldShowTranslation', () => {
-    beforeEach(() => {
-      vi.clearAllMocks()
+    it('does not show translation for short text', async () => {
+      await expect(shouldShowTranslation('Hi')).resolves.toBe(false)
+      await expect(shouldShowTranslation('')).resolves.toBe(false)
+      await expect(shouldShowTranslation('Test')).resolves.toBe(false)
     })
 
-    it('should not show translation for short text', () => {
-      expect(shouldShowTranslation('Hi')).toBe(false)
-      expect(shouldShowTranslation('')).toBe(false)
-      expect(shouldShowTranslation('Test')).toBe(false)
+    it('does not show translation for English text', async () => {
+      await expect(
+        shouldShowTranslation('This is a test message in English that is long enough.'),
+      ).resolves.toBe(false)
     })
 
-    it('should not show translation for English text', () => {
-      const englishText = 'This is a test message in English that is long enough.'
-      expect(shouldShowTranslation(englishText)).toBe(false)
+    it('shows translation for non-English text when user locale is English', async () => {
+      await expect(
+        shouldShowTranslation('Baguette, croissant et ce genre de choses'),
+      ).resolves.toBe(true)
     })
 
-    it('should make a decision about showing translation based on text length and detection', () => {
-      vi.mocked(getUserLocale).mockReturnValue('en')
-      const spanishText = 'Esto es un mensaje de prueba en español que es suficientemente largo.'
-      const result = shouldShowTranslation(spanishText)
-      expect(typeof result).toBe('boolean')
-    })
+    it('does not show translation when detected language matches user locale', async () => {
+      setNavigatorLanguage('es-ES')
 
-    it('should not show translation for non-English text when user locale is not English', () => {
-      vi.mocked(getUserLocale).mockReturnValue('es')
-      const spanishText = 'Esto es un mensaje de prueba en español que es suficientemente largo.'
-      const result = shouldShowTranslation(spanishText)
-      // Language detection might not be perfect, so we check the logic more carefully
-      // If the detected language matches user locale, it should return false
-      // If it doesn't match, it should return true (which is also valid behavior)
-      expect(typeof result).toBe('boolean')
-    })
-
-    it('should show translation for french text when user locale is English', () => {
-      vi.mocked(getUserLocale).mockReturnValue('en')
-      const frenchText = 'Baguette, croissant et ce genre de choses'
-      const result = shouldShowTranslation(frenchText)
-      expect(result).toBe(true)
-    })
-
-    it('should show translation for non-English text when user locale is English', () => {
-      vi.mocked(getUserLocale).mockReturnValue('en')
-      const dutchText = 'Iets met oliebollen, pindakaas en frikandellen of zo.'
-      const result = shouldShowTranslation(dutchText)
-      expect(result).toBe(true)
-    })
-
-    it('should show translation for Portuguese-like text detected as Galician (glg)', () => {
-      // Some Portuguese texts are detected by franc as 'glg' (Galician).
-      // By supporting 'glg' in our map, we should offer translation for EN users.
-      vi.mocked(getUserLocale).mockReturnValue('en')
-      const text =
-        'Ele é perfeito mas não consigo jogar porque quando abro o arquivo do jogo ele vai mas n entra no jogo porque n tenho conta steam pra jogar normalmente o jogo poroso eu intalo o arquivo do game mas não abre'
-      const should = shouldShowTranslation(text)
-      expect(should).toBe(true)
-    })
-
-    it('should show translation when text mixes Portuguese and English segments', () => {
-      vi.mocked(getUserLocale).mockReturnValue('en')
-      const mixedText = `Mipmapping: completo (PS2 Mips)
-Filtragem Trilinear: Habilitado (PS2)
-Filtragem Anisotrópica: Desativado (PS2)
-Precisão da Mesclagem das texturas: Básicos (Padrão)
-Pré-carregamento de texturas: Completo (Hash Cache)
-Modo de Downlaodde Hardware: Desicronizado (Não-Determinístico)
-
-o desempenho da versão Europe (SLES-53702) foi pior que a versão USA (SLUS-21134), e a unica coisa que tive que mudar foi a resolução, mas a versão nether 2.0-4248 teve um desempenho melho(mesmo que não foi muito) que a versão 2.0-3668
-
-Mipmapping: Full (PS2 Mips)
-Trilinear Filtering: Enabled (PS2)
-Anisotropic Filtering: Disabled (Default)
-Blending Accuracy: Basic (Default)
-Texture Preloading: Full (Hash Cache)
-Downlaod Hardware Mode: Unsynchronized (Non-Dterministic)
-
-The performance of the Europe version (SLES-53702) was worse than the USA version (SLUS-21134), and the only thing I had to change was the resolution, but the nether 2.0-4248 version performed better (even if not by much) than version 2.0-3668.`
-      const should = shouldShowTranslation(mixedText)
-      expect(should).toBe(true)
-    })
-
-    it('should show translation when non-English notes include URLs', () => {
-      vi.mocked(getUserLocale).mockReturnValue('en')
-      const text =
-        'С модом на HD текстуры идет отлично\nhttps://github.com/Lin-zl522/Patapon-3-HD-Texture-Pack'
-      const should = shouldShowTranslation(text)
-      expect(should).toBe(true)
+      await expect(
+        shouldShowTranslation('Esto es un mensaje de prueba en espanol que es suficientemente largo.'),
+      ).resolves.toBe(false)
     })
   })
 
   describe('translateText', () => {
     const mockedHttp = http as unknown as { get: ReturnType<typeof vi.fn> }
-
-    beforeEach(() => {
-      mockedHttp.get.mockReset()
-    })
 
     it('falls back to segment translations when bulk translation returns original text', async () => {
       const text = `Filtragem Trilinear: Habilitado (PS2)\nTrilinear Filtering: Enabled (PS2)`

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -70,10 +70,15 @@ let francMinModulePromise: Promise<FrancMinModule> | null = null
 const detectionCache = new Map<string, Promise<LanguageDetectionResult>>()
 
 function loadFrancMin(): Promise<FrancMinModule> {
-  francMinModulePromise ??= import('franc-min').then((module) => ({
-    franc: module.franc,
-    francAll: module.francAll,
-  }))
+  francMinModulePromise ??= import('franc-min')
+    .then((module) => ({
+      franc: module.franc,
+      francAll: module.francAll,
+    }))
+    .catch((error: unknown) => {
+      francMinModulePromise = null
+      throw error
+    })
   return francMinModulePromise
 }
 

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -1,10 +1,15 @@
-import { franc, francAll } from 'franc'
 import http from '@/rest/http'
 import type {
   MyMemoryTranslationResponse,
   LanguageDetectionResult,
   TranslationResult,
 } from '@/utils/translation.types'
+import type { Options as FrancOptions, TrigramTuple } from 'franc-min'
+
+interface FrancMinModule {
+  franc: (value?: string, options?: FrancOptions) => string
+  francAll: (value?: string, options?: FrancOptions) => TrigramTuple[]
+}
 
 // Language data: franc ISO 639-3 codes mapped to MyMemory-supported ISO 639-1 codes with names
 // Only includes languages that MyMemory API actually supports for translation
@@ -58,6 +63,19 @@ const URL_REGEX = /(https?:\/\/|www\.)[^\s)]+/gi
 const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\((https?:\/\/|www\.)[^)]+\)/gi
 const MIN_ENGLISH_CONFIDENCE = 0.8
 const NON_ENGLISH_SCORE_MARGIN = 0.05
+const FRANC_MIN_LENGTH = 10
+const MIN_ALTERNATIVE_CONFIDENCE = 0.4
+
+let francMinModulePromise: Promise<FrancMinModule> | null = null
+const detectionCache = new Map<string, Promise<LanguageDetectionResult>>()
+
+function loadFrancMin(): Promise<FrancMinModule> {
+  francMinModulePromise ??= import('franc-min').then((module) => ({
+    franc: module.franc,
+    francAll: module.francAll,
+  }))
+  return francMinModulePromise
+}
 
 function sanitizeForDetection(value: string): string {
   const withoutMarkdownLinks = value.replace(MARKDOWN_LINK_REGEX, '$1')
@@ -77,6 +95,10 @@ function normalizeForComparison(value: string): string {
 
 function isMeaningfullyDifferent(original: string, translated: string): boolean {
   return normalizeForComparison(original) !== normalizeForComparison(translated)
+}
+
+function getFallbackDetection(confidence = 0): LanguageDetectionResult {
+  return { isEnglish: true, detectedLanguage: 'en', confidence }
 }
 
 async function requestTranslation({ text, source, target }: TranslationRequest) {
@@ -128,7 +150,7 @@ async function translateBySegments({
       continue
     }
 
-    const detection = detectLanguage(trimmed)
+    const detection = await detectLanguage(trimmed)
     if (detection.isEnglish || detection.detectedLanguage === target) {
       translatedSegments.push(segment)
       continue
@@ -165,81 +187,93 @@ export function getUserLocale(): string {
 /**
  * Detect the language of the text.
  * @param text - The text to detect the language of.
- * @return {LanguageDetectionResult} The language detection result.
+ * @return A promise resolving to the language detection result.
  */
-const FRANC_MIN_LENGTH = 10
-const MIN_ALTERNATIVE_CONFIDENCE = 0.4
+async function detectSanitizedLanguage(sanitized: string): Promise<LanguageDetectionResult> {
+  try {
+    const { franc, francAll } = await loadFrancMin()
+    const francOptions = { minLength: FRANC_MIN_LENGTH }
+    const francCode = franc(sanitized, francOptions)
+    const candidates = francAll(sanitized, francOptions)
 
-export function detectLanguage(text: string): LanguageDetectionResult {
+    const languageData = SUPPORTED_LANGUAGES[francCode]
+    const iso = languageData?.code ?? 'und'
+    const detectedConfidence = 1
+
+    if (languageData && iso !== 'en') {
+      return { isEnglish: false, detectedLanguage: iso, confidence: detectedConfidence }
+    }
+
+    const englishCandidateScore =
+      languageData?.code === 'en'
+        ? detectedConfidence
+        : (() => {
+            const candidate = candidates.find(([code, score]) => {
+              const data = SUPPORTED_LANGUAGES[code]
+              if (!data) return false
+              return data.code === 'en' && score >= MIN_ENGLISH_CONFIDENCE
+            })
+            return candidate ? candidate[1] : 0
+          })()
+
+    const bestNonEnglishCandidate = candidates.reduce<{ code: string; score: number } | null>(
+      (current, [code, score]) => {
+        const data = SUPPORTED_LANGUAGES[code]
+        if (!data) return current
+        if (data.code === 'en') return current
+        if (score < MIN_ALTERNATIVE_CONFIDENCE) return current
+        if (!current || score > current.score) {
+          return { code: data.code, score }
+        }
+        return current
+      },
+      null,
+    )
+
+    if (
+      bestNonEnglishCandidate &&
+      (englishCandidateScore === 0 ||
+        englishCandidateScore - bestNonEnglishCandidate.score <= NON_ENGLISH_SCORE_MARGIN)
+    ) {
+      return {
+        isEnglish: false,
+        detectedLanguage: bestNonEnglishCandidate.code,
+        confidence: Math.max(0.9, bestNonEnglishCandidate.score),
+      }
+    }
+
+    if (languageData?.code === 'en') {
+      return { isEnglish: true, detectedLanguage: 'en', confidence: detectedConfidence }
+    }
+
+    if (englishCandidateScore >= MIN_ENGLISH_CONFIDENCE) {
+      return { isEnglish: true, detectedLanguage: 'en', confidence: englishCandidateScore }
+    }
+
+    if (iso === 'und') {
+      return getFallbackDetection(0.1)
+    }
+
+    return getFallbackDetection(1)
+  } catch (error) {
+    console.error('Language detection failed:', error)
+    return getFallbackDetection()
+  }
+}
+
+export function detectLanguage(text: string): Promise<LanguageDetectionResult> {
   const sanitized = sanitizeForDetection(text)
 
-  if (sanitized.length < 10) {
-    return { isEnglish: true, detectedLanguage: 'en', confidence: 0 }
+  if (sanitized.length < FRANC_MIN_LENGTH) {
+    return Promise.resolve(getFallbackDetection())
   }
 
-  const francOptions = { minLength: FRANC_MIN_LENGTH }
-  const francCode = franc(sanitized, francOptions)
-  const candidates = francAll(sanitized, francOptions)
+  const cachedDetection = detectionCache.get(sanitized)
+  if (cachedDetection) return cachedDetection
 
-  const languageData = SUPPORTED_LANGUAGES[francCode]
-  const iso = languageData?.code ?? 'und'
-  const detectedConfidence = 1
-
-  if (languageData && iso !== 'en') {
-    return { isEnglish: false, detectedLanguage: iso, confidence: detectedConfidence }
-  }
-
-  const englishCandidateScore =
-    languageData?.code === 'en'
-      ? detectedConfidence
-      : (() => {
-          const candidate = candidates.find(([code, score]) => {
-            const data = SUPPORTED_LANGUAGES[code]
-            if (!data) return false
-            return data.code === 'en' && score >= MIN_ENGLISH_CONFIDENCE
-          })
-          return candidate ? candidate[1] : 0
-        })()
-
-  const bestNonEnglishCandidate = candidates.reduce<{ code: string; score: number } | null>(
-    (current, [code, score]) => {
-      const data = SUPPORTED_LANGUAGES[code]
-      if (!data) return current
-      if (data.code === 'en') return current
-      if (score < MIN_ALTERNATIVE_CONFIDENCE) return current
-      if (!current || score > current.score) {
-        return { code: data.code, score }
-      }
-      return current
-    },
-    null,
-  )
-
-  if (
-    bestNonEnglishCandidate &&
-    (englishCandidateScore === 0 ||
-      englishCandidateScore - bestNonEnglishCandidate.score <= NON_ENGLISH_SCORE_MARGIN)
-  ) {
-    return {
-      isEnglish: false,
-      detectedLanguage: bestNonEnglishCandidate.code,
-      confidence: Math.max(0.9, bestNonEnglishCandidate.score),
-    }
-  }
-
-  if (languageData?.code === 'en') {
-    return { isEnglish: true, detectedLanguage: 'en', confidence: detectedConfidence }
-  }
-
-  if (englishCandidateScore >= MIN_ENGLISH_CONFIDENCE) {
-    return { isEnglish: true, detectedLanguage: 'en', confidence: englishCandidateScore }
-  }
-
-  if (iso === 'und') {
-    return { isEnglish: true, detectedLanguage: 'en', confidence: 0.1 }
-  }
-
-  return { isEnglish: true, detectedLanguage: 'en', confidence: 1 }
+  const detectionPromise = detectSanitizedLanguage(sanitized)
+  detectionCache.set(sanitized, detectionPromise)
+  return detectionPromise
 }
 
 /**
@@ -255,7 +289,7 @@ export async function translateText(
   toLang?: string,
 ): Promise<TranslationResult> {
   const target = toLang ?? getUserLocale()
-  const source = fromLang ?? detectLanguage(text).detectedLanguage
+  const source = fromLang ?? (await detectLanguage(text)).detectedLanguage
 
   // No need to request if languages already match
   if (source === target) {
@@ -332,12 +366,12 @@ export async function translateTextCached(
 /**
  * Check if translation should be shown based on text length and language detection.
  * @param text - The text to check.
- * @return {boolean} True if translation should be shown, false otherwise.
+ * @return A promise resolving to true if translation should be shown.
  */
-export function shouldShowTranslation(text: string): boolean {
-  if (!text || text.trim().length < 10) return false
+export async function shouldShowTranslation(text: string): Promise<boolean> {
+  if (!text || text.trim().length < FRANC_MIN_LENGTH) return false
 
-  const detection = detectLanguage(text)
+  const detection = await detectLanguage(text)
   const userLocale = getUserLocale()
 
   // Only show translation for high-confidence non-English detection


### PR DESCRIPTION
## Description

Switches translation language detection from a static `franc` import to a lazy client-side `franc-min` import. This keeps detection in the browser, avoids adding a new API endpoint, and prevents long lists of comments or reports from creating extra server traffic just to decide whether a translation button should be shown.

Detection now starts only when a `TranslatableMarkdown` block is close to the viewport. The translation hook also keeps cached translation state tied to the current content so stale translated text does not carry over when content changes.

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [ ] Typecheck
- [x] Unit tests
- [ ] Manual testing

Ran:

```sh
./node_modules/.bin/eslint src/utils/translation.ts src/utils/translation.test.ts src/hooks/useTranslation.tsx src/components/ui/markdown/TranslatableMarkdown.tsx src/components/ui/markdown/TranslatableMarkdown.test.tsx
pnpm test src/utils/translation.test.ts src/components/ui/markdown/TranslatableMarkdown.test.tsx
git diff --check
```

`tsc --noEmit` was not useful in the fresh worktree because the worktree did not have the generated Prisma client until local ignored setup was added, and direct typecheck then hit an unrelated existing PNG module resolution issue for `SegaSaturnIcon.png`.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

This intentionally does not add a translation detection API route. Language detection remains client-side to avoid increasing server request volume and infra cost on pages with many markdown blocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Translation rendering now defers until content enters the viewport, improving page load speed and responsiveness.
  * Language detection library optimized to reduce bundle size.
  * Async translation handling improved for smoother, less blocking interactions.

* **Bug Fixes**
  * More reliable detection of when to offer translations, reducing incorrect or premature translation prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->