### PR TITLE
Fix listing cover art layout containment

### DIFF
--- a/src/app/listings/[id]/components/ListingDetailsClient.tsx
+++ b/src/app/listings/[id]/components/ListingDetailsClient.tsx
@@ -95,15 +95,15 @@ function ListingDetailsClient(props: Props) {
         <CommunitySupportBanner variant="detail" page="listing-detail" />
 
         <Card className="w-full p-4 lg:p-8 shadow-2xl rounded-2xl lg:rounded-3xl border-0 bg-white dark:bg-gray-900 overflow-hidden">
-          <div className="flex w-full flex-col items-start gap-6 lg:gap-8 md:flex-row">
+          <div className="flex w-full min-w-0 flex-col items-start gap-6 lg:gap-8 md:flex-row">
             {/* Game Info */}
-            <div className="flex-1 md:pr-8 sm:border-r-0 md:border-r md:border-gray-200 md:dark:border-gray-700">
+            <div className="w-full min-w-0 flex-1 md:pr-8 sm:border-r-0 md:border-r md:border-gray-200 md:dark:border-gray-700">
               {/* Game Image */}
-              <div className="mb-6">
+              <div className="mb-6 w-full max-w-full overflow-hidden">
                 <GameImage
                   game={props.listing.game}
                   prioritizeBanner={true}
-                  className="w-full aspect-video rounded-lg shadow-md"
+                  className="w-full max-w-full aspect-video rounded-lg shadow-md"
                   aspectRatio="video"
                   showFallback={true}
                   priority={true}
@@ -128,7 +128,7 @@ function ListingDetailsClient(props: Props) {
                 fieldValues={props.listing?.customFieldValues ?? []}
               />
             </div>
-            <div className="flex w-full flex-col items-center gap-4 md:w-auto md:min-w-[180px] md:items-start">
+            <div className="flex w-full flex-col items-center gap-4 md:w-auto md:min-w-[180px] md:shrink-0 md:items-start">
               <div className="flex items-start justify-between w-full gap-2">
                 <AuthorPanel
                   profileImage={props.listing?.author?.profileImage}

--- a/src/app/listings/shared/components/GameImage.test.tsx
+++ b/src/app/listings/shared/components/GameImage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { GameImage } from './GameImage'
+import type { ImgHTMLAttributes } from 'react'
+
+vi.mock('next/image', () => ({
+  default: (
+    props: ImgHTMLAttributes<HTMLImageElement> & {
+      fill?: boolean
+      priority?: boolean
+      unoptimized?: boolean
+    },
+  ) => {
+    const { fill: _fill, priority: _priority, unoptimized: _unoptimized, ...imgProps } = props
+    return <img alt={String(imgProps.alt ?? '')} {...imgProps} />
+  },
+}))
+
+const game = {
+  id: 'game-1',
+  title: 'Wide Cover Game',
+  boxartUrl: 'https://example.com/large-cover.jpg',
+}
+
+describe('GameImage', () => {
+  it('keeps rendered images contained inside their parent flex column', () => {
+    const { container } = render(
+      <GameImage game={game} aspectRatio="video" className="rounded-lg shadow-md" />,
+    )
+
+    const wrapper = container.firstElementChild
+
+    expect(wrapper).toHaveClass('w-full')
+    expect(wrapper).toHaveClass('max-w-full')
+    expect(wrapper).toHaveClass('min-w-0')
+    expect(wrapper).toHaveClass('overflow-hidden')
+    expect(wrapper).toHaveClass('aspect-video')
+    expect(screen.getByAltText(game.title)).toBeInTheDocument()
+  })
+
+  it('keeps fallback images contained when no art is available', () => {
+    const { container } = render(
+      <GameImage game={{ id: 'game-2', title: 'Missing Art' }} showFallback={true} />,
+    )
+
+    const wrapper = container.firstElementChild
+
+    expect(wrapper).toHaveClass('w-full')
+    expect(wrapper).toHaveClass('max-w-full')
+    expect(wrapper).toHaveClass('min-w-0')
+    expect(wrapper).toHaveClass('overflow-hidden')
+    expect(screen.getByText('Missing Art')).toBeInTheDocument()
+  })
+})

--- a/src/app/listings/shared/components/GameImage.tsx
+++ b/src/app/listings/shared/components/GameImage.tsx
@@ -44,7 +44,7 @@ export function GameImage(props: Props) {
     return (
       <div
         className={cn(
-          'relative bg-gradient-to-br from-indigo-100 to-purple-100 dark:from-indigo-900 dark:to-purple-900 flex items-center justify-center',
+          'relative flex w-full min-w-0 max-w-full items-center justify-center overflow-hidden bg-gradient-to-br from-indigo-100 to-purple-100 dark:from-indigo-900 dark:to-purple-900',
           aspectRatioClass,
           props.className,
         )}
@@ -60,7 +60,13 @@ export function GameImage(props: Props) {
   }
 
   return (
-    <div className={cn('relative overflow-hidden', aspectRatioClass, props.className)}>
+    <div
+      className={cn(
+        'relative w-full min-w-0 max-w-full overflow-hidden',
+        aspectRatioClass,
+        props.className,
+      )}
+    >
       <Image
         src={imageUrl}
         alt={props.game.title}

--- a/src/app/pc-listings/[id]/components/PcListingDetailsClient.tsx
+++ b/src/app/pc-listings/[id]/components/PcListingDetailsClient.tsx
@@ -138,15 +138,15 @@ function PcListingDetailsClient(props: Props) {
         <CommunitySupportBanner variant="detail" page="pc-listing-detail" />
 
         <Card className="w-full p-4 lg:p-8 shadow-2xl rounded-2xl lg:rounded-3xl border-0 bg-white dark:bg-gray-900 overflow-hidden">
-          <div className="flex w-full flex-col items-start gap-6 lg:gap-8 md:flex-row">
+          <div className="flex w-full min-w-0 flex-col items-start gap-6 lg:gap-8 md:flex-row">
             {/* Game Info */}
-            <div className="flex-1 md:pr-8 sm:border-r-0 md:border-r md:border-gray-200 md:dark:border-gray-700">
+            <div className="w-full min-w-0 flex-1 md:pr-8 sm:border-r-0 md:border-r md:border-gray-200 md:dark:border-gray-700">
               {/* Game Image */}
-              <div className="mb-6">
+              <div className="mb-6 w-full max-w-full overflow-hidden">
                 <GameImage
                   prioritizeBanner={true}
                   game={props.pcListing.game}
-                  className="w-full aspect-video rounded-lg shadow-md"
+                  className="w-full max-w-full aspect-video rounded-lg shadow-md"
                   aspectRatio="video"
                   showFallback={true}
                   priority={true}
@@ -192,7 +192,7 @@ function PcListingDetailsClient(props: Props) {
               />
             </div>
 
-            <div className="flex w-full flex-col items-center gap-4 md:w-auto md:min-w-[180px] md:items-start">
+            <div className="flex w-full flex-col items-center gap-4 md:w-auto md:min-w-[180px] md:shrink-0 md:items-start">
               <div className="flex items-start justify-between w-full gap-2">
                 <AuthorPanel
                   profileImage={props.pcListing.author?.profileImage}


### PR DESCRIPTION
## Description

Constrains the shared `GameImage` wrapper and both handheld/PC report detail layouts so oversized cover art cannot force the details card wider than its container.

Fixes #337

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [ ] Typecheck
- [x] Unit tests
- [ ] Manual testing

Commands run:

- `node_modules/.bin/vitest run src/app/listings/shared/components/GameImage.test.tsx`
- `node_modules/.bin/eslint src/app/listings/shared/components/GameImage.tsx src/app/listings/shared/components/GameImage.test.tsx 'src/app/listings/[id]/components/ListingDetailsClient.tsx' 'src/app/pc-listings/[id]/components/PcListingDetailsClient.tsx'`

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

Added focused coverage for the containment classes on both the normal image and fallback render paths.
