### PR TITLE
Remove unused SEO verification tags

### DIFF
--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -79,14 +79,6 @@ export const defaultMetadata: Metadata = {
   },
   other: {
     'theme-color': '#111828',
-    'google-site-verification': process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || '', // TODO: add if we start caring
-    'msvalidate.01': process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION || '', // TODO: add if we start caring
-    'yandex-verification': process.env.NEXT_PUBLIC_YANDEX_VERIFICATION || '', // TODO: add if we start caring
-    'fb:app_id': process.env.NEXT_PUBLIC_FACEBOOK_APP_ID || '', // TODO: add if we start caring
-  },
-  verification: {
-    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION, // TODO: add if we start caring
-    yandex: process.env.NEXT_PUBLIC_YANDEX_VERIFICATION, // TODO: add if we start caring
   },
   appleWebApp: {
     capable: true,


### PR DESCRIPTION
## Description

Removes unused site-verification and social metadata tags that were configured with empty fallbacks.

Fixes #385

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Metadata cleanup

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [ ] Typecheck
- [ ] Unit tests
- [ ] Manual testing

Ran:
- `git diff --check`
- `./node_modules/.bin/eslint src/lib/seo/metadata.ts`
- `./node_modules/.bin/prettier --check src/lib/seo/metadata.ts`

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [x] Documentation changes are not needed for this change
- [ ] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

The existing `theme-color` metadata entry is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed search engine verification metadata from default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->