### PR TITLE
Address admin and profile UI TODOs

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -190,7 +190,6 @@ async function main() {
     console.warn('🗑️ Clearing database...')
     console.warn('I hope you know what you are doing 😅')
 
-    // Clear all data in the correct order (children before parents)
     await clearDb()
 
     console.info('✅ Database cleared!')
@@ -199,8 +198,7 @@ async function main() {
   console.info('🌱 Starting database seed...')
 
   try {
-    // Seed in order of dependencies
-    await permissionsSeeder(prisma) // Seed permissions first
+    await permissionsSeeder(prisma)
     await performanceScalesSeeder(prisma)
     await systemsSeeder(prisma)
     await emulatorsSeeder(prisma)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -203,9 +203,9 @@ async function main() {
     await permissionsSeeder(prisma) // Seed permissions first
     await performanceScalesSeeder(prisma)
     await systemsSeeder(prisma)
+    await emulatorsSeeder(prisma)
     await usersSeeder(prisma)
     await userModerationFixturesSeeder(prisma)
-    await emulatorsSeeder(prisma)
     await azaharCustomFieldsSeeder(prisma)
     await edenCustomFieldsSeeder(prisma)
     await gamenativeCustomFieldsSeeder(prisma)

--- a/prisma/seeders/usersSeeder.ts
+++ b/prisma/seeders/usersSeeder.ts
@@ -36,7 +36,6 @@ const users: UserData[] = [
     username: 'moderator',
     role: Role.MODERATOR,
   },
-  // TODO: Assign emulators to Developer User
   {
     email: 'developer@emuready.com',
     name: 'Developer User',
@@ -64,11 +63,27 @@ const users: UserData[] = [
 ]
 
 const DEFAULT_SEED_PASSWORD = 'DevPassword123!'
+const DEVELOPER_SEED_EMAIL = 'developer@emuready.com'
+const SUPER_ADMIN_SEED_EMAIL = 'superadmin@emuready.com'
 
 async function cleanupExistingUsers(prisma: PrismaClient) {
   console.info('🧹 Cleaning up existing seed users...')
 
   const clerk = await clerkClient()
+  const seedUserEmails = users.map((user) => user.email)
+  const seedUsers = await prisma.user.findMany({
+    where: { email: { in: seedUserEmails } },
+    select: { id: true },
+  })
+
+  if (seedUsers.length > 0) {
+    const seedUserIds = seedUsers.map((user) => user.id)
+    await prisma.verifiedDeveloper.deleteMany({
+      where: {
+        OR: [{ userId: { in: seedUserIds } }, { verifiedBy: { in: seedUserIds } }],
+      },
+    })
+  }
 
   for (const userData of users) {
     try {
@@ -90,6 +105,56 @@ async function cleanupExistingUsers(prisma: PrismaClient) {
   }
 
   console.info('✅ Cleanup completed')
+}
+
+async function assignDeveloperEmulators(prisma: PrismaClient) {
+  const [developerUser, verifierUser, emulators] = await Promise.all([
+    prisma.user.findUnique({
+      where: { email: DEVELOPER_SEED_EMAIL },
+      select: { id: true },
+    }),
+    prisma.user.findUnique({
+      where: { email: SUPER_ADMIN_SEED_EMAIL },
+      select: { id: true },
+    }),
+    prisma.emulator.findMany({ select: { id: true } }),
+  ])
+
+  if (!developerUser) {
+    throw new Error('Expected seeded developer user to exist before assigning emulators')
+  }
+
+  if (emulators.length === 0) {
+    console.info('ℹ️  No emulators found to assign to the developer seed user.')
+    return
+  }
+
+  const verifierId = verifierUser?.id ?? developerUser.id
+
+  await prisma.$transaction(
+    emulators.map((emulator) =>
+      prisma.verifiedDeveloper.upsert({
+        where: {
+          userId_emulatorId: {
+            userId: developerUser.id,
+            emulatorId: emulator.id,
+          },
+        },
+        update: {
+          verifiedBy: verifierId,
+          notes: 'Seeded developer emulator access',
+        },
+        create: {
+          userId: developerUser.id,
+          emulatorId: emulator.id,
+          verifiedBy: verifierId,
+          notes: 'Seeded developer emulator access',
+        },
+      }),
+    ),
+  )
+
+  console.info(`✅ Assigned ${emulators.length} emulator(s) to the developer seed user`)
 }
 
 async function usersSeeder(prisma: PrismaClient, shouldCleanup = false) {
@@ -165,6 +230,8 @@ async function usersSeeder(prisma: PrismaClient, shouldCleanup = false) {
   if (failedUsers.length > 0) {
     throw new Error(`Failed to seed users: ${failedUsers.join(', ')}`)
   }
+
+  await assignDeveloperEmulators(prisma)
 
   console.info('✅ Users seeding completed')
   console.info('📝 You can now log in with any of these accounts using the default password.')

--- a/src/app/admin/performance/components/ReplacementSelectionModal.tsx
+++ b/src/app/admin/performance/components/ReplacementSelectionModal.tsx
@@ -33,15 +33,14 @@ function ReplacementSelectionModal(props: Props) {
   )
 
   const handleDelete = async () => {
-    if (!props.scaleToDelete || !selectedReplacementId) return
+    if (!props.scaleToDelete || selectedReplacementId === null) return
 
     setError('')
 
     try {
-      // For now, we'll use the regular delete since the replacement functionality
-      // isn't implemented in the backend yet. This is marked as TODO.
       await deletePerformanceScale.mutateAsync({
         id: props.scaleToDelete.id,
+        replacementId: selectedReplacementId,
       } satisfies RouterInput['performanceScales']['delete'])
     } catch (err) {
       setError(getErrorMessage(err, 'Failed to delete performance scale.'))
@@ -96,8 +95,10 @@ function ReplacementSelectionModal(props: Props) {
           </label>
           <select
             id="replacement"
-            value={selectedReplacementId || ''}
-            onChange={(e) => setSelectedReplacementId(Number(e.target.value))}
+            value={selectedReplacementId ?? ''}
+            onChange={(e) =>
+              setSelectedReplacementId(e.target.value ? Number(e.target.value) : null)
+            }
             className="w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
             required
           >
@@ -123,7 +124,7 @@ function ReplacementSelectionModal(props: Props) {
           <Button
             onClick={handleDelete}
             variant="destructive"
-            disabled={!selectedReplacementId || deletePerformanceScale.isPending}
+            disabled={selectedReplacementId === null || deletePerformanceScale.isPending}
             isLoading={deletePerformanceScale.isPending}
           >
             Delete and Replace

--- a/src/app/admin/performance/page.tsx
+++ b/src/app/admin/performance/page.tsx
@@ -59,7 +59,7 @@ function AdminPerformancePage() {
   })
 
   const performanceStatsQuery = api.performanceScales.stats.useQuery()
-  const performanceScalesQuery = api.performanceScales.get.useQuery({
+  const performanceScalesQuery = api.performanceScales.getWithCounts.useQuery({
     search: table.search || undefined,
     sortField: table.sortField ?? undefined,
     sortDirection: table.sortDirection ?? undefined,
@@ -73,6 +73,7 @@ function AdminPerformancePage() {
     onSuccess: () => {
       toast.success('Performance scale deleted successfully!')
       utils.performanceScales.get.invalidate().catch(console.error)
+      utils.performanceScales.getWithCounts.invalidate().catch(console.error)
       utils.performanceScales.stats.invalidate().catch(console.error)
     },
     onError: (err) => {
@@ -89,6 +90,20 @@ function AdminPerformancePage() {
   }
 
   const handleDelete = async (scale: PerformanceScale) => {
+    const listingsCount = (scale._count?.listings ?? 0) + (scale._count?.pcListings ?? 0)
+
+    if (listingsCount > 0) {
+      setReplacementModal({
+        isOpen: true,
+        scaleToDelete: {
+          id: scale.id,
+          label: scale.label,
+          listingsCount,
+        },
+      })
+      return
+    }
+
     const confirmed = await confirm({
       title: 'Delete Performance Scale',
       description: `Are you sure you want to delete "${scale.label}"? This action cannot be undone.`,
@@ -96,7 +111,6 @@ function AdminPerformancePage() {
 
     if (!confirmed) return
 
-    // Try to delete directly first
     deletePerformanceScale.mutate({
       id: scale.id,
     } satisfies RouterInput['performanceScales']['delete'])
@@ -257,6 +271,7 @@ function AdminPerformancePage() {
         onSuccess={() => {
           setPerformanceModal({ isOpen: false })
           utils.performanceScales.get.invalidate().catch(console.error)
+          utils.performanceScales.getWithCounts.invalidate().catch(console.error)
           utils.performanceScales.stats.invalidate().catch(console.error)
         }}
       />
@@ -268,6 +283,7 @@ function AdminPerformancePage() {
         onSuccess={() => {
           setReplacementModal({ isOpen: false, scaleToDelete: null })
           utils.performanceScales.get.invalidate().catch(console.error)
+          utils.performanceScales.getWithCounts.invalidate().catch(console.error)
           utils.performanceScales.stats.invalidate().catch(console.error)
           toast.success('Performance scale deleted successfully!')
         }}

--- a/src/app/admin/performance/types.ts
+++ b/src/app/admin/performance/types.ts
@@ -3,6 +3,10 @@ export interface PerformanceScale {
   label: string
   description: string | null
   rank: number
+  _count?: {
+    listings: number
+    pcListings: number
+  }
 }
 
 export interface PerformanceScaleForDeletion {

--- a/src/app/admin/users/components/UserBadgeModal.tsx
+++ b/src/app/admin/users/components/UserBadgeModal.tsx
@@ -34,19 +34,16 @@ export default function UserBadgeModal(props: Props) {
   const [selectedBadgeId, setSelectedBadgeId] = useState<string | null>(null)
   const [selectedColor, setSelectedColor] = useState<TailwindColor>('blue')
 
-  // Fetch all active badges
   const badgesQuery = api.badges.get.useQuery(
     { isActive: true, limit: 100 },
     { enabled: props.isOpen },
   )
 
-  // Fetch user's current badges
   const userBadgesQuery = api.users.getUserById.useQuery(
     { userId: props.user?.id ?? '' },
     { enabled: props.isOpen && Boolean(props.user?.id) },
   )
 
-  // Badge assignment mutations
   const assignBadgeMutation = api.badges.assignToUser.useMutation({
     onSuccess: () => {
       toast.success('Badge assigned successfully')
@@ -106,7 +103,6 @@ export default function UserBadgeModal(props: Props) {
         </DialogHeader>
 
         <div className="space-y-6 overflow-y-auto">
-          {/* Current Badges */}
           <div>
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
               Current Badges ({userBadges.length})
@@ -158,7 +154,6 @@ export default function UserBadgeModal(props: Props) {
             )}
           </div>
 
-          {/* Assign New Badge */}
           {availableBadges.length > 0 && (
             <div>
               <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">

--- a/src/app/admin/users/components/UserBadgeModal.tsx
+++ b/src/app/admin/users/components/UserBadgeModal.tsx
@@ -36,7 +36,6 @@ export default function UserBadgeModal(props: Props) {
 
   // Fetch all active badges
   const badgesQuery = api.badges.get.useQuery(
-    // TODO: Implement pagination if needed, probably not needed for badges
     { isActive: true, limit: 100 },
     { enabled: props.isOpen },
   )

--- a/src/app/profile/components/DeviceAndSocPreferences.tsx
+++ b/src/app/profile/components/DeviceAndSocPreferences.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { type UseQueryResult } from '@tanstack/react-query'
 import { Smartphone, Cpu, Settings } from 'lucide-react'
 import { useCallback, useRef, useEffect } from 'react'
 import { AnimatedToggle } from '@/components/ui'
@@ -14,12 +15,7 @@ import SocSelector from './SocSelector'
 type UserPreferencesData = RouterOutput['userPreferences']['get']
 
 interface Props {
-  // TODO: see if we can use UseQueryResult from @tanstack/react-query instead
-  preferencesQuery: {
-    data?: UserPreferencesData
-    isPending: boolean
-    error?: unknown
-  }
+  preferencesQuery: UseQueryResult<UserPreferencesData, unknown>
 }
 
 function DeviceAndSocPreferences(props: Props) {

--- a/src/app/profile/components/DeviceAndSocPreferences.tsx
+++ b/src/app/profile/components/DeviceAndSocPreferences.tsx
@@ -72,9 +72,6 @@ function DeviceAndSocPreferences(props: Props) {
     },
   })
 
-  /**
-   * Invalidate all user preferences related queries.
-   */
   const invalidatePreferences = () => {
     Promise.all([
       utils.userPreferences.get.invalidate(),
@@ -90,11 +87,9 @@ function DeviceAndSocPreferences(props: Props) {
     updatePreferences.mutate({ [key]: value })
   }
 
-  // Debounce refs to prevent excessive API calls
   const deviceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const socTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
-  // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
       if (deviceTimeoutRef.current) {
@@ -117,15 +112,13 @@ function DeviceAndSocPreferences(props: Props) {
     ) => {
       const deviceIds = devices.map((device) => device.id)
 
-      // Clear existing timeout
       if (deviceTimeoutRef.current) {
         clearTimeout(deviceTimeoutRef.current)
       }
 
-      // Set new timeout for debounced update
       deviceTimeoutRef.current = setTimeout(() => {
         bulkUpdateDevices.mutate({ deviceIds })
-      }, 500) // 500ms debounce
+      }, 500)
     },
     [bulkUpdateDevices],
   )
@@ -134,15 +127,13 @@ function DeviceAndSocPreferences(props: Props) {
     (socs: typeof selectedSocs) => {
       const socIds = socs.map((soc) => soc.id)
 
-      // Clear existing timeout
       if (socTimeoutRef.current) {
         clearTimeout(socTimeoutRef.current)
       }
 
-      // Set new timeout for debounced update
       socTimeoutRef.current = setTimeout(() => {
         bulkUpdateSocs.mutate({ socIds })
-      }, 500) // 500ms debounce
+      }, 500)
     },
     [bulkUpdateSocs],
   )
@@ -177,13 +168,11 @@ function DeviceAndSocPreferences(props: Props) {
 
   const { data: preferences } = props.preferencesQuery
 
-  // Map the data structure to what the selectors expect
   const selectedDevices = preferences.devicePreferences?.map((pref) => pref.device) || []
   const selectedSocs = preferences.socPreferences?.map((pref) => pref.soc) || []
 
   return (
     <div className="space-y-8">
-      {/* Listing Filters */}
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6">
         <div className="flex items-center gap-3 mb-6">
           <Settings className="h-6 w-6 text-blue-600 dark:text-blue-400" />
@@ -245,7 +234,6 @@ function DeviceAndSocPreferences(props: Props) {
         </div>
       </div>
 
-      {/* Device Preferences */}
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6">
         <div className="flex items-center gap-3 mb-6">
           <Smartphone className="h-6 w-6 text-green-600 dark:text-green-400" />
@@ -262,7 +250,6 @@ function DeviceAndSocPreferences(props: Props) {
         <DeviceSelector selectedDevices={selectedDevices} onDevicesChange={handleDevicesChange} />
       </div>
 
-      {/* SOC Preferences */}
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6">
         <div className="flex items-center gap-3 mb-6">
           <Cpu className="h-6 w-6 text-purple-600 dark:text-purple-400" />

--- a/src/app/profile/components/connections/BlockedList.tsx
+++ b/src/app/profile/components/connections/BlockedList.tsx
@@ -51,6 +51,8 @@ function BlockedList(props: Props) {
       pagination={query.data?.pagination}
       onPageChange={props.onPageChange}
       emptyMessage="No blocked users"
+      actionSkeletonClassName="w-24"
+      skeletonRows={props.limit}
       renderAction={(user) => (
         <Button
           variant="outline"

--- a/src/app/profile/components/connections/FollowersList.tsx
+++ b/src/app/profile/components/connections/FollowersList.tsx
@@ -22,11 +22,13 @@ const CONFIG = {
     successMessage: 'Follower removed',
     emptyMessage: 'No followers yet',
     buttonLabel: 'Remove',
+    actionSkeletonClassName: 'w-20',
   },
   following: {
     successMessage: 'Unfollowed successfully',
     emptyMessage: 'Not following anyone',
     buttonLabel: 'Unfollow',
+    actionSkeletonClassName: 'w-24',
   },
 } as const
 
@@ -88,6 +90,8 @@ function FollowConnectionList(props: Props) {
       pagination={data?.visibility === 'visible' ? data.pagination : undefined}
       onPageChange={props.onPageChange}
       emptyMessage={config.emptyMessage}
+      actionSkeletonClassName={config.actionSkeletonClassName}
+      skeletonRows={props.limit}
       renderAction={(user) => (
         <Button
           variant="outline"

--- a/src/app/profile/components/connections/FriendsList.tsx
+++ b/src/app/profile/components/connections/FriendsList.tsx
@@ -94,6 +94,8 @@ function FriendsList(props: Props) {
       emptyMessage="No friends yet"
       renderAction={() => null}
       header={pendingRequestsHeader}
+      showActionSkeleton={false}
+      skeletonRows={props.limit}
     />
   )
 }

--- a/src/app/profile/components/connections/SocialConnectionList.tsx
+++ b/src/app/profile/components/connections/SocialConnectionList.tsx
@@ -2,7 +2,7 @@
 
 import { Users } from 'lucide-react'
 import { type ReactNode } from 'react'
-import { LoadingSpinner, Pagination } from '@/components/ui'
+import { Pagination, Skeleton } from '@/components/ui'
 import { ConnectionUserRow } from './ConnectionUserRow'
 import type { RouterOutput } from '@/types/trpc'
 
@@ -29,8 +29,28 @@ interface Props {
   header?: ReactNode
 }
 
+function SocialConnectionListSkeleton() {
+  return (
+    <div className="space-y-1" aria-label="Loading social connections">
+      {[1, 2, 3].map((item) => (
+        <div key={item} className="flex items-center gap-4 py-3 px-2 rounded-lg">
+          <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="h-5 w-24 rounded-full" />
+            </div>
+          </div>
+          <Skeleton className="h-9 w-24 flex-shrink-0 rounded-md" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function SocialConnectionList(props: Props) {
-  if (props.isPending) return <LoadingSpinner /> // TODO: use a custom Skeleton
+  if (props.isPending) return <SocialConnectionListSkeleton />
 
   return (
     <div className="space-y-4">

--- a/src/app/profile/components/connections/SocialConnectionList.tsx
+++ b/src/app/profile/components/connections/SocialConnectionList.tsx
@@ -27,22 +27,33 @@ interface Props {
   emptyMessage: string
   renderAction: (user: SocialUser) => ReactNode
   header?: ReactNode
+  showActionSkeleton?: boolean
+  actionSkeletonClassName?: string
+  skeletonRows?: number
 }
 
-function SocialConnectionListSkeleton() {
+function SocialConnectionListSkeleton(props: {
+  actionClassName: string
+  showAction: boolean
+  rows: number
+}) {
   return (
     <div className="space-y-1" aria-label="Loading social connections">
-      {[1, 2, 3].map((item) => (
-        <div key={item} className="flex items-center gap-4 py-3 px-2 rounded-lg">
-          <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
-          <div className="min-w-0 flex-1 space-y-2">
-            <Skeleton className="h-4 w-32" />
-            <div className="flex items-center gap-2">
-              <Skeleton className="h-5 w-20 rounded-full" />
-              <Skeleton className="h-5 w-24 rounded-full" />
+      {Array.from({ length: props.rows }, (_, index) => (
+        <div key={index} className="flex items-center gap-4 py-3 px-2 rounded-lg">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <Skeleton className="h-10 w-10 flex-shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1">
+              <Skeleton className="h-6 w-32" />
+              <div className="flex items-center gap-2 mt-0.5">
+                <Skeleton className="h-5 w-20 rounded-full" />
+                <Skeleton className="h-6 w-24 rounded-full" />
+              </div>
             </div>
           </div>
-          <Skeleton className="h-9 w-24 flex-shrink-0 rounded-md" />
+          {props.showAction && (
+            <Skeleton className={`${props.actionClassName} h-8 flex-shrink-0 rounded-md`} />
+          )}
         </div>
       ))}
     </div>
@@ -50,7 +61,18 @@ function SocialConnectionListSkeleton() {
 }
 
 export function SocialConnectionList(props: Props) {
-  if (props.isPending) return <SocialConnectionListSkeleton />
+  if (props.isPending) {
+    return (
+      <div className="space-y-4">
+        {props.header}
+        <SocialConnectionListSkeleton
+          actionClassName={props.actionSkeletonClassName ?? 'w-24'}
+          rows={props.skeletonRows ?? 3}
+          showAction={props.showActionSkeleton ?? true}
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-4">

--- a/src/schemas/performanceScale.ts
+++ b/src/schemas/performanceScale.ts
@@ -26,7 +26,15 @@ export const UpdatePerformanceScaleSchema = z.object({
   description: z.string().optional(),
 })
 
-export const DeletePerformanceScaleSchema = z.object({ id: z.number() })
+export const DeletePerformanceScaleSchema = z
+  .object({
+    id: z.number(),
+    replacementId: z.number().optional(),
+  })
+  .refine((data) => data.replacementId === undefined || data.replacementId !== data.id, {
+    message: 'Replacement performance scale must be different from the deleted scale',
+    path: ['replacementId'],
+  })
 
 // Type exports for repository use
 export type GetPerformanceScalesInput = z.input<typeof GetPerformanceScalesSchema>

--- a/src/schemas/performanceScale.ts
+++ b/src/schemas/performanceScale.ts
@@ -36,7 +36,6 @@ export const DeletePerformanceScaleSchema = z
     path: ['replacementId'],
   })
 
-// Type exports for repository use
 export type GetPerformanceScalesInput = z.input<typeof GetPerformanceScalesSchema>
 export type CreatePerformanceScaleInput = z.infer<typeof CreatePerformanceScaleSchema>
 export type UpdatePerformanceScaleInput = z.infer<typeof UpdatePerformanceScaleSchema>

--- a/src/server/api/routers/performanceScales.ts
+++ b/src/server/api/routers/performanceScales.ts
@@ -21,6 +21,11 @@ export const performanceScalesRouter = createTRPCRouter({
     return repository.list(input ?? {})
   }),
 
+  getWithCounts: publicProcedure.input(GetPerformanceScalesSchema).query(async ({ ctx, input }) => {
+    const repository = new PerformanceScalesRepository(ctx.prisma)
+    return repository.listWithCounts(input ?? {})
+  }),
+
   byId: publicProcedure.input(GetPerformanceScaleByIdSchema).query(async ({ ctx, input }) => {
     const repository = new PerformanceScalesRepository(ctx.prisma)
     const scale = await repository.byNumericId(input.id)
@@ -46,7 +51,7 @@ export const performanceScalesRouter = createTRPCRouter({
     .input(DeletePerformanceScaleSchema)
     .mutation(async ({ ctx, input }) => {
       const repository = new PerformanceScalesRepository(ctx.prisma)
-      await repository.deleteByNumericId(input.id)
+      await repository.deleteByNumericIdWithReplacement(input.id, input.replacementId)
       return { success: true }
     }),
 })

--- a/src/server/repositories/performance-scales.repository.ts
+++ b/src/server/repositories/performance-scales.repository.ts
@@ -7,13 +7,7 @@ import type {
   UpdatePerformanceScaleInput,
 } from '@/schemas/performanceScale'
 
-/**
- * Repository for PerformanceScale data access
- * Note: PerformanceScale uses numeric IDs instead of UUIDs
- * We override the base class methods to use number instead of string for IDs
- */
 export class PerformanceScalesRepository extends BaseRepository {
-  // Static query shapes for this repository
   static readonly includes = {
     default: {} satisfies Prisma.PerformanceScaleInclude,
 
@@ -34,7 +28,6 @@ export class PerformanceScalesRepository extends BaseRepository {
       }),
     }
 
-    // Map schema sort fields to Prisma orderBy
     const orderBy: Prisma.PerformanceScaleOrderByWithRelationInput =
       sortField === 'label'
         ? { label: sortDirection || this.sortOrder }
@@ -43,24 +36,20 @@ export class PerformanceScalesRepository extends BaseRepository {
     return this.prisma.performanceScale.findMany({ where, orderBy })
   }
 
-  // Override base class method to use string ID (will convert internally)
   async byId(id: string): Promise<PerformanceScale | null> {
     const numericId = parseInt(id, 10)
     if (isNaN(numericId)) return null
     return this.byNumericId(numericId)
   }
 
-  // Numeric ID version for internal use
   async byNumericId(id: number): Promise<PerformanceScale | null> {
     return this.prisma.performanceScale.findUnique({ where: { id } })
   }
 
   async create(data: CreatePerformanceScaleInput): Promise<PerformanceScale> {
-    // Check for duplicate rank
     const rankExists = await this.existsByRank(data.rank)
     if (rankExists) throw ResourceError.performanceScale.rankAlreadyExists(data.rank)
 
-    // Check for duplicate label
     const labelExists = await this.existsByLabel(data.label)
     if (labelExists) throw ResourceError.performanceScale.alreadyExists(data.label)
 
@@ -70,29 +59,24 @@ export class PerformanceScalesRepository extends BaseRepository {
     )
   }
 
-  // Override base class method to use string ID (will convert internally)
   async update(id: string, data: Partial<UpdatePerformanceScaleInput>): Promise<PerformanceScale> {
     const numericId = parseInt(id, 10)
     if (isNaN(numericId)) throw new Error('Invalid numeric ID')
     return this.updateByNumericId(numericId, data)
   }
 
-  // Numeric ID version for internal use
   async updateByNumericId(
     id: number,
     data: Partial<UpdatePerformanceScaleInput>,
   ): Promise<PerformanceScale> {
-    // Check if scale exists
     const scale = await this.byNumericId(id)
     if (!scale) throw ResourceError.performanceScale.notFound()
 
-    // Check for duplicate rank if being updated
     if (data.rank !== undefined) {
       const rankExists = await this.existsByRank(data.rank, id)
       if (rankExists) throw ResourceError.performanceScale.rankAlreadyExists(data.rank)
     }
 
-    // Check for duplicate label if being updated
     if (data.label) {
       const labelExists = await this.existsByLabel(data.label, id)
       if (labelExists) throw ResourceError.performanceScale.alreadyExists(data.label)
@@ -104,20 +88,17 @@ export class PerformanceScalesRepository extends BaseRepository {
     )
   }
 
-  // Override base class method to use string ID (will convert internally)
   async delete(id: string): Promise<void> {
     const numericId = parseInt(id, 10)
     if (isNaN(numericId)) throw new Error('Invalid numeric ID')
     await this.deleteByNumericId(numericId)
   }
 
-  // Numeric ID version for internal use
   async deleteByNumericId(id: number): Promise<void> {
     await this.deleteByNumericIdWithReplacement(id)
   }
 
   async deleteByNumericIdWithReplacement(id: number, replacementId?: number): Promise<void> {
-    // Check if scale exists and has listings
     const scale = await this.prisma.performanceScale.findUnique({
       where: { id },
       include: { _count: { select: { listings: true, pcListings: true } } },
@@ -163,9 +144,6 @@ export class PerformanceScalesRepository extends BaseRepository {
     )
   }
 
-  /**
-   * Get total count with filters
-   */
   async count(filters: GetPerformanceScalesInput = {}): Promise<number> {
     const { search } = filters
 
@@ -181,9 +159,6 @@ export class PerformanceScalesRepository extends BaseRepository {
     return this.prisma.performanceScale.count({ where })
   }
 
-  /**
-   * Check if rank is already taken
-   */
   async existsByRank(rank: number, excludeId?: number): Promise<boolean> {
     const scale = await this.prisma.performanceScale.findFirst({
       where: { rank, ...(excludeId && { id: { not: excludeId } }) },
@@ -191,9 +166,6 @@ export class PerformanceScalesRepository extends BaseRepository {
     return !!scale
   }
 
-  /**
-   * Check if label exists
-   */
   async existsByLabel(label: string, excludeId?: number): Promise<boolean> {
     const scale = await this.prisma.performanceScale.findFirst({
       where: {
@@ -204,9 +176,6 @@ export class PerformanceScalesRepository extends BaseRepository {
     return !!scale
   }
 
-  /**
-   * Get performance scales with listing counts
-   */
   async listWithCounts(filters: GetPerformanceScalesInput = {}): Promise<
     Prisma.PerformanceScaleGetPayload<{
       include: typeof PerformanceScalesRepository.includes.withCounts
@@ -235,9 +204,6 @@ export class PerformanceScalesRepository extends BaseRepository {
     })
   }
 
-  /**
-   * Get the next available rank
-   */
   async getNextRank(): Promise<number> {
     const highestRank = await this.prisma.performanceScale.findFirst({
       orderBy: { rank: Prisma.SortOrder.desc },
@@ -246,9 +212,6 @@ export class PerformanceScalesRepository extends BaseRepository {
     return (highestRank?.rank ?? 0) + 1
   }
 
-  /**
-   * Reorder performance scales
-   */
   async reorder(scales: { id: number; rank: number }[]): Promise<void> {
     await this.prisma.$transaction(
       scales.map((scale) =>
@@ -260,27 +223,18 @@ export class PerformanceScalesRepository extends BaseRepository {
     )
   }
 
-  /**
-   * Get performance scale by label
-   */
   async byLabel(label: string): Promise<PerformanceScale | null> {
     return this.prisma.performanceScale.findFirst({
       where: { label: { equals: label, mode: this.mode } },
     })
   }
 
-  /**
-   * Get performance scale by rank
-   */
   async byRank(rank: number): Promise<PerformanceScale | null> {
     return this.prisma.performanceScale.findFirst({
       where: { rank },
     })
   }
 
-  /**
-   * Get statistics about performance scales
-   */
   async stats(): Promise<{
     total: number
     withListings: number

--- a/src/server/repositories/performance-scales.repository.ts
+++ b/src/server/repositories/performance-scales.repository.ts
@@ -107,7 +107,9 @@ export class PerformanceScalesRepository extends BaseRepository {
     if (!scale) throw ResourceError.performanceScale.notFound()
 
     if (replacementId === id) {
-      AppError.badRequest('Replacement performance scale must be different from the deleted scale')
+      throw AppError.badRequest(
+        'Replacement performance scale must be different from the deleted scale',
+      )
     }
 
     if (replacementId !== undefined) {

--- a/src/server/repositories/performance-scales.repository.ts
+++ b/src/server/repositories/performance-scales.repository.ts
@@ -1,4 +1,4 @@
-import { ResourceError } from '@/lib/errors'
+import { AppError, ResourceError } from '@/lib/errors'
 import { Prisma, type PerformanceScale } from '@orm/client'
 import { BaseRepository } from './base.repository'
 import type {
@@ -113,6 +113,10 @@ export class PerformanceScalesRepository extends BaseRepository {
 
   // Numeric ID version for internal use
   async deleteByNumericId(id: number): Promise<void> {
+    await this.deleteByNumericIdWithReplacement(id)
+  }
+
+  async deleteByNumericIdWithReplacement(id: number, replacementId?: number): Promise<void> {
     // Check if scale exists and has listings
     const scale = await this.prisma.performanceScale.findUnique({
       where: { id },
@@ -121,13 +125,40 @@ export class PerformanceScalesRepository extends BaseRepository {
 
     if (!scale) throw ResourceError.performanceScale.notFound()
 
+    if (replacementId === id) {
+      AppError.badRequest('Replacement performance scale must be different from the deleted scale')
+    }
+
+    if (replacementId !== undefined) {
+      const replacementScale = await this.prisma.performanceScale.findUnique({
+        where: { id: replacementId },
+        select: { id: true },
+      })
+
+      if (!replacementScale) throw ResourceError.performanceScale.notFound()
+    }
+
     const totalListings = scale._count.listings + scale._count.pcListings
-    if (totalListings > 0) {
+    if (totalListings > 0 && replacementId === undefined) {
       throw ResourceError.performanceScale.inUse(totalListings)
     }
 
     await this.handleDatabaseOperation(
-      () => this.prisma.performanceScale.delete({ where: { id } }),
+      () =>
+        this.prisma.$transaction(async (tx) => {
+          if (replacementId !== undefined) {
+            await tx.listing.updateMany({
+              where: { performanceId: id },
+              data: { performanceId: replacementId },
+            })
+            await tx.pcListing.updateMany({
+              where: { performanceId: id },
+              data: { performanceId: replacementId },
+            })
+          }
+
+          await tx.performanceScale.delete({ where: { id } })
+        }),
       'PerformanceScale',
     )
   }
@@ -176,14 +207,31 @@ export class PerformanceScalesRepository extends BaseRepository {
   /**
    * Get performance scales with listing counts
    */
-  async listWithCounts(): Promise<
+  async listWithCounts(filters: GetPerformanceScalesInput = {}): Promise<
     Prisma.PerformanceScaleGetPayload<{
       include: typeof PerformanceScalesRepository.includes.withCounts
     }>[]
   > {
+    const { search, sortField = 'rank', sortDirection } = filters
+
+    const where: Prisma.PerformanceScaleWhereInput = {
+      ...(search && {
+        OR: [
+          { label: { contains: search, mode: this.mode } },
+          { description: { contains: search, mode: this.mode } },
+        ],
+      }),
+    }
+
+    const orderBy: Prisma.PerformanceScaleOrderByWithRelationInput =
+      sortField === 'label'
+        ? { label: sortDirection || this.sortOrder }
+        : { rank: sortDirection || this.sortOrder }
+
     return this.prisma.performanceScale.findMany({
+      where,
       include: PerformanceScalesRepository.includes.withCounts,
-      orderBy: { rank: this.sortOrder },
+      orderBy,
     })
   }
 

--- a/src/server/utils/emulator-config/eden/eden.defaults.ts
+++ b/src/server/utils/emulator-config/eden/eden.defaults.ts
@@ -165,7 +165,6 @@ export const AUDIO_OUTPUT_ENGINE_MAPPING: Record<string, AudioOutputEngine> = {
   Null: 3,
 }
 
-// Resolution multiplier mapping for Eden resolution setup
 export const RESOLUTION_MULTIPLIER_MAPPING: Record<string, ResolutionSetup> = {
   '0.25': 0,
   '0.25x': 0,

--- a/src/server/utils/emulator-config/eden/eden.defaults.ts
+++ b/src/server/utils/emulator-config/eden/eden.defaults.ts
@@ -166,7 +166,6 @@ export const AUDIO_OUTPUT_ENGINE_MAPPING: Record<string, AudioOutputEngine> = {
 }
 
 // Resolution multiplier mapping for Eden resolution setup
-// TODO: update with new mappings from Eden, we added 0.25x
 export const RESOLUTION_MULTIPLIER_MAPPING: Record<string, ResolutionSetup> = {
   '0.25': 0,
   '0.25x': 0,


### PR DESCRIPTION
## Description

Addresses several small TODOs tracked in #411:

- replaces the social connections loading spinner with a row-shaped skeleton state
- types device/SOC preferences with `UseQueryResult`
- removes stale badge pagination and Eden 0.25x mapping TODOs
- assigns the Developer seed user to seeded emulators for local developer-role testing
- wires performance scale replacement through the backend before deleting an in-use scale

Part of #411

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor
- [x] Other (please describe): Seeder and admin workflow cleanup

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [ ] Typecheck
- [ ] Unit tests
- [ ] Manual testing

Ran:
- `git diff --check`
- `./node_modules/.bin/eslint prisma/seed.ts prisma/seeders/usersSeeder.ts src/app/admin/performance/components/ReplacementSelectionModal.tsx src/app/admin/performance/page.tsx src/app/admin/performance/types.ts src/app/admin/users/components/UserBadgeModal.tsx src/app/profile/components/DeviceAndSocPreferences.tsx src/app/profile/components/connections/SocialConnectionList.tsx src/schemas/performanceScale.ts src/server/api/routers/performanceScales.ts src/server/repositories/performance-scales.repository.ts src/server/utils/emulator-config/eden/eden.defaults.ts`
- `./node_modules/.bin/prettier --check prisma/seed.ts prisma/seeders/usersSeeder.ts src/app/admin/performance/components/ReplacementSelectionModal.tsx src/app/admin/performance/page.tsx src/app/admin/performance/types.ts src/app/admin/users/components/UserBadgeModal.tsx src/app/profile/components/DeviceAndSocPreferences.tsx src/app/profile/components/connections/SocialConnectionList.tsx src/schemas/performanceScale.ts src/server/api/routers/performanceScales.ts src/server/repositories/performance-scales.repository.ts src/server/utils/emulator-config/eden/eden.defaults.ts`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/emuready ./node_modules/.bin/prisma validate`

Attempted:
- `pnpm types` (blocked before TypeScript because pnpm tried to purge the symlinked worktree `node_modules` without a TTY)
- `./node_modules/.bin/tsc --noEmit --pretty false` after plain Prisma client generation (blocked by existing missing TypedSQL `@orm/sql` output and `SegaSaturnIcon.png` module resolution outside this change)
- `./node_modules/.bin/prisma generate --sql` (blocked because TypedSQL requires a reachable local database)

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [x] Documentation changes are not needed for this change
- [ ] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

The trust-logs `AdminStatsDisplay` item from #411 was handled in #426. The mobile API-key enforcement TODO is intentionally left for a separate decision because it changes public mobile API access behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow deleting a performance scale by selecting a replacement so related items are reassigned instead of blocking deletion

* **UI/UX Improvements**
  * Show counts on performance scales listing for clearer visibility
  * Require an explicit replacement selection and disable the delete action until chosen
  * Replace generic loading spinners with configurable skeletons across profile and social lists
* **Bug Fixes**
  * Prevent selecting the same scale as its own replacement (validation)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->