### PR TITLE
Fix GameNative startup default

### DIFF
--- a/prisma/seeders/gamenativeCustomFieldsSeeder.ts
+++ b/prisma/seeders/gamenativeCustomFieldsSeeder.ts
@@ -199,7 +199,7 @@ const GAMENATIVE_CUSTOM_FIELDS: GameNativeCustomFieldSeed[] = [
     type: CustomFieldType.SELECT,
     required: false,
     displayOrder: 9,
-    defaultValue: 'Aggressive (Stop services on startup)',
+    defaultValue: 'Essential (Load only essential services)',
     options: [
       { value: 'Normal (Load all services)', label: 'Normal (Load all services)' },
       {


### PR DESCRIPTION
## Description
- Aligns the GameNative `startup_selection` seeded default with the config default of Essential.
- Leaves the existing GameNative FEXCore/Box fields untouched; those are already present on current `staging`.

Addresses #309.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] `./node_modules/.bin/vitest run src/shared/emulator-config/gamenative/parser.test.ts src/server/utils/emulator-config/gamenative/gamenative.converter.test.ts`
- [x] `./node_modules/.bin/eslint prisma/seeders/gamenativeCustomFieldsSeeder.ts`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default startup configuration to load only essential services instead of stopping services on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->