### PR TITLE
Filter admin CPU and GPU brands server-side

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@ This file is the source of working guidance for AI coding agents in this reposit
 - Do not remove or rewrite existing TODO comments unless the user explicitly
   asks, or unless the TODO is directly made obsolete by the code change.
 - Prefer function declarations for top-level functions/components.
+- Avoid object destructuring when values are used only once or when it makes
+  ownership less clear. Prefer `object.property` access unless destructuring
+  materially improves readability.
 - Component props interfaces should be named `Props`.
 - Do not destructure component props in function parameters; use `props.foo`.
 - Keep `useEffect` dependencies correct.

--- a/src/app/admin/cpus/page.tsx
+++ b/src/app/admin/cpus/page.tsx
@@ -64,7 +64,7 @@ function AdminCpusPage() {
   })
 
   const cpusStatsQuery = api.cpus.stats.useQuery()
-  const brandsQuery = api.deviceBrands.get.useQuery({ limit: 100 })
+  const brandsQuery = api.deviceBrands.get.useQuery({ limit: 100, category: 'cpu' })
   const deleteCpu = api.cpus.delete.useMutation()
   const confirm = useConfirmDialog()
 
@@ -77,12 +77,6 @@ function AdminCpusPage() {
 
   const userQuery = api.users.me.useQuery()
   const canManageDevices = hasPermission(userQuery.data?.permissions, PERMISSIONS.MANAGE_DEVICES)
-
-  // TODO: Temporary fix for brands query
-  // only keep 'Intel', 'AMD', and 'Apple' brands
-  const brands = (brandsQuery.data || []).filter((brand) =>
-    ['intel', 'amd', 'apple'].includes(brand.name.toLowerCase()),
-  )
 
   const invalidateCpuQueries = () => {
     utils.cpus.get.invalidate().catch(console.error)
@@ -176,7 +170,7 @@ function AdminCpusPage() {
         <Autocomplete
           value={table.additionalParams.brandId || ''}
           onChange={(value) => table.setAdditionalParam('brandId', value || '')}
-          items={[{ id: '', name: 'All Brands' }, ...brands]}
+          items={[{ id: '', name: 'All Brands' }, ...(brandsQuery.data || [])]}
           optionToValue={(brand) => brand.id}
           optionToLabel={(brand) => brand.name}
           className="w-full md:w-64"

--- a/src/app/admin/gpus/page.tsx
+++ b/src/app/admin/gpus/page.tsx
@@ -64,7 +64,7 @@ function AdminGpusPage() {
   })
 
   const gpusStatsQuery = api.gpus.stats.useQuery()
-  const brandsQuery = api.deviceBrands.get.useQuery({ limit: 100 })
+  const brandsQuery = api.deviceBrands.get.useQuery({ limit: 100, category: 'gpu' })
   const deleteGpu = api.gpus.delete.useMutation()
   const confirm = useConfirmDialog()
 
@@ -77,12 +77,6 @@ function AdminGpusPage() {
 
   const userQuery = api.users.me.useQuery()
   const canManageDevices = hasPermission(userQuery.data?.permissions, PERMISSIONS.MANAGE_DEVICES)
-
-  // TODO: Temporary fix for brands query
-  // only keep 'Intel', 'AMD' and 'NVIDIA' brands
-  const brands = (brandsQuery.data || []).filter((brand) =>
-    ['intel', 'amd', 'nvidia'].includes(brand.name.toLowerCase()),
-  )
 
   const invalidateGpuQueries = () => {
     utils.gpus.get.invalidate().catch(console.error)
@@ -176,7 +170,7 @@ function AdminGpusPage() {
         <Autocomplete
           value={table.additionalParams.brandId || ''}
           onChange={(value) => table.setAdditionalParam('brandId', value || '')}
-          items={[{ id: '', name: 'All Brands' }, ...brands]}
+          items={[{ id: '', name: 'All Brands' }, ...(brandsQuery.data || [])]}
           optionToValue={(brand) => brand.id}
           optionToLabel={(brand) => brand.name}
           className="w-full md:w-64"

--- a/src/schemas/deviceBrand.ts
+++ b/src/schemas/deviceBrand.ts
@@ -1,11 +1,13 @@
 import { z } from 'zod'
 
 export const DeviceBrandSortField = z.enum(['name', 'devicesCount'])
+export const DeviceBrandCategory = z.enum(['cpu', 'gpu'])
 export const SortDirection = z.enum(['asc', 'desc'])
 
 export const GetDeviceBrandsSchema = z
   .object({
     search: z.string().optional(),
+    category: DeviceBrandCategory.optional(),
     limit: z.number().default(50),
     sortField: DeviceBrandSortField.optional(),
     sortDirection: SortDirection.optional(),

--- a/src/server/api/routers/mobile/deviceBrands.ts
+++ b/src/server/api/routers/mobile/deviceBrands.ts
@@ -1,45 +1,15 @@
 import { ResourceError } from '@/lib/errors'
 import { GetDeviceBrandsSchema, GetDeviceBrandByIdSchema } from '@/schemas/deviceBrand'
 import { createMobileTRPCRouter, mobilePublicProcedure } from '@/server/api/mobileContext'
-import type { Prisma } from '@orm/client'
+import { DeviceBrandsRepository } from '@/server/repositories/device-brands.repository'
 
 export const mobileDeviceBrandsRouter = createMobileTRPCRouter({
   /**
    * Get device brands with search and sorting
    */
   get: mobilePublicProcedure.input(GetDeviceBrandsSchema).query(async ({ ctx, input }) => {
-    const { search, category, limit, sortField, sortDirection } = input ?? {}
-
-    const where: Prisma.DeviceBrandWhereInput = {
-      ...(search && { name: { contains: search, mode: 'insensitive' } }),
-      ...(category === 'cpu' && { cpus: { some: {} } }),
-      ...(category === 'gpu' && { gpus: { some: {} } }),
-    }
-
-    const orderBy: Prisma.DeviceBrandOrderByWithRelationInput[] = []
-
-    if (sortField && sortDirection) {
-      switch (sortField) {
-        case 'name':
-          orderBy.push({ name: sortDirection })
-          break
-        case 'devicesCount':
-          orderBy.push({ devices: { _count: sortDirection } })
-          break
-      }
-    }
-
-    // Default ordering if no sort specified
-    if (!orderBy.length) {
-      orderBy.push({ name: 'asc' })
-    }
-
-    return ctx.prisma.deviceBrand.findMany({
-      where,
-      include: { _count: { select: { devices: true } } },
-      orderBy,
-      take: limit,
-    })
+    const repository = new DeviceBrandsRepository(ctx.prisma)
+    return repository.list(input ?? {}, { defaultLimit: undefined })
   }),
 
   /**

--- a/src/server/api/routers/mobile/deviceBrands.ts
+++ b/src/server/api/routers/mobile/deviceBrands.ts
@@ -8,7 +8,13 @@ export const mobileDeviceBrandsRouter = createMobileTRPCRouter({
    * Get device brands with search and sorting
    */
   get: mobilePublicProcedure.input(GetDeviceBrandsSchema).query(async ({ ctx, input }) => {
-    const { search, limit, sortField, sortDirection } = input ?? {}
+    const { search, category, limit, sortField, sortDirection } = input ?? {}
+
+    const where: Prisma.DeviceBrandWhereInput = {
+      ...(search && { name: { contains: search, mode: 'insensitive' } }),
+      ...(category === 'cpu' && { cpus: { some: {} } }),
+      ...(category === 'gpu' && { gpus: { some: {} } }),
+    }
 
     const orderBy: Prisma.DeviceBrandOrderByWithRelationInput[] = []
 
@@ -29,7 +35,7 @@ export const mobileDeviceBrandsRouter = createMobileTRPCRouter({
     }
 
     return ctx.prisma.deviceBrand.findMany({
-      where: search ? { name: { contains: search, mode: 'insensitive' } } : undefined,
+      where,
       include: { _count: { select: { devices: true } } },
       orderBy,
       take: limit,

--- a/src/server/api/routers/mobile/deviceBrands.ts
+++ b/src/server/api/routers/mobile/deviceBrands.ts
@@ -9,17 +9,15 @@ export const mobileDeviceBrandsRouter = createMobileTRPCRouter({
    */
   get: mobilePublicProcedure.input(GetDeviceBrandsSchema).query(async ({ ctx, input }) => {
     const repository = new DeviceBrandsRepository(ctx.prisma)
-    return repository.list(input ?? {}, { defaultLimit: undefined })
+    return repository.list(input ?? {})
   }),
 
   /**
    * Get device brand by ID
    */
   getById: mobilePublicProcedure.input(GetDeviceBrandByIdSchema).query(async ({ ctx, input }) => {
-    const brand = await ctx.prisma.deviceBrand.findUnique({
-      where: { id: input.id },
-      include: { _count: { select: { devices: true } } },
-    })
+    const repository = new DeviceBrandsRepository(ctx.prisma)
+    const brand = await repository.byIdWithCounts(input.id)
 
     return brand || ResourceError.deviceBrand.notFound()
   }),

--- a/src/server/repositories/device-brands.repository.test.ts
+++ b/src/server/repositories/device-brands.repository.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type PrismaClient } from '@orm/client'
+import { DeviceBrandsRepository } from './device-brands.repository'
+
+vi.mock('@orm/client', async () => {
+  const actual = await import('@orm/client')
+  return {
+    ...actual,
+    Prisma: {
+      ...actual.Prisma,
+      QueryMode: { insensitive: 'insensitive' },
+      SortOrder: { asc: 'asc', desc: 'desc' },
+    },
+  }
+})
+
+function createMockPrisma() {
+  return {
+    deviceBrand: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+  } as unknown as PrismaClient
+}
+
+describe('DeviceBrandsRepository', () => {
+  let prisma: PrismaClient
+  let repository: DeviceBrandsRepository
+
+  beforeEach(() => {
+    prisma = createMockPrisma()
+    repository = new DeviceBrandsRepository(prisma)
+  })
+
+  it('filters brands to CPU-backed brands when category is cpu', async () => {
+    await repository.list({ category: 'cpu', search: 'in', limit: 10 })
+
+    expect(prisma.deviceBrand.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          name: { contains: 'in', mode: 'insensitive' },
+          cpus: { some: {} },
+        },
+        take: 10,
+      }),
+    )
+  })
+
+  it('filters brands to GPU-backed brands when category is gpu', async () => {
+    await repository.list({ category: 'gpu' })
+
+    expect(prisma.deviceBrand.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          gpus: { some: {} },
+        },
+      }),
+    )
+  })
+
+  it('uses the same category filter when counting brands', async () => {
+    await repository.count({ category: 'cpu' })
+
+    expect(prisma.deviceBrand.count).toHaveBeenCalledWith({
+      where: {
+        cpus: { some: {} },
+      },
+    })
+  })
+})

--- a/src/server/repositories/device-brands.repository.test.ts
+++ b/src/server/repositories/device-brands.repository.test.ts
@@ -18,6 +18,7 @@ function createMockPrisma() {
   return {
     deviceBrand: {
       findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
       count: vi.fn().mockResolvedValue(0),
     },
   } as unknown as PrismaClient
@@ -68,14 +69,17 @@ describe('DeviceBrandsRepository', () => {
     )
   })
 
-  it('allows callers to disable the default limit', async () => {
-    await repository.list({}, { defaultLimit: undefined })
+  it('loads a brand by id with its device count', async () => {
+    await repository.byIdWithCounts('brand-id')
 
-    expect(prisma.deviceBrand.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        take: undefined,
-      }),
-    )
+    expect(prisma.deviceBrand.findUnique).toHaveBeenCalledWith({
+      where: { id: 'brand-id' },
+      include: {
+        _count: {
+          select: { devices: true },
+        },
+      },
+    })
   })
 
   it('uses the same category filter when counting brands', async () => {

--- a/src/server/repositories/device-brands.repository.test.ts
+++ b/src/server/repositories/device-brands.repository.test.ts
@@ -58,6 +58,26 @@ describe('DeviceBrandsRepository', () => {
     )
   })
 
+  it('uses the default limit when no limit is provided', async () => {
+    await repository.list()
+
+    expect(prisma.deviceBrand.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 50,
+      }),
+    )
+  })
+
+  it('allows callers to disable the default limit', async () => {
+    await repository.list({}, { defaultLimit: undefined })
+
+    expect(prisma.deviceBrand.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: undefined,
+      }),
+    )
+  })
+
   it('uses the same category filter when counting brands', async () => {
     await repository.count({ category: 'cpu' })
 

--- a/src/server/repositories/device-brands.repository.ts
+++ b/src/server/repositories/device-brands.repository.ts
@@ -7,6 +7,14 @@ import type {
   UpdateDeviceBrandInput,
 } from '@/schemas/deviceBrand'
 
+interface DeviceBrandListOptions {
+  defaultLimit: number | undefined
+}
+
+const DEFAULT_LIST_OPTIONS: DeviceBrandListOptions = {
+  defaultLimit: 50,
+}
+
 /**
  * Repository for DeviceBrand data access
  */
@@ -22,10 +30,11 @@ export class DeviceBrandsRepository extends BaseRepository {
   } as const
   async list(
     filters: GetDeviceBrandsInput = {},
+    options: DeviceBrandListOptions = DEFAULT_LIST_OPTIONS,
   ): Promise<
     Prisma.DeviceBrandGetPayload<{ include: typeof DeviceBrandsRepository.includes.withCounts }>[]
   > {
-    const { limit = 50, sortField = 'name', sortDirection } = filters
+    const { limit, sortField = 'name', sortDirection } = filters
     const where = this.buildWhereClause(filters)
 
     // Map schema sort fields to Prisma orderBy
@@ -38,7 +47,7 @@ export class DeviceBrandsRepository extends BaseRepository {
       where,
       include: DeviceBrandsRepository.includes.withCounts,
       orderBy,
-      take: limit,
+      take: limit ?? options.defaultLimit,
     })
   }
 

--- a/src/server/repositories/device-brands.repository.ts
+++ b/src/server/repositories/device-brands.repository.ts
@@ -7,14 +7,6 @@ import type {
   UpdateDeviceBrandInput,
 } from '@/schemas/deviceBrand'
 
-interface DeviceBrandListOptions {
-  defaultLimit: number | undefined
-}
-
-const DEFAULT_LIST_OPTIONS: DeviceBrandListOptions = {
-  defaultLimit: 50,
-}
-
 /**
  * Repository for DeviceBrand data access
  */
@@ -30,11 +22,10 @@ export class DeviceBrandsRepository extends BaseRepository {
   } as const
   async list(
     filters: GetDeviceBrandsInput = {},
-    options: DeviceBrandListOptions = DEFAULT_LIST_OPTIONS,
   ): Promise<
     Prisma.DeviceBrandGetPayload<{ include: typeof DeviceBrandsRepository.includes.withCounts }>[]
   > {
-    const { limit, sortField = 'name', sortDirection } = filters
+    const { limit = 50, sortField = 'name', sortDirection } = filters
     const where = this.buildWhereClause(filters)
 
     // Map schema sort fields to Prisma orderBy
@@ -47,12 +38,24 @@ export class DeviceBrandsRepository extends BaseRepository {
       where,
       include: DeviceBrandsRepository.includes.withCounts,
       orderBy,
-      take: limit ?? options.defaultLimit,
+      take: limit,
     })
   }
 
   async byId(id: string): Promise<DeviceBrand | null> {
     return this.prisma.deviceBrand.findUnique({ where: { id } })
+  }
+
+  async byIdWithCounts(
+    id: string,
+  ): Promise<
+    | Prisma.DeviceBrandGetPayload<{ include: typeof DeviceBrandsRepository.includes.withCounts }>
+    | null
+  > {
+    return this.prisma.deviceBrand.findUnique({
+      where: { id },
+      include: DeviceBrandsRepository.includes.withCounts,
+    })
   }
 
   async create(data: CreateDeviceBrandInput): Promise<DeviceBrand> {

--- a/src/server/repositories/device-brands.repository.ts
+++ b/src/server/repositories/device-brands.repository.ts
@@ -114,14 +114,12 @@ export class DeviceBrandsRepository extends BaseRepository {
   }
 
   private buildWhereClause(filters: GetDeviceBrandsInput = {}): Prisma.DeviceBrandWhereInput {
-    const { search, category } = filters
-
     return {
-      ...(search && {
-        name: { contains: search, mode: this.mode },
+      ...(filters.search && {
+        name: { contains: filters.search, mode: this.mode },
       }),
-      ...(category === 'cpu' && { cpus: { some: {} } }),
-      ...(category === 'gpu' && { gpus: { some: {} } }),
+      ...(filters.category === 'cpu' && { cpus: { some: {} } }),
+      ...(filters.category === 'gpu' && { gpus: { some: {} } }),
     }
   }
 

--- a/src/server/repositories/device-brands.repository.ts
+++ b/src/server/repositories/device-brands.repository.ts
@@ -25,13 +25,8 @@ export class DeviceBrandsRepository extends BaseRepository {
   ): Promise<
     Prisma.DeviceBrandGetPayload<{ include: typeof DeviceBrandsRepository.includes.withCounts }>[]
   > {
-    const { search, limit = 50, sortField = 'name', sortDirection } = filters
-
-    const where: Prisma.DeviceBrandWhereInput = {
-      ...(search && {
-        name: { contains: search, mode: this.mode },
-      }),
-    }
+    const { limit = 50, sortField = 'name', sortDirection } = filters
+    const where = this.buildWhereClause(filters)
 
     // Map schema sort fields to Prisma orderBy
     const orderBy: Prisma.DeviceBrandOrderByWithRelationInput =
@@ -101,15 +96,21 @@ export class DeviceBrandsRepository extends BaseRepository {
    * Get total count with filters
    */
   async count(filters: GetDeviceBrandsInput = {}): Promise<number> {
-    const { search } = filters
+    const where = this.buildWhereClause(filters)
 
-    const where: Prisma.DeviceBrandWhereInput = {
+    return this.prisma.deviceBrand.count({ where })
+  }
+
+  private buildWhereClause(filters: GetDeviceBrandsInput = {}): Prisma.DeviceBrandWhereInput {
+    const { search, category } = filters
+
+    return {
       ...(search && {
         name: { contains: search, mode: this.mode },
       }),
+      ...(category === 'cpu' && { cpus: { some: {} } }),
+      ...(category === 'gpu' && { gpus: { some: {} } }),
     }
-
-    return this.prisma.deviceBrand.count({ where })
   }
 
   /**


### PR DESCRIPTION
## Description

Adds a `category` filter to the device brands query so CPU and GPU admin pages can request relevant brands from the server instead of hard-coding client-side brand name allowlists.

Fixes #396

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Local build
- [x] Lint
- [x] Typecheck
- [x] Unit tests
- [ ] Manual testing

Checks run:
- `./node_modules/.bin/vitest run src/server/repositories/device-brands.repository.test.ts`
- `./node_modules/.bin/eslint src/schemas/deviceBrand.ts src/server/repositories/device-brands.repository.ts src/server/repositories/device-brands.repository.test.ts src/server/api/routers/mobile/deviceBrands.ts src/app/admin/cpus/page.tsx src/app/admin/gpus/page.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint .` (completed with existing React Compiler warnings, 0 errors)

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the [style guidelines](https://github.com/Producdevity/EmuReady/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that all checks (lint, typecheck, test) pass

## Notes for reviewers

`pnpm test src/server/repositories/device-brands.repository.test.ts` could not run directly in the temp worktree because the pnpm wrapper performs a dependency-status install and requires a local `.env.local`/`DATABASE_URL` for Prisma postinstall. The same test passed through the local Vitest binary after generating/copying ignored local artifacts for verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brand filters on CPU and GPU admin pages now show only manufacturers relevant to the selected device category and populate options from the updated brand source.

* **Tests**
  * Added tests covering category-specific brand filtering, item counts, and default pagination behavior.

* **Documentation**
  * Added a TypeScript/code-quality guideline advising when to avoid object destructuring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->